### PR TITLE
Update community labels: add Figgie players and d/accs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -154,8 +154,9 @@ export default async function Component() {
                     'Community builders',
                     'Hackers',
                     'Thinkers',
-                    'Players',
-                    'Members of technical (and untechnical) staff',
+                    'Figgie players',
+                    'd/accs',
+                    'Members of technical and untechnical staff',
                   ].map((label) => (
                     <div
                       key={label}


### PR DESCRIPTION
- Changed "Players" to "Figgie players"
- Added "d/accs" to the community list
- Removed parentheses from "Members of technical and untechnical staff"