### PR TITLE
Use last 6 characters of IDs for day pass names

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -134,7 +134,7 @@ async function handleMemberDayPass(session: Stripe.Checkout.Session) {
 
   try {
     await createRecord(Tables.DayPasses, {
-      Name: session.id,
+      Name: session.id.slice(-6),
       Username: userName,
       Status: 'Unused',
       'Stripe link (from User)': `Member day pass - $25 - ${userEmail}`,
@@ -257,7 +257,7 @@ async function createAirtableRecord({
     const personId = await findOrCreatePerson({ customerName, customerEmail });
 
     const fields: Record<string, unknown> = {
-      Name: paymentId,
+      Name: paymentId.slice(-6),
       'Pass Type': passType,
       Status: 'Unused',
     };


### PR DESCRIPTION
## Summary
Updated the day pass naming convention to use only the last 6 characters of payment/session IDs instead of the full ID string.

## Changes
- Modified `handleMemberDayPass()` to use `session.id.slice(-6)` for the day pass Name field
- Modified `createAirtableRecord()` to use `paymentId.slice(-6)` for the day pass Name field

## Details
This change shortens the day pass identifiers in Airtable records from full IDs to their last 6 characters, likely to improve readability and reduce clutter in the database while maintaining uniqueness for practical purposes.

https://claude.ai/code/session_01MNZo8fz79ATmvh69wsyknQ