### PR TITLE
filter 'maybe', 'idea', and 'cancelled'

### DIFF
--- a/app/api/events-cal/route.ts
+++ b/app/api/events-cal/route.ts
@@ -78,7 +78,12 @@ export async function GET() {
 
     // Transform Airtable records to Event objects
     const events: Event[] = data.records
-      .filter((record: any) => record.fields?.['Start Date'])
+      .filter((record: any) => {
+        if (!record.fields?.['Start Date']) return false
+        
+        const status = record.fields.Status?.toLowerCase()
+        return status !== 'idea' && status !== 'maybe' && status !== 'cancelled'
+      })
       .map(parseAirtableEvent)
 
     // Generate iCal content

--- a/app/lib/events.ts
+++ b/app/lib/events.ts
@@ -62,7 +62,12 @@ export async function getEvents(): Promise<Event[]> {
   )
   const data = await res.json()
   const records = data.records?.filter(
-    (event: AirtableEvent) => event.fields?.['Start Date']
+    (event: AirtableEvent) => {
+      if (!event.fields?.['Start Date']) return false
+      
+      const status = event.fields.Status?.toLowerCase()
+      return status !== 'idea' && status !== 'maybe' && status !== 'cancelled'
+    }
   )
 
   return records?.map(parseAirtableEvent) || []


### PR DESCRIPTION
issue: prospective events are showing up on the calendar, but we only want to see confirmed events. this is a quick fix for that by filtering events with the status 'maybe', 'idea', and 'cancelled'