### PR TITLE
Add Discord bot for event submissions

### DIFF
--- a/app/api/discord/interactions/route.ts
+++ b/app/api/discord/interactions/route.ts
@@ -1,0 +1,289 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  verifyDiscordSignature,
+  pongResponse,
+  deferredResponse,
+  messageResponse,
+  updateMessageResponse,
+  sendFollowupMessage,
+  editOriginalMessage,
+  getDisplayName,
+  getUserId,
+  getUsername,
+  InteractionType,
+  ButtonStyle,
+  type DiscordInteraction,
+} from '@/app/lib/discord'
+import {
+  parseEventRequest,
+  formatProposalMessage,
+  createEventsInAirtable,
+  getExistingEventNames,
+  formatConfirmationMessage,
+  generatePrefillUrl,
+  type EventProposal,
+} from '@/app/lib/discord-events'
+
+// In-memory store for pending proposals (in production, use Redis or similar)
+// Key: `${interactionId}` -> EventProposal
+const pendingProposals = new Map<string, EventProposal>()
+
+// Clean up old proposals after 1 hour
+setInterval(
+  () => {
+    const oneHourAgo = Date.now() - 60 * 60 * 1000
+    for (const [key] of pendingProposals) {
+      // In a real implementation, store timestamps with proposals
+      // For now, just limit size
+      if (pendingProposals.size > 100) {
+        pendingProposals.delete(key)
+      }
+    }
+  },
+  60 * 60 * 1000
+)
+
+export async function POST(request: NextRequest) {
+  // Get verification headers
+  const signature = request.headers.get('x-signature-ed25519')
+  const timestamp = request.headers.get('x-signature-timestamp')
+
+  if (!signature || !timestamp) {
+    return NextResponse.json({ error: 'Missing signature headers' }, { status: 401 })
+  }
+
+  // Read body as text for signature verification
+  const body = await request.text()
+
+  // Verify signature
+  const isValid = await verifyDiscordSignature(body, signature, timestamp)
+  if (!isValid) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  // Parse the interaction
+  const interaction: DiscordInteraction = JSON.parse(body)
+
+  // Handle PING (Discord uses this to verify the endpoint)
+  if (interaction.type === InteractionType.PING) {
+    return pongResponse()
+  }
+
+  // Handle slash commands
+  if (interaction.type === InteractionType.APPLICATION_COMMAND) {
+    return handleApplicationCommand(interaction)
+  }
+
+  // Handle button clicks
+  if (interaction.type === InteractionType.MESSAGE_COMPONENT) {
+    return handleMessageComponent(interaction)
+  }
+
+  return NextResponse.json({ error: 'Unknown interaction type' }, { status: 400 })
+}
+
+async function handleApplicationCommand(interaction: DiscordInteraction) {
+  const commandName = interaction.data?.name
+
+  if (commandName === 'add-event') {
+    // Get the request text from command options
+    const requestOption = interaction.data?.options?.find((opt) => opt.name === 'request')
+    const requestText = requestOption?.value || ''
+
+    if (!requestText) {
+      return messageResponse(
+        'Please provide an event description. Example: `/add-event yoga class at 7pm on Thursday`',
+        true
+      )
+    }
+
+    // Defer the response since parsing may take a moment
+    // We'll follow up with the actual response
+    const applicationId = interaction.application_id
+    const interactionToken = interaction.token
+    const hostDiscordUsername = getUsername(interaction)
+    const hostDiscordId = getUserId(interaction)
+    const hostDisplayName = getDisplayName(interaction)
+
+    // Return deferred response immediately
+    // Then process in background
+    processEventRequest(applicationId, interactionToken, requestText, hostDiscordUsername, hostDiscordId, hostDisplayName)
+
+    return deferredResponse()
+  }
+
+  return messageResponse('Unknown command', true)
+}
+
+async function processEventRequest(
+  applicationId: string,
+  interactionToken: string,
+  requestText: string,
+  hostDiscordUsername: string,
+  hostDiscordId: string,
+  hostDisplayName: string
+) {
+  try {
+    // Fetch existing event names for context
+    const existingNames = await getExistingEventNames()
+
+    // Parse the request
+    const parsed = await parseEventRequest(requestText, hostDiscordUsername, hostDiscordId, hostDisplayName, existingNames)
+
+    // Handle different response types
+    if (parsed.useFormInstead) {
+      await editOriginalMessage(
+        applicationId,
+        interactionToken,
+        `This request is a bit complex for me to handle automatically. Please use the form instead:\n\n${parsed.formUrl || generatePrefillUrl({ discordUsername: hostDiscordUsername })}`
+      )
+      return
+    }
+
+    if (parsed.needsMoreInfo) {
+      const questions = parsed.questions?.join('\n- ') || 'Could you provide more details?'
+      await editOriginalMessage(
+        applicationId,
+        interactionToken,
+        `I need a bit more information:\n- ${questions}\n\nOr you can use the form: ${generatePrefillUrl({ discordUsername: hostDiscordUsername })}`
+      )
+      return
+    }
+
+    if (parsed.proposals.length === 0) {
+      await editOriginalMessage(
+        applicationId,
+        interactionToken,
+        `I couldn't parse that request. Try something like:\n- "yoga class at 7pm on Thursday"\n- "repeat my cafe event every Friday"\n\nOr use the form: ${generatePrefillUrl({ discordUsername: hostDiscordUsername })}`
+      )
+      return
+    }
+
+    // We have a valid proposal
+    const proposal = parsed.proposals[0]
+
+    // Store proposal for later confirmation
+    // Use a unique key based on the interaction
+    const proposalKey = `${applicationId}-${Date.now()}`
+    pendingProposals.set(proposalKey, proposal)
+
+    // Send the proposal with confirmation buttons
+    const proposalMessage = formatProposalMessage(proposal)
+
+    await sendFollowupMessage(
+      applicationId,
+      interactionToken,
+      proposalMessage,
+      [
+        {
+          customId: `confirm:${proposalKey}`,
+          label: 'Confirm',
+          style: ButtonStyle.SUCCESS,
+          emoji: '✅',
+        },
+        {
+          customId: `cancel:${proposalKey}`,
+          label: 'Cancel',
+          style: ButtonStyle.SECONDARY,
+          emoji: '❌',
+        },
+        {
+          customId: `form:${proposalKey}`,
+          label: 'Use Form Instead',
+          style: ButtonStyle.SECONDARY,
+        },
+      ]
+    )
+
+    // Edit the original deferred message to indicate we're waiting
+    await editOriginalMessage(
+      applicationId,
+      interactionToken,
+      'Event proposal created! Please confirm below.'
+    )
+  } catch (error) {
+    console.error('Error processing event request:', error)
+    await editOriginalMessage(
+      applicationId,
+      interactionToken,
+      `Something went wrong. Please try the form instead: ${generatePrefillUrl({})}`
+    )
+  }
+}
+
+async function handleMessageComponent(interaction: DiscordInteraction) {
+  const customId = interaction.message?.components?.[0]?.components?.[0]?.custom_id || ''
+
+  // Parse the custom_id to determine action
+  // Format: action:proposalKey
+  const [action, proposalKey] = customId.split(':')
+
+  if (action === 'confirm') {
+    const proposal = pendingProposals.get(proposalKey)
+
+    if (!proposal) {
+      return updateMessageResponse(
+        'This proposal has expired. Please create a new one with `/add-event`.',
+        true
+      )
+    }
+
+    // Verify the user clicking is the same who created the proposal
+    const clickerId = getUserId(interaction)
+    if (clickerId !== proposal.hostDiscordId) {
+      // Different user - don't allow
+      return messageResponse("You can only confirm your own event proposals.", true)
+    }
+
+    // Create the events in Airtable
+    const result = await createEventsInAirtable(proposal)
+
+    if (result.success) {
+      // Clean up
+      pendingProposals.delete(proposalKey)
+
+      const confirmationMessage = formatConfirmationMessage(proposal, result.recordIds, result.createdNewPerson)
+      return updateMessageResponse(confirmationMessage, true)
+    } else {
+      return updateMessageResponse(
+        `Failed to create events: ${result.error}\n\nPlease try the form: ${generatePrefillUrl({ name: proposal.name, discordUsername: proposal.hostDiscordUsername })}`,
+        true
+      )
+    }
+  }
+
+  if (action === 'cancel') {
+    const proposal = pendingProposals.get(proposalKey)
+
+    // Verify the user clicking is the same who created the proposal
+    if (proposal) {
+      const clickerId = getUserId(interaction)
+      if (clickerId !== proposal.hostDiscordId) {
+        return messageResponse("You can only cancel your own event proposals.", true)
+      }
+    }
+
+    pendingProposals.delete(proposalKey)
+    return updateMessageResponse('Event creation cancelled.', true)
+  }
+
+  if (action === 'form') {
+    const proposal = pendingProposals.get(proposalKey)
+    pendingProposals.delete(proposalKey)
+
+    const formUrl = proposal
+      ? generatePrefillUrl({
+          name: proposal.name,
+          discordUsername: proposal.hostDiscordUsername,
+          startDate: proposal.startDate,
+          endDate: proposal.endDate,
+          description: proposal.description,
+          url: proposal.url,
+        })
+      : generatePrefillUrl({})
+
+    return updateMessageResponse(`Here's the form with your details pre-filled:\n${formUrl}`, true)
+  }
+
+  return updateMessageResponse('Unknown action', true)
+}

--- a/app/lib/discord-events.ts
+++ b/app/lib/discord-events.ts
@@ -1,0 +1,619 @@
+import Anthropic from '@anthropic-ai/sdk'
+import {
+  format,
+  parse,
+  addWeeks,
+  addDays,
+  nextFriday,
+  nextMonday,
+  nextTuesday,
+  nextWednesday,
+  nextThursday,
+  nextSaturday,
+  nextSunday,
+  startOfDay,
+  setHours,
+  setMinutes,
+  isBefore,
+  addMonths,
+} from 'date-fns'
+import { formatInTimeZone, toZonedTime } from 'date-fns-tz'
+import { escapeAirtableString } from './airtable-helpers'
+
+const TIMEZONE = 'America/Los_Angeles'
+const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID
+const AIRTABLE_FORM_BASE_URL = `https://airtable.com/${AIRTABLE_BASE_ID}/pagHlAqA2JFG7nNP2/form`
+
+export interface EventProposal {
+  name: string
+  startDate: Date
+  endDate?: Date
+  description?: string
+  url?: string
+  hostDiscordUsername: string // Discord username (e.g., "rachel_shu")
+  hostDiscordId: string // Discord user ID
+  hostDisplayName: string // Display name for UI (e.g., "Rachel")
+  visibility: 'Public' | 'Members' | 'Private'
+  isRecurring: boolean
+  recurrencePattern?: string
+  occurrences?: Date[] // For recurring events, all the start dates
+}
+
+export interface ParsedEventRequest {
+  proposals: EventProposal[]
+  needsMoreInfo: boolean
+  questions?: string[]
+  useFormInstead: boolean
+  formUrl?: string
+  rawParsed: {
+    eventName?: string
+    inferredFromExisting?: boolean
+    dates?: string[]
+    times?: { start: string; end?: string }
+    recurrence?: string
+    visibility?: string
+  }
+}
+
+// Parse natural language event request using Claude
+export async function parseEventRequest(
+  request: string,
+  hostDiscordUsername: string,
+  hostDiscordId: string,
+  hostDisplayName: string,
+  existingEventNames: string[]
+): Promise<ParsedEventRequest> {
+  const anthropic = new Anthropic({
+    apiKey: process.env.MOX_ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY,
+  })
+
+  const now = new Date()
+  const nowPT = toZonedTime(now, TIMEZONE)
+  const currentDateStr = formatInTimeZone(now, TIMEZONE, 'EEEE, MMMM d, yyyy')
+  const currentTimeStr = formatInTimeZone(now, TIMEZONE, 'h:mm a')
+
+  const existingEventsContext =
+    existingEventNames.length > 0
+      ? `\nExisting event names in the system (user may be referring to one of these):\n${existingEventNames.slice(0, 50).join('\n')}`
+      : ''
+
+  const systemPrompt = `You are parsing event requests for a community space calendar. Extract structured event information from natural language.
+
+Current date/time: ${currentDateStr} at ${currentTimeStr} PT (Pacific Time)
+All times should be interpreted as Pacific Time unless explicitly stated otherwise.
+${existingEventsContext}
+
+Return a JSON object with these fields:
+{
+  "eventName": "string - the name of the event. If they reference 'my X event' and it matches an existing event, use that name",
+  "inferredFromExisting": "boolean - true if the event name was matched to an existing event",
+  "startDate": "string - ISO date YYYY-MM-DD",
+  "startTime": "string - 24h format HH:MM",
+  "endTime": "string or null - 24h format HH:MM, if not specified assume 2 hours after start",
+  "recurrence": "string or null - one of: 'weekly', 'biweekly', 'monthly', or null for one-time",
+  "recurrenceDay": "string or null - day of week for recurring events",
+  "recurrenceEndDate": "string or null - ISO date, max 3 months from now",
+  "visibility": "string - 'Public', 'Members', or 'Private'. Default to 'Public' if not specified",
+  "url": "string or null - if they mention a link",
+  "description": "string or null - if they provide a description",
+  "needsMoreInfo": "boolean - true if critical info is missing (like event name for new events)",
+  "questions": ["array of questions to ask if needsMoreInfo is true"],
+  "tooComplicated": "boolean - true if the request is too complex to parse reliably"
+}
+
+Guidelines:
+- "next Friday" means the upcoming Friday (not today if today is Friday)
+- "every Friday" means weekly recurring on Fridays, starting from the next Friday
+- "my cafe event" or "my yoga class" - try to match to existing events
+- If no end time given, assume 2 hours after start
+- Cap recurring events at 3 months maximum
+- If the request is vague about a NEW event name, set needsMoreInfo: true
+- If the request involves complex scheduling or edits, set tooComplicated: true`
+
+  const response = await anthropic.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages: [
+      {
+        role: 'user',
+        content: `Parse this event request: "${request}"`,
+      },
+    ],
+  })
+
+  const content = response.content[0]
+  if (content.type !== 'text') {
+    throw new Error('Unexpected response type from Claude')
+  }
+
+  let parsed
+  try {
+    // Extract JSON from response (handle markdown code blocks)
+    const jsonMatch = content.text.match(/```(?:json)?\s*([\s\S]*?)```/) || [null, content.text]
+    parsed = JSON.parse(jsonMatch[1] || content.text)
+  } catch {
+    console.error('Failed to parse Claude response:', content.text)
+    return {
+      proposals: [],
+      needsMoreInfo: true,
+      questions: ["I couldn't understand that request. Could you rephrase it?"],
+      useFormInstead: false,
+      rawParsed: {},
+    }
+  }
+
+  // If too complicated, return form link
+  if (parsed.tooComplicated) {
+    const formUrl = generatePrefillUrl({
+      name: parsed.eventName,
+      discordUsername: hostDiscordUsername,
+      visibility: parsed.visibility,
+    })
+    return {
+      proposals: [],
+      needsMoreInfo: false,
+      useFormInstead: true,
+      formUrl,
+      rawParsed: parsed,
+    }
+  }
+
+  // If needs more info
+  if (parsed.needsMoreInfo) {
+    return {
+      proposals: [],
+      needsMoreInfo: true,
+      questions: parsed.questions || ['Could you provide more details about the event?'],
+      useFormInstead: false,
+      rawParsed: parsed,
+    }
+  }
+
+  // Build proposals
+  const proposals: EventProposal[] = []
+
+  // Parse the start date and time
+  const startDateStr = parsed.startDate
+  const startTimeStr = parsed.startTime || '19:00' // Default 7pm
+
+  let baseStartDate: Date
+  try {
+    const [hours, minutes] = startTimeStr.split(':').map(Number)
+    baseStartDate = parse(startDateStr, 'yyyy-MM-dd', new Date())
+    baseStartDate = setHours(baseStartDate, hours)
+    baseStartDate = setMinutes(baseStartDate, minutes)
+  } catch {
+    return {
+      proposals: [],
+      needsMoreInfo: true,
+      questions: ['I had trouble understanding the date/time. Could you clarify?'],
+      useFormInstead: false,
+      rawParsed: parsed,
+    }
+  }
+
+  // Calculate end time
+  let baseEndDate: Date | undefined
+  if (parsed.endTime) {
+    const [endHours, endMinutes] = parsed.endTime.split(':').map(Number)
+    baseEndDate = new Date(baseStartDate)
+    baseEndDate = setHours(baseEndDate, endHours)
+    baseEndDate = setMinutes(baseEndDate, endMinutes)
+  } else {
+    // Default 2 hours
+    baseEndDate = new Date(baseStartDate.getTime() + 2 * 60 * 60 * 1000)
+  }
+
+  // Handle recurring events
+  if (parsed.recurrence) {
+    const occurrences: Date[] = []
+    const maxDate = addMonths(new Date(), 3) // Cap at 3 months
+    let currentDate = new Date(baseStartDate)
+
+    // Find the first occurrence
+    if (parsed.recurrenceDay) {
+      currentDate = getNextDayOfWeek(currentDate, parsed.recurrenceDay)
+      // Preserve the time
+      currentDate = setHours(currentDate, baseStartDate.getHours())
+      currentDate = setMinutes(currentDate, baseStartDate.getMinutes())
+    }
+
+    // Generate all occurrences
+    while (isBefore(currentDate, maxDate) && occurrences.length < 13) {
+      occurrences.push(new Date(currentDate))
+
+      switch (parsed.recurrence) {
+        case 'weekly':
+          currentDate = addWeeks(currentDate, 1)
+          break
+        case 'biweekly':
+          currentDate = addWeeks(currentDate, 2)
+          break
+        case 'monthly':
+          currentDate = addMonths(currentDate, 1)
+          break
+        default:
+          currentDate = addWeeks(currentDate, 1)
+      }
+    }
+
+    // Calculate duration for end dates
+    const duration = baseEndDate
+      ? baseEndDate.getTime() - baseStartDate.getTime()
+      : 2 * 60 * 60 * 1000
+
+    // Create proposal for recurring event
+    proposals.push({
+      name: parsed.eventName || 'Untitled Event',
+      startDate: occurrences[0],
+      endDate: new Date(occurrences[0].getTime() + duration),
+      description: parsed.description,
+      url: parsed.url,
+      hostDiscordUsername,
+      hostDiscordId,
+      hostDisplayName,
+      visibility: parsed.visibility || 'Public',
+      isRecurring: true,
+      recurrencePattern: `${parsed.recurrence} on ${parsed.recurrenceDay || format(baseStartDate, 'EEEE')}s`,
+      occurrences: occurrences.map((d) => new Date(d)),
+    })
+  } else {
+    // Single event
+    proposals.push({
+      name: parsed.eventName || 'Untitled Event',
+      startDate: baseStartDate,
+      endDate: baseEndDate,
+      description: parsed.description,
+      url: parsed.url,
+      hostDiscordUsername,
+      hostDiscordId,
+      hostDisplayName,
+      visibility: parsed.visibility || 'Public',
+      isRecurring: false,
+    })
+  }
+
+  return {
+    proposals,
+    needsMoreInfo: false,
+    useFormInstead: false,
+    rawParsed: {
+      eventName: parsed.eventName,
+      inferredFromExisting: parsed.inferredFromExisting,
+      dates: proposals[0]?.occurrences?.map((d) => format(d, 'yyyy-MM-dd')) || [
+        format(baseStartDate, 'yyyy-MM-dd'),
+      ],
+      times: { start: startTimeStr, end: parsed.endTime },
+      recurrence: parsed.recurrence,
+      visibility: parsed.visibility,
+    },
+  }
+}
+
+function getNextDayOfWeek(date: Date, dayName: string): Date {
+  const dayMap: { [key: string]: (d: Date) => Date } = {
+    monday: nextMonday,
+    tuesday: nextTuesday,
+    wednesday: nextWednesday,
+    thursday: nextThursday,
+    friday: nextFriday,
+    saturday: nextSaturday,
+    sunday: nextSunday,
+  }
+
+  const fn = dayMap[dayName.toLowerCase()]
+  if (fn) {
+    return fn(date)
+  }
+
+  // Default to next week same day
+  return addDays(date, 7)
+}
+
+// Format a proposal for Discord display
+export function formatProposalMessage(proposal: EventProposal): string {
+  const lines: string[] = []
+
+  lines.push(`**Proposal:** ${proposal.name}`)
+
+  if (proposal.isRecurring && proposal.occurrences) {
+    const firstDate = formatInTimeZone(proposal.occurrences[0], TIMEZONE, 'EEEE, MMMM d')
+    const lastDate = formatInTimeZone(
+      proposal.occurrences[proposal.occurrences.length - 1],
+      TIMEZONE,
+      'MMMM d'
+    )
+    const startTime = formatInTimeZone(proposal.startDate, TIMEZONE, 'h:mm a')
+    const endTime = proposal.endDate
+      ? formatInTimeZone(proposal.endDate, TIMEZONE, 'h:mm a')
+      : null
+
+    lines.push(
+      `${proposal.recurrencePattern} (${proposal.occurrences.length} events: ${firstDate} - ${lastDate})`
+    )
+    lines.push(`Time: ${startTime}${endTime ? ` - ${endTime}` : ''} PT`)
+  } else {
+    const dateStr = formatInTimeZone(proposal.startDate, TIMEZONE, 'EEEE, MMMM d')
+    const startTime = formatInTimeZone(proposal.startDate, TIMEZONE, 'h:mm a')
+    const endTime = proposal.endDate
+      ? formatInTimeZone(proposal.endDate, TIMEZONE, 'h:mm a')
+      : null
+
+    lines.push(`${dateStr} at ${startTime}${endTime ? ` - ${endTime}` : ''} PT`)
+  }
+
+  lines.push(`Hosted by: ${proposal.hostDisplayName} (@${proposal.hostDiscordUsername})`)
+  lines.push(`Visibility: ${proposal.visibility}`)
+  lines.push(`Status: Idea`)
+
+  if (proposal.url) {
+    lines.push(`Link: ${proposal.url}`)
+  }
+
+  if (proposal.description) {
+    lines.push(`Description: ${proposal.description}`)
+  }
+
+  return lines.join('\n')
+}
+
+// Find a person by Discord Username, or create one if not found
+async function findOrCreatePersonByDiscordUsername(
+  discordUsername: string
+): Promise<{ personId: string; isNew: boolean }> {
+  // First, try to find existing person by Discord Username
+  const escapedUsername = escapeAirtableString(discordUsername)
+  const formula = `{Discord Username} = '${escapedUsername}'`
+
+  try {
+    const searchResponse = await fetch(
+      `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/People?filterByFormula=${encodeURIComponent(formula)}&maxRecords=1`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`,
+        },
+      }
+    )
+
+    if (searchResponse.ok) {
+      const searchData = await searchResponse.json()
+      if (searchData.records && searchData.records.length > 0) {
+        // Found existing person
+        return { personId: searchData.records[0].id, isNew: false }
+      }
+    }
+  } catch (error) {
+    console.error('Error searching for person:', error)
+  }
+
+  // Person not found, create a new one with Discord Username
+  try {
+    const createResponse = await fetch(
+      `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/People`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.AIRTABLE_WRITE_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          records: [
+            {
+              fields: {
+                'Discord Username': discordUsername,
+                // Leave Name empty - admin can merge/update later
+              },
+            },
+          ],
+        }),
+      }
+    )
+
+    if (!createResponse.ok) {
+      const error = await createResponse.text()
+      console.error('Failed to create person:', error)
+      throw new Error('Failed to create person record')
+    }
+
+    const createData = await createResponse.json()
+    return { personId: createData.records[0].id, isNew: true }
+  } catch (error) {
+    console.error('Error creating person:', error)
+    throw error
+  }
+}
+
+// Create events in Airtable
+export async function createEventsInAirtable(
+  proposal: EventProposal
+): Promise<{ success: boolean; recordIds: string[]; error?: string; createdNewPerson?: boolean }> {
+  // First, find or create the host person record
+  let personId: string
+  let createdNewPerson = false
+
+  try {
+    const personResult = await findOrCreatePersonByDiscordUsername(proposal.hostDiscordUsername)
+    personId = personResult.personId
+    createdNewPerson = personResult.isNew
+  } catch (error) {
+    console.error('Error finding/creating person:', error)
+    return {
+      success: false,
+      recordIds: [],
+      error: 'Failed to find or create host person record',
+    }
+  }
+
+  const dates = proposal.isRecurring && proposal.occurrences ? proposal.occurrences : [proposal.startDate]
+
+  // Calculate duration for end dates
+  const duration =
+    proposal.endDate && proposal.startDate
+      ? proposal.endDate.getTime() - proposal.startDate.getTime()
+      : 2 * 60 * 60 * 1000
+
+  const records = dates.map((startDate) => ({
+    fields: {
+      Name: proposal.name,
+      'Start Date': startDate.toISOString(),
+      'End Date': new Date(startDate.getTime() + duration).toISOString(),
+      'Event Description': proposal.description || '',
+      URL: proposal.url || '',
+      'Hosted by': [personId], // Link to People table via record ID
+      Status: 'Idea', // Always create as "Idea" (capitalized to match Airtable select option)
+      Type: proposal.visibility === 'Private' ? 'private' : undefined,
+    },
+  }))
+
+  const recordIds: string[] = []
+
+  // Airtable API allows max 10 records per request
+  for (let i = 0; i < records.length; i += 10) {
+    const batch = records.slice(i, i + 10)
+
+    try {
+      const response = await fetch(
+        `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/Events`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${process.env.AIRTABLE_WRITE_KEY}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ records: batch }),
+        }
+      )
+
+      if (!response.ok) {
+        const error = await response.text()
+        console.error('Airtable API error:', error)
+        return {
+          success: false,
+          recordIds,
+          error: 'Failed to create events in Airtable',
+          createdNewPerson,
+        }
+      }
+
+      const data = await response.json()
+      recordIds.push(...data.records.map((r: { id: string }) => r.id))
+    } catch (error) {
+      console.error('Error creating events:', error)
+      return {
+        success: false,
+        recordIds,
+        error: 'Failed to create events in Airtable',
+        createdNewPerson,
+      }
+    }
+  }
+
+  return { success: true, recordIds, createdNewPerson }
+}
+
+// Fetch existing event names from Airtable
+export async function getExistingEventNames(): Promise<string[]> {
+  try {
+    const response = await fetch(
+      `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/Events?fields%5B%5D=Name&maxRecords=100`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`,
+        },
+        next: { revalidate: 300 }, // Cache for 5 minutes
+      }
+    )
+
+    if (!response.ok) {
+      return []
+    }
+
+    const data = await response.json()
+    const names = new Set<string>()
+    data.records?.forEach((record: { fields: { Name?: string } }) => {
+      if (record.fields.Name) {
+        names.add(record.fields.Name)
+      }
+    })
+
+    return Array.from(names)
+  } catch (error) {
+    console.error('Error fetching event names:', error)
+    return []
+  }
+}
+
+// Generate a prefilled Airtable form URL
+export function generatePrefillUrl(params: {
+  name?: string
+  discordUsername?: string
+  startDate?: Date
+  endDate?: Date
+  description?: string
+  url?: string
+  visibility?: string
+}): string {
+  const prefill: Record<string, string> = {}
+
+  if (params.name) {
+    prefill['prefill_Name'] = params.name
+  }
+  // Note: Can't prefill linked record fields via URL, so we skip host
+  if (params.startDate) {
+    prefill['prefill_Start Date'] = params.startDate.toISOString()
+  }
+  if (params.endDate) {
+    prefill['prefill_End Date'] = params.endDate.toISOString()
+  }
+  if (params.description) {
+    prefill['prefill_Event Description'] = params.description
+  }
+  if (params.url) {
+    prefill['prefill_URL'] = params.url
+  }
+
+  const queryString = Object.entries(prefill)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&')
+
+  return queryString ? `${AIRTABLE_FORM_BASE_URL}?${queryString}` : AIRTABLE_FORM_BASE_URL
+}
+
+// Format confirmation message after creating events
+export function formatConfirmationMessage(
+  proposal: EventProposal,
+  recordIds: string[],
+  createdNewPerson?: boolean
+): string {
+  const lines: string[] = []
+
+  if (proposal.isRecurring && proposal.occurrences) {
+    lines.push(`**Created ${recordIds.length} events for "${proposal.name}"**`)
+    lines.push('')
+    lines.push(`First event: ${formatInTimeZone(proposal.occurrences[0], TIMEZONE, 'EEEE, MMMM d')}`)
+    lines.push(
+      `Last event: ${formatInTimeZone(proposal.occurrences[proposal.occurrences.length - 1], TIMEZONE, 'EEEE, MMMM d')}`
+    )
+  } else {
+    lines.push(`**Created "${proposal.name}"**`)
+    lines.push('')
+    lines.push(`Date: ${formatInTimeZone(proposal.startDate, TIMEZONE, 'EEEE, MMMM d, yyyy')}`)
+    lines.push(
+      `Time: ${formatInTimeZone(proposal.startDate, TIMEZONE, 'h:mm a')}${proposal.endDate ? ` - ${formatInTimeZone(proposal.endDate, TIMEZONE, 'h:mm a')}` : ''} PT`
+    )
+  }
+
+  lines.push('')
+  lines.push('Status: **Idea** (pending confirmation)')
+
+  if (createdNewPerson) {
+    lines.push('')
+    lines.push(`_Note: Created a new profile for @${proposal.hostDiscordUsername} - an admin may merge this with your existing profile._`)
+  }
+
+  lines.push('')
+  lines.push('To edit details or change status, visit: https://moxsf.com/portal')
+
+  return lines.join('\n')
+}

--- a/app/lib/discord.ts
+++ b/app/lib/discord.ts
@@ -1,0 +1,361 @@
+import { NextResponse } from 'next/server'
+
+// Discord API types
+export interface DiscordUser {
+  id: string
+  username: string
+  discriminator: string
+  global_name?: string
+  avatar?: string
+}
+
+export interface DiscordInteraction {
+  id: string
+  application_id: string
+  type: InteractionType
+  data?: {
+    id: string
+    name: string
+    options?: { name: string; type: number; value: string }[]
+  }
+  guild_id?: string
+  channel_id?: string
+  member?: {
+    user: DiscordUser
+    nick?: string
+    roles: string[]
+  }
+  user?: DiscordUser
+  token: string
+  version: number
+  message?: DiscordMessage
+}
+
+export interface DiscordMessage {
+  id: string
+  channel_id: string
+  content: string
+  author: DiscordUser
+  components?: MessageComponent[]
+}
+
+export interface MessageComponent {
+  type: number
+  components?: MessageComponent[]
+  custom_id?: string
+  label?: string
+  style?: number
+  emoji?: { name: string }
+}
+
+export enum InteractionType {
+  PING = 1,
+  APPLICATION_COMMAND = 2,
+  MESSAGE_COMPONENT = 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE = 4,
+  MODAL_SUBMIT = 5,
+}
+
+export enum InteractionResponseType {
+  PONG = 1,
+  CHANNEL_MESSAGE_WITH_SOURCE = 4,
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5,
+  DEFERRED_UPDATE_MESSAGE = 6,
+  UPDATE_MESSAGE = 7,
+  APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8,
+  MODAL = 9,
+}
+
+export enum ButtonStyle {
+  PRIMARY = 1,
+  SECONDARY = 2,
+  SUCCESS = 3,
+  DANGER = 4,
+  LINK = 5,
+}
+
+export enum ComponentType {
+  ACTION_ROW = 1,
+  BUTTON = 2,
+  STRING_SELECT = 3,
+  TEXT_INPUT = 4,
+  USER_SELECT = 5,
+  ROLE_SELECT = 6,
+  MENTIONABLE_SELECT = 7,
+  CHANNEL_SELECT = 8,
+}
+
+// Verify Discord signature using Web Crypto API (Edge runtime compatible)
+export async function verifyDiscordSignature(
+  body: string,
+  signature: string,
+  timestamp: string
+): Promise<boolean> {
+  const publicKey = process.env.DISCORD_PUBLIC_KEY
+  if (!publicKey) {
+    console.error('DISCORD_PUBLIC_KEY not configured')
+    return false
+  }
+
+  try {
+    // Convert hex public key to Uint8Array
+    const keyData = hexToUint8Array(publicKey)
+
+    // Import the public key
+    const key = await crypto.subtle.importKey(
+      'raw',
+      keyData,
+      { name: 'Ed25519', namedCurve: 'Ed25519' },
+      false,
+      ['verify']
+    )
+
+    // Convert signature from hex
+    const signatureData = hexToUint8Array(signature)
+
+    // Create message to verify (timestamp + body)
+    const message = new TextEncoder().encode(timestamp + body)
+
+    // Verify signature
+    const isValid = await crypto.subtle.verify('Ed25519', key, signatureData, message)
+
+    return isValid
+  } catch (error) {
+    console.error('Signature verification failed:', error)
+    return false
+  }
+}
+
+function hexToUint8Array(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+  }
+  return bytes
+}
+
+// Response builders
+export function pongResponse() {
+  return NextResponse.json({ type: InteractionResponseType.PONG })
+}
+
+export function messageResponse(content: string, ephemeral = false) {
+  return NextResponse.json({
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      content,
+      flags: ephemeral ? 64 : 0, // 64 = ephemeral flag
+    },
+  })
+}
+
+export function deferredResponse(ephemeral = false) {
+  return NextResponse.json({
+    type: InteractionResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      flags: ephemeral ? 64 : 0,
+    },
+  })
+}
+
+export function messageWithButtonsResponse(
+  content: string,
+  buttons: { customId: string; label: string; style: ButtonStyle; emoji?: string }[]
+) {
+  return NextResponse.json({
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      content,
+      components: [
+        {
+          type: ComponentType.ACTION_ROW,
+          components: buttons.map((btn) => ({
+            type: ComponentType.BUTTON,
+            custom_id: btn.customId,
+            label: btn.label,
+            style: btn.style,
+            emoji: btn.emoji ? { name: btn.emoji } : undefined,
+          })),
+        },
+      ],
+    },
+  })
+}
+
+export function updateMessageResponse(content: string, removeButtons = false) {
+  return NextResponse.json({
+    type: InteractionResponseType.UPDATE_MESSAGE,
+    data: {
+      content,
+      components: removeButtons ? [] : undefined,
+    },
+  })
+}
+
+// Discord API helpers for follow-up messages
+const DISCORD_API_BASE = 'https://discord.com/api/v10'
+
+export async function sendFollowupMessage(
+  applicationId: string,
+  interactionToken: string,
+  content: string,
+  buttons?: { customId: string; label: string; style: ButtonStyle; emoji?: string }[]
+) {
+  const body: Record<string, unknown> = { content }
+
+  if (buttons && buttons.length > 0) {
+    body.components = [
+      {
+        type: ComponentType.ACTION_ROW,
+        components: buttons.map((btn) => ({
+          type: ComponentType.BUTTON,
+          custom_id: btn.customId,
+          label: btn.label,
+          style: btn.style,
+          emoji: btn.emoji ? { name: btn.emoji } : undefined,
+        })),
+      },
+    ]
+  }
+
+  const response = await fetch(
+    `${DISCORD_API_BASE}/webhooks/${applicationId}/${interactionToken}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  )
+
+  if (!response.ok) {
+    const error = await response.text()
+    console.error('Failed to send followup message:', error)
+    throw new Error(`Discord API error: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+export async function editOriginalMessage(
+  applicationId: string,
+  interactionToken: string,
+  content: string,
+  removeButtons = false
+) {
+  const body: Record<string, unknown> = { content }
+  if (removeButtons) {
+    body.components = []
+  }
+
+  const response = await fetch(
+    `${DISCORD_API_BASE}/webhooks/${applicationId}/${interactionToken}/messages/@original`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  )
+
+  if (!response.ok) {
+    const error = await response.text()
+    console.error('Failed to edit original message:', error)
+    throw new Error(`Discord API error: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+// Create a thread from a message
+export async function createThread(
+  channelId: string,
+  messageId: string,
+  name: string
+): Promise<{ id: string }> {
+  const response = await fetch(
+    `${DISCORD_API_BASE}/channels/${channelId}/messages/${messageId}/threads`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+      },
+      body: JSON.stringify({
+        name: name.substring(0, 100), // Thread names max 100 chars
+        auto_archive_duration: 1440, // Archive after 24 hours of inactivity
+      }),
+    }
+  )
+
+  if (!response.ok) {
+    const error = await response.text()
+    console.error('Failed to create thread:', error)
+    throw new Error(`Discord API error: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+// Send a message to a specific channel
+export async function sendChannelMessage(
+  channelId: string,
+  content: string,
+  buttons?: { customId: string; label: string; style: ButtonStyle; emoji?: string }[]
+): Promise<DiscordMessage> {
+  const body: Record<string, unknown> = { content }
+
+  if (buttons && buttons.length > 0) {
+    body.components = [
+      {
+        type: ComponentType.ACTION_ROW,
+        components: buttons.map((btn) => ({
+          type: ComponentType.BUTTON,
+          custom_id: btn.customId,
+          label: btn.label,
+          style: btn.style,
+          emoji: btn.emoji ? { name: btn.emoji } : undefined,
+        })),
+      },
+    ]
+  }
+
+  const response = await fetch(`${DISCORD_API_BASE}/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    console.error('Failed to send channel message:', error)
+    throw new Error(`Discord API error: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+// Get display name for a Discord user
+export function getDisplayName(interaction: DiscordInteraction): string {
+  if (interaction.member) {
+    return (
+      interaction.member.nick ||
+      interaction.member.user.global_name ||
+      interaction.member.user.username
+    )
+  }
+  if (interaction.user) {
+    return interaction.user.global_name || interaction.user.username
+  }
+  return 'Unknown User'
+}
+
+export function getUserId(interaction: DiscordInteraction): string {
+  return interaction.member?.user.id || interaction.user?.id || ''
+}
+
+// Get Discord username (the actual @username, not display name)
+export function getUsername(interaction: DiscordInteraction): string {
+  return interaction.member?.user.username || interaction.user?.username || 'unknown'
+}

--- a/docs/discord-bot-setup.md
+++ b/docs/discord-bot-setup.md
@@ -1,0 +1,140 @@
+# Mox Discord Event Bot Setup
+
+This document explains how to set up the Discord bot for adding events to the Mox calendar.
+
+## Overview
+
+The bot uses Discord's HTTP-based interactions (slash commands) hosted on Vercel. Users can run `/add-event` in Discord to propose events, which are then created in Airtable with "idea" status.
+
+## Architecture
+
+```
+Discord → POST /api/discord/interactions → Parse request → Propose event → User confirms → Create in Airtable
+```
+
+**Files:**
+- `/app/api/discord/interactions/route.ts` - Main webhook handler
+- `/app/lib/discord.ts` - Discord utilities (signature verification, response builders)
+- `/app/lib/discord-events.ts` - Event parsing and Airtable integration
+- `/scripts/register-discord-commands.ts` - Command registration script
+
+## Setup Steps
+
+### 1. Create Discord Application
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click "New Application" and name it (e.g., "Moxette")
+3. Note down the **Application ID** and **Public Key** from the General Information page
+
+### 2. Create Bot User
+
+1. Go to the "Bot" section in your application
+2. Click "Reset Token" to generate a bot token (save it securely!)
+3. Under "Privileged Gateway Intents", you can leave all off (we use interactions, not message content)
+
+### 3. Set Environment Variables
+
+Add these to your `.env.local` and Vercel environment:
+
+```bash
+DISCORD_APPLICATION_ID=your_application_id
+DISCORD_PUBLIC_KEY=your_public_key
+DISCORD_BOT_TOKEN=your_bot_token
+DISCORD_GUILD_ID=your_guild_id  # Optional: for faster command updates during dev
+```
+
+### 4. Deploy to Vercel
+
+Deploy your changes to Vercel so the `/api/discord/interactions` endpoint is live.
+
+### 5. Configure Discord Interactions URL
+
+1. In Discord Developer Portal, go to your application
+2. Go to "General Information"
+3. Set **Interactions Endpoint URL** to: `https://moxsf.com/api/discord/interactions`
+4. Discord will send a PING to verify - if verification fails, check your logs
+
+### 6. Register Slash Commands
+
+Run the registration script:
+
+```bash
+bun run register-discord
+```
+
+Or for guild-specific commands (faster updates during development):
+
+```bash
+DISCORD_GUILD_ID=your_guild_id bun run register-discord
+```
+
+### 7. Invite Bot to Server
+
+1. Go to "OAuth2" → "URL Generator"
+2. Select scopes: `bot`, `applications.commands`
+3. Select bot permissions: `Send Messages`, `Use Slash Commands`
+4. Copy the generated URL and open it to invite the bot to your server
+
+## Usage
+
+Users can run:
+```
+/add-event yoga class at 7pm on Thursday
+/add-event repeat my cafe event every Friday
+/add-event team dinner at 6:30pm on Jan 25
+```
+
+The bot will:
+1. Parse the request using Claude
+2. Display a proposal with confirm/cancel buttons
+3. On confirmation, create the event(s) in Airtable with status "idea"
+4. Provide a link to the portal for further edits
+
+## Event Flow
+
+```
+User: /add-event yoga at 7pm Thursday
+            ↓
+Bot: Parses with Claude AI
+            ↓
+Bot: **Proposal:** yoga
+     Thursday, January 16 at 7:00 PM - 9:00 PM PT
+     Hosted by: @username
+     Status: Idea
+     [✅ Confirm] [❌ Cancel] [Use Form Instead]
+            ↓
+User: Clicks ✅ Confirm
+            ↓
+Bot: **Created "yoga"**
+     Date: Thursday, January 16, 2025
+     Time: 7:00 PM - 9:00 PM PT
+     Status: **Idea** (pending confirmation)
+     To edit details, visit: https://moxsf.com/portal
+```
+
+## Configuration
+
+- **Timezone**: All times are interpreted as Pacific Time
+- **Recurring Events**: Capped at 3 months (max ~13 occurrences)
+- **Event Status**: Always created as "idea"
+- **Complex Requests**: Bot will provide a prefilled form link instead
+
+## Troubleshooting
+
+### "Invalid signature" errors
+- Verify `DISCORD_PUBLIC_KEY` is correct
+- Make sure the endpoint URL in Discord matches your deployed URL
+
+### Commands not appearing
+- Global commands take up to 1 hour to propagate
+- Use `DISCORD_GUILD_ID` for instant updates during testing
+- Check that bot has `applications.commands` scope
+
+### Event creation fails
+- Verify `AIRTABLE_WRITE_KEY` is set and has write permissions
+- Check Vercel logs for specific errors
+
+### Bot not responding
+- Check Vercel function logs
+- Verify the interactions endpoint is returning 200 for PING
+- Ensure bot has necessary permissions in the channel

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "register-discord": "bun run scripts/register-discord-commands.ts",
+    "test-discord": "bun run scripts/test-discord-bot.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/scripts/register-discord-commands.ts
+++ b/scripts/register-discord-commands.ts
@@ -1,0 +1,114 @@
+/**
+ * Script to register Discord slash commands for the Mox event bot.
+ *
+ * Run this script once when setting up the bot or when changing commands:
+ *   bun run scripts/register-discord-commands.ts
+ *
+ * Required environment variables:
+ *   DISCORD_APPLICATION_ID - Your Discord application ID
+ *   DISCORD_BOT_TOKEN - Your Discord bot token
+ *   DISCORD_GUILD_ID (optional) - For guild-specific commands (faster updates during dev)
+ */
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10'
+
+interface SlashCommand {
+  name: string
+  description: string
+  type?: number
+  options?: CommandOption[]
+}
+
+interface CommandOption {
+  name: string
+  description: string
+  type: number
+  required?: boolean
+}
+
+// Application command option types
+const OptionType = {
+  SUB_COMMAND: 1,
+  SUB_COMMAND_GROUP: 2,
+  STRING: 3,
+  INTEGER: 4,
+  BOOLEAN: 5,
+  USER: 6,
+  CHANNEL: 7,
+  ROLE: 8,
+  MENTIONABLE: 9,
+  NUMBER: 10,
+  ATTACHMENT: 11,
+}
+
+// Define the commands to register
+const commands: SlashCommand[] = [
+  {
+    name: 'add-event',
+    description: 'Add an event to the Mox calendar',
+    type: 1, // CHAT_INPUT
+    options: [
+      {
+        name: 'request',
+        description:
+          'Describe the event (e.g., "yoga class at 7pm Thursday" or "repeat cafe event every Friday")',
+        type: OptionType.STRING,
+        required: true,
+      },
+    ],
+  },
+]
+
+async function registerCommands() {
+  const applicationId = process.env.DISCORD_APPLICATION_ID
+  const botToken = process.env.DISCORD_BOT_TOKEN
+  const guildId = process.env.DISCORD_GUILD_ID // Optional: for guild-specific commands
+
+  if (!applicationId || !botToken) {
+    console.error('Error: Missing required environment variables')
+    console.error('Required: DISCORD_APPLICATION_ID, DISCORD_BOT_TOKEN')
+    process.exit(1)
+  }
+
+  // Determine endpoint - guild commands update instantly, global take up to 1 hour
+  const endpoint = guildId
+    ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
+    : `${DISCORD_API_BASE}/applications/${applicationId}/commands`
+
+  console.log(`Registering ${commands.length} command(s)...`)
+  console.log(`Endpoint: ${guildId ? `Guild (${guildId})` : 'Global'}`)
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bot ${botToken}`,
+      },
+      body: JSON.stringify(commands),
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      console.error('Failed to register commands:', error)
+      process.exit(1)
+    }
+
+    const data = await response.json()
+    console.log('Successfully registered commands:')
+    data.forEach((cmd: { name: string; id: string }) => {
+      console.log(`  - /${cmd.name} (ID: ${cmd.id})`)
+    })
+
+    if (!guildId) {
+      console.log('\nNote: Global commands may take up to 1 hour to propagate.')
+      console.log('For faster testing, set DISCORD_GUILD_ID for guild-specific commands.')
+    }
+  } catch (error) {
+    console.error('Error registering commands:', error)
+    process.exit(1)
+  }
+}
+
+// Run the script
+registerCommands()

--- a/scripts/test-discord-bot.ts
+++ b/scripts/test-discord-bot.ts
@@ -1,0 +1,164 @@
+/**
+ * Test harness for the Discord event bot.
+ *
+ * This allows testing the event parsing and creation flow without Discord.
+ *
+ * Usage:
+ *   bun run scripts/test-discord-bot.ts "yoga class at 7pm Thursday"
+ *   bun run scripts/test-discord-bot.ts "repeat cafe event every Friday"
+ *   bun run scripts/test-discord-bot.ts --create "yoga class at 7pm Thursday"
+ *
+ * Options:
+ *   --create  Actually create the event in Airtable (otherwise just shows proposal)
+ *   --username <name>  Set Discord username (default: test_user)
+ */
+
+import {
+  parseEventRequest,
+  formatProposalMessage,
+  createEventsInAirtable,
+  getExistingEventNames,
+  formatConfirmationMessage,
+} from '../app/lib/discord-events'
+
+async function main() {
+  const args = process.argv.slice(2)
+
+  if (args.length === 0 || args[0] === '--help') {
+    console.log(`
+Discord Bot Test Harness
+========================
+
+Usage:
+  bun run scripts/test-discord-bot.ts "yoga class at 7pm Thursday"
+  bun run scripts/test-discord-bot.ts "repeat cafe event every Friday"
+  bun run scripts/test-discord-bot.ts --create "yoga class at 7pm Thursday"
+
+Options:
+  --create           Actually create the event in Airtable (otherwise just shows proposal)
+  --username <name>  Set Discord username (default: test_user)
+  --help             Show this help message
+`)
+    return
+  }
+
+  // Parse arguments
+  let shouldCreate = false
+  let discordUsername = 'test_user'
+  let requestText = ''
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--create') {
+      shouldCreate = true
+    } else if (args[i] === '--username' && args[i + 1]) {
+      discordUsername = args[i + 1]
+      i++
+    } else if (!args[i].startsWith('--')) {
+      requestText = args[i]
+    }
+  }
+
+  if (!requestText) {
+    console.error('Error: Please provide an event request text')
+    process.exit(1)
+  }
+
+  console.log('\n========================================')
+  console.log('Discord Event Bot Test')
+  console.log('========================================\n')
+  console.log(`Request: "${requestText}"`)
+  console.log(`Discord Username: ${discordUsername}`)
+  console.log(`Create in Airtable: ${shouldCreate ? 'Yes' : 'No (dry run)'}`)
+  console.log('')
+
+  // Fetch existing event names
+  console.log('Fetching existing event names...')
+  const existingNames = await getExistingEventNames()
+  console.log(`Found ${existingNames.length} existing events`)
+  if (existingNames.length > 0) {
+    console.log(`Sample events: ${existingNames.slice(0, 5).join(', ')}...`)
+  }
+  console.log('')
+
+  // Parse the request
+  console.log('Parsing event request...')
+  const parsed = await parseEventRequest(
+    requestText,
+    discordUsername,
+    'test_discord_id_123',
+    `Test User (${discordUsername})`,
+    existingNames
+  )
+
+  console.log('\n--- Raw Parsed Data ---')
+  console.log(JSON.stringify(parsed.rawParsed, null, 2))
+
+  if (parsed.needsMoreInfo) {
+    console.log('\n--- Bot would ask for more info ---')
+    console.log('Questions:')
+    parsed.questions?.forEach(q => console.log(`  - ${q}`))
+    return
+  }
+
+  if (parsed.useFormInstead) {
+    console.log('\n--- Bot would redirect to form ---')
+    console.log(`Form URL: ${parsed.formUrl}`)
+    return
+  }
+
+  if (parsed.proposals.length === 0) {
+    console.log('\n--- No proposals generated ---')
+    console.log('Bot would show error message')
+    return
+  }
+
+  // Show the proposal
+  const proposal = parsed.proposals[0]
+  console.log('\n--- Event Proposal ---')
+  console.log(formatProposalMessage(proposal))
+
+  console.log('\n--- Proposal Details (JSON) ---')
+  console.log(JSON.stringify({
+    name: proposal.name,
+    hostDiscordUsername: proposal.hostDiscordUsername,
+    hostDisplayName: proposal.hostDisplayName,
+    startDate: proposal.startDate.toISOString(),
+    endDate: proposal.endDate?.toISOString(),
+    visibility: proposal.visibility,
+    isRecurring: proposal.isRecurring,
+    recurrencePattern: proposal.recurrencePattern,
+    occurrencesCount: proposal.occurrences?.length,
+  }, null, 2))
+
+  if (proposal.isRecurring && proposal.occurrences) {
+    console.log('\n--- Recurring Event Dates ---')
+    proposal.occurrences.forEach((date, i) => {
+      console.log(`  ${i + 1}. ${date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}`)
+    })
+  }
+
+  // Create in Airtable if requested
+  if (shouldCreate) {
+    console.log('\n--- Creating in Airtable ---')
+    console.log('Creating event(s)...')
+
+    const result = await createEventsInAirtable(proposal)
+
+    if (result.success) {
+      console.log(`\nSuccess! Created ${result.recordIds.length} record(s)`)
+      console.log(`Record IDs: ${result.recordIds.join(', ')}`)
+      if (result.createdNewPerson) {
+        console.log(`\nNote: Created new Person record for @${proposal.hostDiscordUsername}`)
+      }
+      console.log('\n--- Confirmation Message ---')
+      console.log(formatConfirmationMessage(proposal, result.recordIds, result.createdNewPerson))
+    } else {
+      console.error(`\nError: ${result.error}`)
+    }
+  } else {
+    console.log('\n--- Dry Run Complete ---')
+    console.log('Use --create flag to actually create the event in Airtable')
+  }
+}
+
+main().catch(console.error)


### PR DESCRIPTION
## Summary
- Add `/add-event` slash command for natural language event creation in Discord
- Parse event requests using Claude (handles dates, times, recurring events)
- Look up users by Discord username in People table
- Create new Person record if Discord username not found
- Link events to People via "Hosted by" field
- Events created with "Idea" status
- Cap recurring events at 3 months (max 13 occurrences)

## New files
- `app/api/discord/interactions/route.ts` - webhook handler
- `app/lib/discord.ts` - Discord utilities
- `app/lib/discord-events.ts` - event parsing and Airtable integration
- `scripts/register-discord-commands.ts` - command registration
- `scripts/test-discord-bot.ts` - local test harness
- `docs/discord-bot-setup.md` - setup documentation

## Test plan
- [ ] Register Discord commands with the bot
- [ ] Test `/add-event` with various natural language inputs
- [ ] Verify events appear in Airtable with correct status
- [ ] Test recurring event creation
- [ ] Verify Discord username lookup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)