### PR TITLE
Fix day pass payment ID handling to use full session ID

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -134,7 +134,7 @@ async function handleMemberDayPass(session: Stripe.Checkout.Session) {
 
   try {
     await createRecord(Tables.DayPasses, {
-      Name: session.id.slice(-6),
+      Name: session.id,
       Username: userName,
       Status: 'Unused',
       'Stripe link (from User)': `Member day pass - $25 - ${userEmail}`,

--- a/app/day-pass/activate/api/route.ts
+++ b/app/day-pass/activate/api/route.ts
@@ -66,14 +66,8 @@ export async function POST(request: Request) {
       return Response.json({ success: false, status: 'not-found' })
     }
 
-    // Truncate payment ID to last 6 chars to match how it's stored in Airtable
-    // For multi-pass purchases, IDs end with "-1", "-2", etc. so we need to preserve that
-    const truncatedId = paymentId.includes('-')
-      ? paymentId.slice(0, -2).slice(-6) + paymentId.slice(-2) // e.g., "cs_live_abc123-1" -> "c123-1"
-      : paymentId.slice(-6) // e.g., "cs_live_abc123" -> "bc123"
-
-    // Fetch day pass record from Airtable
-    const escapedPaymentId = escapeAirtableString(truncatedId)
+    // Fetch day pass record from Airtable using the full payment ID
+    const escapedPaymentId = escapeAirtableString(paymentId)
     const record = await findRecord<DayPassFields>(
       Tables.DayPasses,
       `{Name}='${escapedPaymentId}'`

--- a/app/portal/api/create-day-pass-checkout/route.ts
+++ b/app/portal/api/create-day-pass-checkout/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: Request) {
           quantity: 1,
         },
       ],
-      success_url: `${baseUrl}/day-pass/activate?payment_id={CHECKOUT_SESSION_ID}`,
+      success_url: `${baseUrl}/day-pass/activate?id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/portal`,
       metadata: {
         type: 'member_day_pass',


### PR DESCRIPTION
## Summary
This PR fixes the day pass payment ID handling by storing and querying the full Stripe checkout session ID instead of truncating it to the last 6 characters. This resolves issues with payment ID matching in Airtable and simplifies the lookup logic.

## Key Changes
- **Webhook handler**: Changed day pass record creation to store the full `session.id` instead of `session.id.slice(-6)`
- **Activation endpoint**: Removed complex truncation logic that was attempting to preserve multi-pass suffixes (e.g., "-1", "-2") and now uses the full payment ID for Airtable queries
- **Checkout creation**: Updated the success URL parameter name from `payment_id` to `id` to match the activation endpoint's expected query parameter

## Implementation Details
The previous implementation truncated session IDs to 6 characters, which created a mismatch between:
- What was stored in Airtable (truncated ID)
- What was being queried during activation (complex truncation logic)

By using the full session ID throughout, we eliminate this fragile truncation logic and ensure consistent payment ID matching across the system. The full session ID is unique and provides better traceability for debugging.

https://claude.ai/code/session_012iZN4w9gESaszoZAoijk6G