### PR TITLE
Add floorplans public page with Airtable-backed floor images

### DIFF
--- a/app/floorplans/page.tsx
+++ b/app/floorplans/page.tsx
@@ -1,0 +1,89 @@
+import { Metadata } from 'next'
+import Image from 'next/image'
+import { getFloors } from '@/app/lib/floors'
+import type { Floor } from '@/app/lib/floors'
+
+export const metadata: Metadata = {
+  title: 'Floorplans | Mox',
+  description: 'Explore the four floors of Mox SF — coworking, private offices, event spaces, and more.',
+}
+
+export default async function FloorplansPage() {
+  const floors = await getFloors()
+
+  return (
+    <div className="min-h-screen bg-background-page dark:bg-background-page-dark text-text-primary dark:text-text-primary-dark">
+      {/* Header */}
+      <div className="relative py-16 sm:py-20 px-4 sm:px-6 text-center border-b border-gray-200 dark:border-gray-700">
+        <div
+          className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-5 dark:invert"
+          style={{ backgroundImage: 'url(/images/mox_sketch.png)' }}
+        />
+        <div className="relative z-10">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-gray-200 font-display mb-4">
+            Floorplans
+          </h1>
+          <p className="text-lg text-text-secondary dark:text-text-secondary-dark max-w-2xl mx-auto">
+            Mox occupies four floors at 1680 Mission Street, San Francisco. Each floor has its own
+            character — from event spaces on the ground floor to focused work areas above.
+          </p>
+        </div>
+      </div>
+
+      {/* Floors */}
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-12 space-y-20">
+        {floors.map((floor) => (
+          <FloorSection key={floor.id} floor={floor} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function FloorSection({ floor }: { floor: Floor }) {
+  return (
+    <section id={`floor-${floor.number}`}>
+      <div className="mb-6 border-b border-gray-200 dark:border-gray-700 pb-4">
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-200 font-display mb-2">
+          {floor.name}
+        </h2>
+        {floor.description && (
+          <p className="text-text-secondary dark:text-text-secondary-dark text-base">
+            {floor.description}
+          </p>
+        )}
+      </div>
+
+      {/* SVG Floorplan */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-6">
+        <div className="p-4 sm:p-6">
+          <img
+            src={floor.svgPath}
+            alt={`${floor.name} floorplan`}
+            className="w-full h-auto dark:invert dark:opacity-90"
+          />
+        </div>
+      </div>
+
+      {/* Photos from Airtable */}
+      {floor.images.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {floor.images.map((img, i) => (
+            <div
+              key={img.url}
+              className="relative aspect-[4/3] overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
+            >
+              <Image
+                src={img.url}
+                alt={`${floor.name} — photo ${i + 1}`}
+                fill
+                className="object-cover"
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/app/lib/airtable.ts
+++ b/app/lib/airtable.ts
@@ -11,6 +11,7 @@ export const Tables = {
   DayPasses: 'Day Passes',
   Rooms: 'Rooms',
   RoomBookings: 'Room Bookings',
+  Floors: 'Floors',
 } as const
 
 export type TableName = (typeof Tables)[keyof typeof Tables]

--- a/app/lib/floors.ts
+++ b/app/lib/floors.ts
@@ -1,0 +1,83 @@
+import { getRecords, Tables } from './airtable'
+
+export interface FloorImage {
+  url: string
+  filename: string
+  width?: number
+  height?: number
+}
+
+export interface Floor {
+  id: string
+  number: string // "1", "2", "3", "4"
+  name: string // e.g. "Floor 1"
+  description?: string
+  images: FloorImage[]
+  svgPath: string // path to the SVG floorplan in /public/floorplans/
+}
+
+interface FloorFields {
+  Name: string
+  Description?: string
+  Images?: Array<{
+    url: string
+    filename: string
+    width?: number
+    height?: number
+  }>
+}
+
+// Static floor descriptions — these are defaults if Airtable doesn't have one
+const FLOOR_DEFAULTS: Record<string, { description: string }> = {
+  '1': {
+    description: 'The ground floor features our main reception, event spaces, lounge areas, and kitchen. A hub for community gatherings and public events.',
+  },
+  '2': {
+    description: 'The second floor houses coworking areas and dedicated desks, with plenty of natural light and collaborative open space.',
+  },
+  '3': {
+    description: 'The third floor is home to startups and resident teams, with private offices and focused work areas.',
+  },
+  '4': {
+    description: 'The fourth floor hosts EA-affiliated organizations, hangout areas, and additional meeting rooms.',
+  },
+}
+
+export async function getFloors(): Promise<Floor[]> {
+  try {
+    const records = await getRecords<FloorFields>(Tables.Floors, {
+      sort: [{ field: 'Name', direction: 'asc' }],
+    })
+
+    return records.map((record) => {
+      const number = record.fields.Name?.replace(/\D/g, '') || ''
+      return {
+        id: record.id,
+        number,
+        name: record.fields.Name || `Floor ${number}`,
+        description: record.fields.Description || FLOOR_DEFAULTS[number]?.description,
+        images: (record.fields.Images || []).map((img) => ({
+          url: img.url,
+          filename: img.filename,
+          width: img.width,
+          height: img.height,
+        })),
+        svgPath: `/floorplans/Floor ${number}.svg`,
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching floors from Airtable:', error)
+    // Fall back to static floor data
+    return STATIC_FLOORS
+  }
+}
+
+// Fallback static floors if Airtable table doesn't exist yet
+const STATIC_FLOORS: Floor[] = ['1', '2', '3', '4'].map((number) => ({
+  id: `floor-${number}`,
+  number,
+  name: `Floor ${number}`,
+  description: FLOOR_DEFAULTS[number]?.description,
+  images: [],
+  svgPath: `/floorplans/Floor ${number}.svg`,
+}))

--- a/docs/airtable-schema.md
+++ b/docs/airtable-schema.md
@@ -158,6 +158,20 @@ Physical room/desk management.
 
 ---
 
+### Floors
+
+Per-floor metadata used by the `/floorplans` public page.
+
+| Field | Type | Description | Used by App |
+|-------|------|-------------|-------------|
+| `Name` | singleLineText | Floor name, e.g. "Floor 1" | ✅ Floorplans page |
+| `Description` | multilineText | Short description of the floor's character/use | ✅ Floorplans page |
+| `Images` | multipleAttachments | Photos of the floor (shown alongside SVG floorplan) | ✅ Floorplans page |
+
+The SVG floorplans themselves are stored as static files in `/public/floorplans/Floor N.svg`.
+
+---
+
 ### Other Tables (not used by app)
 
 - **Investments** - Investment tracking

--- a/public/floorplans/Floor 1.svg
+++ b/public/floorplans/Floor 1.svg
@@ -1,0 +1,6578 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="LAYER_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2507.39 1410.79">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 52.94px;
+      }
+
+      .cls-1, .cls-2 {
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-2 {
+        font-size: 52.94px;
+      }
+
+      .cls-3 {
+        fill: none;
+        stroke: #000;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: .71px;
+      }
+    </style>
+  </defs>
+  <g id="LWPOLYLINE">
+    <polygon class="cls-3" points="1102.77 985.95 1102.77 989.58 1103.37 989.58 1103.37 981.72 1102.77 981.72 1102.77 985.35 1095.81 985.35 1095.81 981.72 1095.2 981.72 1095.2 989.58 1095.81 989.58 1095.81 985.95 1102.77 985.95"/>
+  </g>
+  <g id="CIRCLE">
+    <circle class="cls-3" cx="1098.98" cy="985.5" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-2" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="994.42" x2="915.5" y2="982.02"/>
+  </g>
+  <g id="LWPOLYLINE-3" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1888.42" y1="1263.07" x2="1888.42" y2="1261.25"/>
+  </g>
+  <g id="LWPOLYLINE-4" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="881.92" y="1253.99" width="42.96" height="17.85"/>
+  </g>
+  <g id="LWPOLYLINE-5" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1888.42" y="1257.93" width="50.82" height="17.85"/>
+  </g>
+  <g id="LWPOLYLINE-6" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.46 1257.92 2107.76 1257.92 2107.76 1275.77 2162.51 1275.77"/>
+  </g>
+  <g id="LWPOLYLINE-7" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1939.25" y1="1271.84" x2="2107.76" y2="1271.84"/>
+  </g>
+  <g id="LWPOLYLINE-8" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1939.25" y1="1261.55" x2="2107.76" y2="1261.55"/>
+  </g>
+  <g id="LWPOLYLINE-9" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1922.61" y1="1141.45" x2="1926.55" y2="1141.45"/>
+  </g>
+  <g id="LWPOLYLINE-10" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1962.54 1137.22 1962.54 1141.45 2044.53 1141.45"/>
+  </g>
+  <g id="LWPOLYLINE-11" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2022.14" y1="1234.93" x2="2044.53" y2="1234.93"/>
+  </g>
+  <g id="LWPOLYLINE-12" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2028.19" y1="1240.68" x2="2050.58" y2="1240.68"/>
+  </g>
+  <g id="LWPOLYLINE-13" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1916.56" y1="1137.22" x2="1926.54" y2="1137.22"/>
+  </g>
+  <g id="LWPOLYLINE-14" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1962.54" y1="1137.22" x2="2044.53" y2="1137.22"/>
+  </g>
+  <g id="LWPOLYLINE-15" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2044.53 1028.61 2044.53 1061.58 2050.57 1061.58"/>
+  </g>
+  <g id="LWPOLYLINE-16" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="1028.61" x2="2048.46" y2="1028.61"/>
+  </g>
+  <g id="LWPOLYLINE-17" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2044.53 883.1 2044.53 992.31 2048.46 992.31"/>
+  </g>
+  <g id="LWPOLYLINE-18" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="1097.58" x2="2050.57" y2="1097.58"/>
+  </g>
+  <g id="LWPOLYLINE-19" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1939.25" y="1267" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-20" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M455.06,1253.99h-26.92c-11.96-.08-21.65-9.72-21.78-21.68"/>
+  </g>
+  <g id="LWPOLYLINE-21" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="286.55 1275.77 286.55 1253.99 258.72 1253.99"/>
+  </g>
+  <g id="LWPOLYLINE-22" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.66" y1="1210.43" x2="401.51" y2="1210.43"/>
+  </g>
+  <g id="LWPOLYLINE-23" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="406.66 1158.39 406.66 1164.14 401.51 1164.14"/>
+  </g>
+  <g id="LWPOLYLINE-24" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="455.06" y="1253.99" width="51.43" height="21.78"/>
+  </g>
+  <g id="LWPOLYLINE-25" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.55" y1="1271.23" x2="455.06" y2="1271.23"/>
+  </g>
+  <g id="LWPOLYLINE-26" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.55" y1="1271.84" x2="455.06" y2="1271.84"/>
+  </g>
+  <g id="LWPOLYLINE-27" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.55" y1="1261.86" x2="455.06" y2="1261.86"/>
+  </g>
+  <g id="LWPOLYLINE-28" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="170.38" y1="1280.31" x2="294.72" y2="1280.31"/>
+  </g>
+  <g id="LWPOLYLINE-29" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="170.38 1280.31 170.38 1252.17 237.85 1252.17"/>
+  </g>
+  <g id="LWPOLYLINE-30" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.55" y1="1275.77" x2="235.12" y2="1275.77"/>
+  </g>
+  <g id="LWPOLYLINE-31" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="721.89 701.88 673.48 717.91 679.53 736.67 728.24 720.94 721.89 701.88"/>
+  </g>
+  <g id="LWPOLYLINE-32" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M481.99,785.08l-144.31,47.19,144.31-47.19Z"/>
+  </g>
+  <g id="CIRCLE-2" data-name="CIRCLE">
+    <circle class="cls-3" cx="1295.02" cy="707.78" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-33" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1298.8 985.95 1298.8 989.58 1299.41 989.58 1299.41 981.72 1298.8 981.72 1298.8 985.35 1291.85 985.35 1291.85 981.72 1291.24 981.72 1291.24 989.58 1291.85 989.58 1291.85 985.95 1298.8 985.95"/>
+  </g>
+  <g id="CIRCLE-3" data-name="CIRCLE">
+    <circle class="cls-3" cx="1295.02" cy="985.5" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-34" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1494.54 985.95 1494.54 989.58 1495.14 989.58 1495.14 981.72 1494.54 981.72 1494.54 985.35 1487.58 985.35 1487.58 981.72 1486.97 981.72 1486.97 989.58 1487.58 989.58 1487.58 985.95 1494.54 985.95"/>
+  </g>
+  <g id="LWPOLYLINE-35" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1692.09 985.95 1692.09 989.58 1692.69 989.58 1692.69 981.72 1692.09 981.72 1692.09 985.35 1685.13 985.35 1685.13 981.72 1684.52 981.72 1684.52 989.58 1685.13 989.58 1685.13 985.95 1692.09 985.95"/>
+  </g>
+  <g id="LWPOLYLINE-36" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1922.01 985.95 1922.01 989.58 1922.61 989.58 1922.61 981.72 1922.01 981.72 1922.01 985.35 1915.04 985.35 1915.04 981.72 1914.44 981.72 1914.44 989.58 1915.04 989.58 1915.04 985.95 1922.01 985.95"/>
+  </g>
+  <g id="CIRCLE-4" data-name="CIRCLE">
+    <circle class="cls-3" cx="1918.52" cy="985.5" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-37" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1922.01 708.24 1922.01 712.17 1922.61 712.17 1922.61 704 1922.01 704 1922.01 707.93 1915.04 707.93 1915.04 704 1914.44 704 1914.44 712.17 1915.04 712.17 1915.04 708.24 1922.01 708.24"/>
+  </g>
+  <g id="CIRCLE-5" data-name="CIRCLE">
+    <circle class="cls-3" cx="1918.22" cy="707.78" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-38" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1691.78 708.24 1691.78 712.17 1692.39 712.17 1692.39 704 1691.78 704 1691.78 707.93 1684.83 707.93 1684.83 704 1684.22 704 1684.22 712.17 1684.83 712.17 1684.83 708.24 1691.78 708.24"/>
+  </g>
+  <g id="LWPOLYLINE-39" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="907.03 985.95 907.03 989.58 907.34 989.58 907.34 981.72 907.03 981.72 907.03 985.35 899.77 985.35 899.77 981.72 899.47 981.72 899.47 989.58 899.77 989.58 899.77 985.95 907.03 985.95"/>
+  </g>
+  <g id="CIRCLE-6" data-name="CIRCLE">
+    <circle class="cls-3" cx="902.95" cy="985.5" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-40" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="703.13 985.95 703.13 989.58 703.43 989.58 703.43 981.72 703.13 981.72 703.13 985.35 695.87 985.35 695.87 981.72 695.56 981.72 695.56 989.58 695.87 989.58 695.87 985.95 703.13 985.95"/>
+  </g>
+  <g id="LWPOLYLINE-41" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.53 985.95 499.53 989.58 499.84 989.58 499.84 981.72 499.53 981.72 499.53 985.35 492.27 985.35 492.27 981.72 491.97 981.72 491.97 989.58 492.27 989.58 492.27 985.95 499.53 985.95"/>
+  </g>
+  <g id="CIRCLE-7" data-name="CIRCLE">
+    <circle class="cls-3" cx="495.75" cy="985.5" r="9.83"/>
+  </g>
+  <g id="LWPOLYLINE-42" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1494.54 708.24 1494.54 712.17 1495.14 712.17 1495.14 704 1494.54 704 1494.54 707.93 1487.58 707.93 1487.58 704 1486.97 704 1486.97 712.17 1487.58 712.17 1487.58 708.24 1494.54 708.24"/>
+  </g>
+  <g id="CIRCLE-8" data-name="CIRCLE">
+    <circle class="cls-3" cx="1490.76" cy="707.79" r="8.33"/>
+  </g>
+  <g id="LWPOLYLINE-43" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1298.5 708.24 1298.5 712.17 1299.11 712.17 1299.11 704 1298.5 704 1298.5 707.93 1291.54 707.93 1291.54 704 1291.24 704 1291.24 712.17 1291.54 712.17 1291.54 708.24 1298.5 708.24"/>
+  </g>
+  <g id="LWPOLYLINE-44" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1102.77 708.24 1102.77 712.17 1103.37 712.17 1103.37 704 1102.77 704 1102.77 707.93 1095.81 707.93 1095.81 704 1095.2 704 1095.2 712.17 1095.81 712.17 1095.81 708.24 1102.77 708.24"/>
+  </g>
+  <g id="CIRCLE-9" data-name="CIRCLE">
+    <circle class="cls-3" cx="1098.98" cy="707.78" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-45" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="907.03 708.24 907.03 712.17 907.34 712.17 907.34 704 907.03 704 907.03 707.93 899.77 707.93 899.77 704 899.47 704 899.47 712.17 899.77 712.17 899.77 708.24 907.03 708.24"/>
+  </g>
+  <g id="CIRCLE-10" data-name="CIRCLE">
+    <circle class="cls-3" cx="902.95" cy="707.78" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-46" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2134.68 708.24 2134.68 712.17 2134.98 712.17 2134.98 704 2134.68 704 2134.68 707.93 2127.42 707.93 2127.42 704 2127.11 704 2127.11 712.17 2127.42 712.17 2127.42 708.24 2134.68 708.24"/>
+  </g>
+  <g id="CIRCLE-11" data-name="CIRCLE">
+    <circle class="cls-3" cx="2130.59" cy="707.78" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-47" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1902.64 521.58 1903.85 525.21 1904.16 524.9 1901.74 517.35 1901.44 517.64 1902.34 521.27 1895.69 523.39 1894.48 519.76 1894.18 520.07 1896.59 527.63 1897.2 527.33 1895.99 523.7 1902.64 521.58"/>
+  </g>
+  <g id="CIRCLE-12" data-name="CIRCLE">
+    <circle class="cls-3" cx="1899.16" cy="522.33" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-48" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2069.94 488.9 2071.15 492.53 2070.84 492.84 2068.43 484.97 2068.73 484.97 2069.94 488.6 2076.59 486.18 2075.39 482.86 2075.99 482.54 2078.41 490.11 2078.11 490.42 2076.9 486.78 2069.94 488.9"/>
+  </g>
+  <g id="CIRCLE-13" data-name="CIRCLE">
+    <circle class="cls-3" cx="2073.12" cy="487.55" r="10.14"/>
+  </g>
+  <g id="LWPOLYLINE-49" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1096.11 588.43 1097.01 592.06 1097.62 592.06 1095.21 584.2 1094.6 584.5 1095.81 588.13 1089.15 590.25 1087.94 586.62 1087.64 586.92 1090.06 594.48 1090.36 594.18 1089.15 590.86 1096.11 588.43"/>
+  </g>
+  <g id="LWPOLYLINE-50" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="703.74 717.61 704.94 720.94 705.55 720.94 702.83 713.38 702.53 713.38 703.74 717.01 697.08 719.13 695.87 715.8 695.27 715.8 697.99 723.36 698.29 723.36 697.08 719.73 703.74 717.61"/>
+  </g>
+  <g id="LWPOLYLINE-51" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="511.33 780.84 512.54 784.47 512.84 784.47 510.43 776.61 509.82 776.91 511.03 780.54 504.37 782.66 503.16 779.02 502.86 779.33 505.28 786.89 505.58 786.59 504.68 783.26 511.33 780.84"/>
+  </g>
+  <g id="LWPOLYLINE-52" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1691.78 1267 1691.78 1270.93 1692.39 1270.93 1692.39 1262.77 1691.78 1262.77 1691.78 1266.7 1684.83 1266.7 1684.83 1262.77 1684.52 1262.77 1684.52 1270.93 1684.83 1270.93 1684.83 1267 1691.78 1267"/>
+  </g>
+  <g id="LWPOLYLINE-53" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1298.5 1263.07 1298.5 1266.7 1299.11 1266.7 1299.11 1258.84 1298.5 1258.84 1298.5 1262.46 1291.54 1262.46 1291.54 1258.84 1291.24 1258.84 1291.24 1266.7 1291.54 1266.7 1291.54 1263.07 1298.5 1263.07"/>
+  </g>
+  <g id="LWPOLYLINE-54" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1102.77 1263.07 1102.77 1266.7 1103.37 1266.7 1103.37 1258.84 1102.77 1258.84 1102.77 1262.46 1095.81 1262.46 1095.81 1258.84 1095.2 1258.84 1095.2 1266.7 1095.81 1266.7 1095.81 1263.07 1102.77 1263.07"/>
+  </g>
+  <g id="LWPOLYLINE-55" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="906.73 1263.07 906.73 1267 907.34 1267 907.34 1258.84 906.73 1258.84 906.73 1262.76 899.77 1262.76 899.77 1258.84 899.47 1258.84 899.47 1267 899.77 1267 899.77 1263.07 906.73 1263.07"/>
+  </g>
+  <g id="LWPOLYLINE-56" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="702.83 1265.18 702.83 1269.12 703.43 1269.12 703.43 1260.95 702.83 1260.95 702.83 1264.58 695.87 1264.58 695.87 1260.95 695.57 1260.95 695.57 1269.12 695.87 1269.12 695.87 1265.18 702.83 1265.18"/>
+  </g>
+  <g id="LWPOLYLINE-57" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="484.41 1265.18 484.41 1269.12 484.71 1269.12 484.71 1260.95 484.41 1260.95 484.41 1264.58 477.15 1264.58 477.15 1260.95 476.84 1260.95 476.84 1269.12 477.15 1269.12 477.15 1265.18 484.41 1265.18"/>
+  </g>
+  <g id="LWPOLYLINE-58" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1922.01 1267 1922.01 1270.93 1922.61 1270.93 1922.61 1262.77 1922.01 1262.77 1922.01 1266.7 1915.04 1266.7 1915.04 1262.77 1914.44 1262.77 1914.44 1270.93 1915.04 1270.93 1915.04 1267 1922.01 1267"/>
+  </g>
+  <g id="LWPOLYLINE-59" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="273.24 1065.52 269.61 1065.21 269.61 1065.52 277.47 1066.42 277.47 1066.12 273.85 1065.52 274.76 1058.56 278.39 1059.17 278.39 1058.56 270.52 1057.65 270.52 1058.26 274.15 1058.56 273.24 1065.52"/>
+  </g>
+  <g id="LWPOLYLINE-60" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="297.44 854.05 293.82 853.75 293.82 854.05 301.68 854.96 301.68 854.66 298.05 854.05 298.65 847.09 302.59 847.4 302.59 847.09 294.72 846.19 294.42 846.79 298.35 847.09 297.44 854.05"/>
+  </g>
+  <g id="LWPOLYLINE-61" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2160.09 1263.37 2163.72 1263.97 2163.72 1263.37 2155.86 1262.46 2155.86 1263.07 2159.49 1263.37 2158.88 1270.33 2154.95 1270.02 2154.95 1270.63 2162.81 1271.54 2162.81 1270.94 2159.19 1270.63 2160.09 1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-62" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2183.39 988.98 2179.45 988.68 2179.45 989.28 2187.62 989.88 2187.62 989.58 2183.69 989.28 2184.59 982.02 2188.23 982.63 2188.23 982.02 2180.36 981.11 2180.36 981.72 2183.99 982.02 2183.39 988.98"/>
+  </g>
+  <g id="LWPOLYLINE-63" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2212.43 710.66 2208.5 710.05 2208.5 710.66 2216.67 711.56 2216.67 710.96 2212.73 710.66 2213.63 703.4 2217.27 704 2217.27 703.4 2209.4 702.49 2209.4 703.09 2213.03 703.4 2212.43 710.66"/>
+  </g>
+  <g id="LWPOLYLINE-64" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2238.75 457.14 2235.12 456.53 2234.82 457.14 2242.98 458.04 2242.98 457.44 2239.35 457.14 2239.95 450.18 2243.59 450.48 2243.89 449.88 2235.72 449.28 2235.72 449.57 2239.35 449.88 2238.75 457.14"/>
+  </g>
+  <g id="LWPOLYLINE-65" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2280.5 199.09 2281.7 202.71 2282.01 202.41 2279.59 194.85 2279.29 195.15 2280.19 198.78 2273.54 200.9 2272.33 197.27 2272.03 197.57 2274.45 205.13 2275.05 204.84 2273.84 201.21 2280.5 199.09"/>
+  </g>
+  <g id="LWPOLYLINE-66" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="294.72" y1="1271.84" x2="294.72" y2="1280.31"/>
+  </g>
+  <g id="LWPOLYLINE-67" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1942.27" y1="1268.51" x2="1979.79" y2="1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-68" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1942.27" y1="1267.6" x2="1979.79" y2="1267.6"/>
+  </g>
+  <g id="LWPOLYLINE-69" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1940.46" y="1267" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-70" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2106.55" y="1267" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-71" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2104.73" y="1267" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-72" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2023.05" y="1267" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-73" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2023.95" y="1267" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-74" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2020.93" y="1267" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-75" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1979.79" y="1267" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-76" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1981.6" y="1267" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-77" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2065.4" y="1267" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-78" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2063.28" y="1267" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-79" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2020.93" y1="1268.51" x2="1983.72" y2="1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-80" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2020.93" y1="1267.6" x2="1983.72" y2="1267.6"/>
+  </g>
+  <g id="LWPOLYLINE-81" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2026.07" y1="1268.51" x2="2063.28" y2="1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-82" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2026.07" y1="1267.6" x2="2063.28" y2="1267.6"/>
+  </g>
+  <g id="LWPOLYLINE-83" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2104.73" y1="1268.51" x2="2067.21" y2="1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-84" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2104.73" y1="1267.6" x2="2067.21" y2="1267.6"/>
+  </g>
+  <g id="LWPOLYLINE-85" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="288.67" y1="1270.02" x2="290.79" y2="1267.9"/>
+  </g>
+  <g id="LWPOLYLINE-86" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="290.79 1267.91 293.51 1270.63 295.93 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-87" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="295.93 1267.91 298.65 1270.63 301.38 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-88" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="301.38 1267.91 304.1 1270.63 306.82 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-89" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="306.82 1267.91 309.24 1270.63 311.96 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-90" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="311.97 1267.91 314.69 1270.63 317.41 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-91" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="317.41 1267.91 319.83 1270.63 322.55 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-92" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="322.56 1267.91 325.28 1270.63 328 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-93" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="328 1267.91 330.72 1270.63 333.15 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-94" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="333.14 1267.91 335.87 1270.63 338.59 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-95" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="338.59 1267.91 341.31 1270.63 344.03 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-96" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="344.03 1267.91 346.45 1270.63 349.17 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-97" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="349.18 1267.91 351.9 1270.63 354.62 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-98" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="354.62 1267.91 357.04 1270.63 359.76 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-99" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="359.77 1267.91 362.49 1270.63 365.21 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-100" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="365.21 1267.91 367.93 1270.63 369.75 1268.81"/>
+  </g>
+  <g id="LWPOLYLINE-101" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="286.55" y="1266.39" width="2.12" height="4.84"/>
+  </g>
+  <g id="LWPOLYLINE-102" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="369.75" y="1266.39" width="2.12" height="4.84"/>
+  </g>
+  <g id="LWPOLYLINE-103" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="452.94" y="1266.39" width="2.12" height="4.84"/>
+  </g>
+  <g id="LWPOLYLINE-104" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="452.94" y1="1266.39" x2="288.67" y2="1266.39"/>
+  </g>
+  <g id="LWPOLYLINE-105" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="371.87 1269.42 373.08 1270.63 375.8 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-106" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="375.8 1267.91 378.52 1270.63 380.94 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-107" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="380.94 1267.91 383.66 1270.63 386.39 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-108" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="386.39 1267.91 389.11 1270.63 391.83 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-109" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="391.83 1267.91 394.25 1270.63 396.97 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-110" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="396.98 1267.91 399.7 1270.63 402.42 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-111" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="402.42 1267.91 405.14 1270.63 407.57 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-112" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="407.57 1267.91 410.29 1270.63 413.01 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-113" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="413.01 1267.91 415.73 1270.63 418.15 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-114" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="418.15 1267.91 420.88 1270.63 423.6 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-115" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="423.6 1267.91 426.32 1270.63 429.04 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-116" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="429.04 1267.91 431.46 1270.63 434.19 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-117" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="434.19 1267.91 436.91 1270.63 439.63 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-118" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="439.63 1267.91 442.05 1270.63 444.77 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-119" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="444.78 1267.91 447.5 1270.63 450.22 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-120" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="452.94" y1="1270.63" x2="452.94" y2="1270.63"/>
+  </g>
+  <g id="LWPOLYLINE-121" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="452.94" y1="1270.63" x2="450.22" y2="1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-122" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="729.15 1271.84 729.15 1253.99 696.78 1253.99 673.79 1253.99 673.79 1275.77 724.92 1275.77 724.92 1271.84 729.15 1271.84"/>
+  </g>
+  <g id="LWPOLYLINE-123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="729.15" y1="1267.91" x2="881.92" y2="1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-124" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="729.15" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-125" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="731.87" y1="1264.58" x2="765.45" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-126" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="731.87" y1="1263.37" x2="765.45" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-127" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="730.06" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-128" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="880.72" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-129" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="878.9" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-130" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="804.78" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-131" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="805.99" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-132" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="802.96" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-133" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="765.45" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-134" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="767.57" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-135" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="802.96" y1="1264.58" x2="769.38" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-136" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="802.96" y1="1263.37" x2="769.38" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-137" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="878.9" y1="1264.58" x2="845.32" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-138" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="878.9" y1="1263.37" x2="845.32" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-139" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="843.5" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-140" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="841.39" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-141" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="807.8" y1="1264.58" x2="841.39" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-142" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="807.8" y1="1263.37" x2="841.39" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-143" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1077.65" y="1253.99" width="43.26" height="17.85"/>
+  </g>
+  <g id="LWPOLYLINE-144" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1077.66" y1="1267.91" x2="924.89" y2="1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-145" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1273.69,1267.91h-152.77,152.77Z"/>
+  </g>
+  <g id="LWPOLYLINE-146" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1469.43" y1="1267.91" x2="1316.65" y2="1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-147" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1720.22 1253.99 1685.73 1253.99 1665.46 1253.99 1665.46 1271.84 1669.4 1271.84 1669.4 1275.77 1720.22 1275.77 1720.22 1253.99"/>
+  </g>
+  <g id="LWPOLYLINE-148" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1512.39" y1="1267.91" x2="1665.47" y2="1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-149" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1720.22" y1="1269.72" x2="1722.94" y2="1269.72"/>
+  </g>
+  <g id="LWPOLYLINE-150" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1725.36" y1="1269.72" x2="1749.26" y2="1269.72"/>
+  </g>
+  <g id="LWPOLYLINE-151" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1725.36" y1="1268.51" x2="1749.26" y2="1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-152" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1751.68" y1="1269.72" x2="1856.96" y2="1269.72"/>
+  </g>
+  <g id="LWPOLYLINE-153" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1722.94" y="1263.07" width="2.42" height="7.26"/>
+  </g>
+  <g id="LWPOLYLINE-154" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1749.26" y="1263.07" width="2.42" height="7.26"/>
+  </g>
+  <g id="LWPOLYLINE-155" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1888.42" y1="1269.72" x2="1885.7" y2="1269.72"/>
+  </g>
+  <g id="LWPOLYLINE-156" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1883.28" y1="1269.72" x2="1859.69" y2="1269.72"/>
+  </g>
+  <g id="LWPOLYLINE-157" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1883.28" y1="1268.51" x2="1859.69" y2="1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-158" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1883.28" y="1263.07" width="2.42" height="7.26"/>
+  </g>
+  <g id="LWPOLYLINE-159" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1856.96" y="1263.07" width="2.72" height="7.26"/>
+  </g>
+  <g id="LWPOLYLINE-160" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1751.68" y1="1263.07" x2="1856.96" y2="1263.07"/>
+  </g>
+  <g id="LWPOLYLINE-161" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1719.31" y1="1233.42" x2="1723.85" y2="1233.42"/>
+  </g>
+  <g id="LWPOLYLINE-162" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1719.31 1134.8 1719.31 1237.65 1720.22 1237.65"/>
+  </g>
+  <g id="LWPOLYLINE-163" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="511.63" y1="1267.3" x2="538.86" y2="1267.3"/>
+  </g>
+  <g id="LWPOLYLINE-164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="511.63" y1="1267" x2="538.86" y2="1267"/>
+  </g>
+  <g id="LWPOLYLINE-165" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="541.89" y="1263.37" width="5.75" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-166" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="506.49" y="1263.37" width="2.12" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-167" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="508.61" y="1263.37" width="3.02" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-168" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="538.86" y="1263.37" width="3.02" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-169" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="668.34" y1="1267.3" x2="641.42" y2="1267.3"/>
+  </g>
+  <g id="LWPOLYLINE-170" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="668.34" y1="1267" x2="641.42" y2="1267"/>
+  </g>
+  <g id="LWPOLYLINE-171" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="632.34" y="1263.37" width="6.05" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-172" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="671.36" y="1263.37" width="2.42" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-173" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="668.34" y="1263.37" width="3.02" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-174" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="638.39" y="1263.37" width="3.02" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-175" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="544.3" y1="1263.37" x2="544.3" y2="1255.2"/>
+  </g>
+  <g id="LWPOLYLINE-176" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="544" y1="1263.37" x2="544" y2="1255.2"/>
+  </g>
+  <g id="LWPOLYLINE-177" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="541.89" y="1249.45" width="5.75" height="5.75"/>
+  </g>
+  <g id="LWPOLYLINE-178" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="635.97 1255.2 635.97 1263.37 635.97 1255.2"/>
+  </g>
+  <g id="LWPOLYLINE-179" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="632.34" y="1249.45" width="6.05" height="5.75"/>
+  </g>
+  <g id="LWPOLYLINE-180" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="577.58 1282.13 547.64 1252.18 549.15 1250.96 579.1 1280.61"/>
+  </g>
+  <g id="LWPOLYLINE-181" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="576.67 1283.03 580.61 1278.8 583.93 1274.26 586.66 1269.11 588.47 1263.67 589.68 1257.92 589.99 1252.17"/>
+  </g>
+  <g id="LWPOLYLINE-182" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="602.39 1282.13 632.34 1252.18 630.83 1250.96 600.88 1280.61"/>
+  </g>
+  <g id="LWPOLYLINE-183" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="603.3 1283.03 599.36 1278.8 596.04 1274.26 593.62 1269.11 591.5 1263.67 590.29 1257.92 589.98 1252.17"/>
+  </g>
+  <g id="LWPOLYLINE-184" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1900.52" y1="321.61" x2="1979.18" y2="295.59"/>
+  </g>
+  <g id="LWPOLYLINE-185" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1902.94" y1="328.57" x2="1976.76" y2="304.06"/>
+  </g>
+  <g id="LWPOLYLINE-186" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1898.71 333.71 1905.36 353.68 1989.47 325.84"/>
+  </g>
+  <g id="LWPOLYLINE-187" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="336.47" y1="828.64" x2="343.73" y2="850.42"/>
+  </g>
+  <g id="LWPOLYLINE-188" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="352.2" y1="819.26" x2="354.92" y2="826.83"/>
+  </g>
+  <g id="LWPOLYLINE-189" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="339.49" y1="838.02" x2="483.8" y2="790.83"/>
+  </g>
+  <g id="LWPOLYLINE-190" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="340.71" y1="834.99" x2="341.91" y2="832.57"/>
+  </g>
+  <g id="LWPOLYLINE-191" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="341.92 832.57 345.24 834.09 347.06 830.76"/>
+  </g>
+  <g id="LWPOLYLINE-192" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="347.06 830.75 350.39 832.57 352.2 829.25"/>
+  </g>
+  <g id="LWPOLYLINE-193" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="352.2 829.24 355.53 830.76 357.04 827.43"/>
+  </g>
+  <g id="LWPOLYLINE-194" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="357.04 827.43 360.37 829.24 362.19 825.92"/>
+  </g>
+  <g id="LWPOLYLINE-195" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="362.19 825.91 365.51 827.43 367.33 824.1"/>
+  </g>
+  <g id="LWPOLYLINE-196" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="367.33 824.1 370.66 825.92 372.17 822.59"/>
+  </g>
+  <g id="LWPOLYLINE-197" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="372.17 822.59 375.5 824.1 377.31 820.78"/>
+  </g>
+  <g id="LWPOLYLINE-198" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="377.31 820.77 380.64 822.59 382.46 819.26"/>
+  </g>
+  <g id="LWPOLYLINE-199" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="382.45 819.26 385.78 820.77 387.3 817.45"/>
+  </g>
+  <g id="LWPOLYLINE-200" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="387.3 817.44 390.62 819.26 392.44 815.94"/>
+  </g>
+  <g id="LWPOLYLINE-201" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="392.44 815.93 395.77 817.45 397.58 814.12"/>
+  </g>
+  <g id="LWPOLYLINE-202" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="397.58 814.12 400.91 815.93 402.42 812.61"/>
+  </g>
+  <g id="LWPOLYLINE-203" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="402.42 812.61 406.05 814.12 407.57 810.79"/>
+  </g>
+  <g id="LWPOLYLINE-204" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="409.68" y1="812" x2="407.56" y2="810.79"/>
+  </g>
+  <g id="LWPOLYLINE-205" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="339.19 837.11 341.01 836.51 339.5 831.66 337.68 832.27 339.19 837.11"/>
+  </g>
+  <g id="LWPOLYLINE-206" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="410.29 813.82 412.41 813.21 410.59 808.37 408.77 808.97 410.29 813.82"/>
+  </g>
+  <g id="LWPOLYLINE-207" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="481.38 790.52 483.5 789.92 481.99 785.07 479.87 785.68 481.38 790.52"/>
+  </g>
+  <g id="LWPOLYLINE-208" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="341.01" y1="836.51" x2="483.5" y2="789.91"/>
+  </g>
+  <g id="LWPOLYLINE-209" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="339.49" y1="831.67" x2="481.98" y2="785.07"/>
+  </g>
+  <g id="LWPOLYLINE-210" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="411.5" y1="811.09" x2="412.7" y2="809.28"/>
+  </g>
+  <g id="LWPOLYLINE-211" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="412.71 809.28 416.03 810.79 417.55 807.46"/>
+  </g>
+  <g id="LWPOLYLINE-212" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="417.55 807.46 421.18 809.28 422.69 805.95"/>
+  </g>
+  <g id="LWPOLYLINE-213" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="422.69 805.95 426.02 807.46 427.84 804.14"/>
+  </g>
+  <g id="LWPOLYLINE-214" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="427.83 804.13 431.16 805.95 432.98 802.62"/>
+  </g>
+  <g id="LWPOLYLINE-215" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="432.98 802.62 436.3 804.14 437.82 800.81"/>
+  </g>
+  <g id="LWPOLYLINE-216" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="437.82 800.81 441.14 802.62 442.96 799.3"/>
+  </g>
+  <g id="LWPOLYLINE-217" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="442.96 799.29 446.29 800.81 448.1 797.48"/>
+  </g>
+  <g id="LWPOLYLINE-218" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="448.1 797.48 451.43 799.3 452.94 795.97"/>
+  </g>
+  <g id="LWPOLYLINE-219" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="452.94 795.97 456.27 797.48 458.09 794.15"/>
+  </g>
+  <g id="LWPOLYLINE-220" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="458.09 794.15 461.41 795.97 463.23 792.64"/>
+  </g>
+  <g id="LWPOLYLINE-221" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="463.23 792.64 466.56 794.15 468.07 790.83"/>
+  </g>
+  <g id="LWPOLYLINE-222" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="468.07 790.82 471.4 792.64 473.21 789.31"/>
+  </g>
+  <g id="LWPOLYLINE-223" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="473.21 789.31 476.54 790.82 478.36 787.5"/>
+  </g>
+  <g id="LWPOLYLINE-224" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="481.08" y1="789.01" x2="478.36" y2="787.5"/>
+  </g>
+  <g id="LWPOLYLINE-225" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="917.92 637.44 869.52 653.48 874.96 670.42 923.67 654.39 917.92 637.44"/>
+  </g>
+  <g id="LWPOLYLINE-226" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1113.96 573.01 1065.55 589.04 1071 605.68 1119.71 589.95 1113.96 573.01"/>
+  </g>
+  <g id="LWPOLYLINE-227" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1979.18" y1="295.59" x2="1987.65" y2="309.81"/>
+  </g>
+  <g id="LWPOLYLINE-228" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2000.66 272.6 1991.58 307.69 1993.09 307.99 2002.17 273.21"/>
+  </g>
+  <g id="LWPOLYLINE-229" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1999.45 272.3 2004.29 273.81 2008.53 275.93 2012.76 278.34 2016.7 281.67 2019.72 285.3 2022.44 289.24"/>
+  </g>
+  <g id="LWPOLYLINE-230" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2284.73 188.2 2235.72 204.23 2241.47 221.17"/>
+  </g>
+  <g id="LWPOLYLINE-231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2284.73" y1="188.19" x2="2285.64" y2="191.52"/>
+  </g>
+  <g id="LWPOLYLINE-232" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2185.2" y1="239.62" x2="2186.1" y2="242.05"/>
+  </g>
+  <g id="LWPOLYLINE-233" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2092.93,255.36l144.31-47.5-144.31,47.5Z"/>
+  </g>
+  <g id="LWPOLYLINE-234" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2241.47" y1="221.17" x2="2097.16" y2="268.66"/>
+  </g>
+  <g id="LWPOLYLINE-235" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2166.45" y1="233.27" x2="2167.05" y2="232.37"/>
+  </g>
+  <g id="LWPOLYLINE-236" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.05 232.36 2170.38 234.18 2171.89 230.85"/>
+  </g>
+  <g id="LWPOLYLINE-237" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.89 230.85 2175.52 232.36 2177.03 229.04"/>
+  </g>
+  <g id="LWPOLYLINE-238" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2177.03 229.03 2180.36 230.85 2182.18 227.52"/>
+  </g>
+  <g id="LWPOLYLINE-239" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2182.18 227.52 2185.5 229.34 2187.32 225.71"/>
+  </g>
+  <g id="LWPOLYLINE-240" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2187.32 225.71 2190.65 227.52 2192.16 224.2"/>
+  </g>
+  <g id="LWPOLYLINE-241" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2192.16 224.19 2195.49 226.01 2197.3 222.38"/>
+  </g>
+  <g id="LWPOLYLINE-242" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2197.3 222.38 2200.63 224.19 2202.45 220.87"/>
+  </g>
+  <g id="LWPOLYLINE-243" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2202.45 220.87 2205.77 222.68 2207.29 219.05"/>
+  </g>
+  <g id="LWPOLYLINE-244" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2207.29 219.05 2210.61 220.87 2212.43 217.54"/>
+  </g>
+  <g id="LWPOLYLINE-245" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2212.43 217.54 2215.76 219.35 2217.57 216.03"/>
+  </g>
+  <g id="LWPOLYLINE-246" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2217.57 216.03 2220.9 217.54 2222.41 214.21"/>
+  </g>
+  <g id="LWPOLYLINE-247" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2222.41 214.21 2225.74 216.03 2227.56 212.7"/>
+  </g>
+  <g id="LWPOLYLINE-248" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2227.55 212.7 2230.88 214.21 2232.7 210.88"/>
+  </g>
+  <g id="LWPOLYLINE-249" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2232.7 210.88 2236.02 212.7 2236.33 211.8"/>
+  </g>
+  <g id="LWPOLYLINE-250" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2238.75 212.7 2236.93 213.31 2235.12 208.76 2237.23 207.86 2238.75 212.7"/>
+  </g>
+  <g id="LWPOLYLINE-251" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2167.65 236.3 2165.53 236.9 2164.02 232.07 2165.84 231.45 2167.65 236.3"/>
+  </g>
+  <g id="LWPOLYLINE-252" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2096.26 259.59 2094.44 260.2 2092.93 255.36 2094.74 254.75 2096.26 259.59"/>
+  </g>
+  <g id="LWPOLYLINE-253" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2236.93" y1="213.3" x2="2094.44" y2="260.2"/>
+  </g>
+  <g id="LWPOLYLINE-254" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2235.12" y1="208.77" x2="2092.94" y2="255.36"/>
+  </g>
+  <g id="LWPOLYLINE-255" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2095.65" y1="257.17" x2="2096.26" y2="255.66"/>
+  </g>
+  <g id="LWPOLYLINE-256" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2096.26 255.66 2099.59 257.47 2101.4 254.15"/>
+  </g>
+  <g id="LWPOLYLINE-257" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2101.4 254.14 2104.73 255.66 2106.55 252.33"/>
+  </g>
+  <g id="LWPOLYLINE-258" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2106.55 252.33 2109.87 254.14 2111.39 250.82"/>
+  </g>
+  <g id="LWPOLYLINE-259" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2111.39 250.82 2114.71 252.33 2116.53 249"/>
+  </g>
+  <g id="LWPOLYLINE-260" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2116.53 249 2119.86 250.82 2121.67 247.49"/>
+  </g>
+  <g id="LWPOLYLINE-261" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2121.67 247.49 2125 249 2126.51 245.67"/>
+  </g>
+  <g id="LWPOLYLINE-262" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2126.51 245.67 2129.84 247.49 2131.66 244.16"/>
+  </g>
+  <g id="LWPOLYLINE-263" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2131.66 244.16 2134.98 245.67 2136.8 242.35"/>
+  </g>
+  <g id="LWPOLYLINE-264" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2136.8 242.34 2140.12 244.16 2141.64 240.83"/>
+  </g>
+  <g id="LWPOLYLINE-265" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2141.64 240.83 2144.96 242.35 2146.78 239.02"/>
+  </g>
+  <g id="LWPOLYLINE-266" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2146.78 239.02 2150.11 240.83 2151.93 237.51"/>
+  </g>
+  <g id="LWPOLYLINE-267" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2151.92 237.5 2155.25 239.02 2156.76 235.69"/>
+  </g>
+  <g id="LWPOLYLINE-268" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.76 235.69 2160.09 237.51 2161.91 234.18"/>
+  </g>
+  <g id="LWPOLYLINE-269" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2165.23" y1="235.69" x2="2165.23" y2="235.69"/>
+  </g>
+  <g id="LWPOLYLINE-270" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2165.23" y1="235.69" x2="2161.91" y2="234.18"/>
+  </g>
+  <g id="LWPOLYLINE-271" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="670.76" y1="1217.69" x2="677.72" y2="1217.69"/>
+  </g>
+  <g id="LWPOLYLINE-272" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="677.72" y1="1235.23" x2="714.93" y2="1235.23"/>
+  </g>
+  <g id="LWPOLYLINE-273" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="501.04 1097.88 508.61 1092.75 499.83 1067.33 654.73 1067.33"/>
+  </g>
+  <g id="LWPOLYLINE-274" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="550.96 1067.33 550.96 1070.36 641.11 1070.36"/>
+  </g>
+  <g id="LWPOLYLINE-275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="700.41 1062.49 700.41 1067.33 915.51 1067.33"/>
+  </g>
+  <g id="LWPOLYLINE-276" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="911.27 1067.33 911.27 1070.96 915.5 1070.96"/>
+  </g>
+  <g id="LWPOLYLINE-277" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="911.27" y1="1106.96" x2="915.5" y2="1106.96"/>
+  </g>
+  <g id="LWPOLYLINE-278" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="729.15" y1="1257.62" x2="881.92" y2="1257.62"/>
+  </g>
+  <g id="LWPOLYLINE-279" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="720.38" y1="1252.48" x2="730.66" y2="1252.48"/>
+  </g>
+  <g id="LWPOLYLINE-280" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="714.93 1067.33 714.93 1128.14 720.38 1128.14"/>
+  </g>
+  <g id="LWPOLYLINE-281" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="714.93 1128.14 714.93 1186.83 720.38 1186.83"/>
+  </g>
+  <g id="LWPOLYLINE-282" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="465.05 961.75 498.32 1062.49 654.73 1062.49"/>
+  </g>
+  <g id="LWPOLYLINE-283" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="490.15" y1="1037.38" x2="572.44" y2="1037.38"/>
+  </g>
+  <g id="LWPOLYLINE-284" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="644.14" y1="1039.5" x2="649.28" y2="1039.5"/>
+  </g>
+  <g id="LWPOLYLINE-285" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="584.24" y1="1057.35" x2="644.14" y2="1057.35"/>
+  </g>
+  <g id="LWPOLYLINE-286" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="700.41" y1="1062.49" x2="910.66" y2="1062.49"/>
+  </g>
+  <g id="LWPOLYLINE-287" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="669.25 982.02 674.09 996.24 764.85 996.24"/>
+  </g>
+  <g id="LWPOLYLINE-288" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="800.85 991.09 800.85 996.24 910.67 996.24"/>
+  </g>
+  <g id="LWPOLYLINE-289" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="910.66 996.24 910.66 1000.17 915.5 1000.17"/>
+  </g>
+  <g id="LWPOLYLINE-290" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="910.66" y1="1036.17" x2="915.5" y2="1036.17"/>
+  </g>
+  <g id="LWPOLYLINE-291" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="674.09 980.2 677.72 991.1 691.94 991.1"/>
+  </g>
+  <g id="LWPOLYLINE-292" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="706.46" y1="991.1" x2="764.85" y2="991.1"/>
+  </g>
+  <g id="LWPOLYLINE-293" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="701.62" y1="877.04" x2="704.64" y2="877.04"/>
+  </g>
+  <g id="LWPOLYLINE-294" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="740.95 873.11 740.95 877.04 801.15 877.04"/>
+  </g>
+  <g id="LWPOLYLINE-295" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="711" y1="904.57" x2="748.21" y2="904.57"/>
+  </g>
+  <g id="LWPOLYLINE-296" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="709.48" y1="900.94" x2="744.28" y2="900.94"/>
+  </g>
+  <g id="LWPOLYLINE-297" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="837.15 873.11 837.15 877.04 911.26 877.04"/>
+  </g>
+  <g id="LWPOLYLINE-298" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="700.41" y1="873.11" x2="704.64" y2="873.11"/>
+  </g>
+  <g id="LWPOLYLINE-299" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="740.95" y1="873.11" x2="801.15" y2="873.11"/>
+  </g>
+  <g id="LWPOLYLINE-300" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="837.15" y1="873.11" x2="911.26" y2="873.11"/>
+  </g>
+  <g id="LWPOLYLINE-301" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="911.27" y1="869.18" x2="915.5" y2="869.18"/>
+  </g>
+  <g id="LWPOLYLINE-302" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="911.27 711.57 911.27 831.67 915.5 831.67"/>
+  </g>
+  <g id="LWPOLYLINE-303" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.85" y1="991.1" x2="895.84" y2="991.1"/>
+  </g>
+  <g id="LWPOLYLINE-304" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="910.36" y1="991.1" x2="915.51" y2="991.1"/>
+  </g>
+  <g id="LWPOLYLINE-305" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="677.72" y1="1239.17" x2="681.35" y2="1239.17"/>
+  </g>
+  <g id="LWPOLYLINE-306" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="711.3" y1="1239.17" x2="714.93" y2="1239.17"/>
+  </g>
+  <g id="LWPOLYLINE-307" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="670.76" y1="1263.37" x2="670.76" y2="1217.69"/>
+  </g>
+  <g id="LWPOLYLINE-308" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="677.72" y1="1253.99" x2="677.72" y2="1217.69"/>
+  </g>
+  <g id="LWPOLYLINE-309" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="714.93" y1="1253.99" x2="714.93" y2="1186.83"/>
+  </g>
+  <g id="LWPOLYLINE-310" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="654.73" y1="1067.33" x2="654.73" y2="1062.49"/>
+  </g>
+  <g id="LWPOLYLINE-311" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="649.28" y1="1062.49" x2="649.28" y2="1039.5"/>
+  </g>
+  <g id="LWPOLYLINE-312" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="644.14" y1="1057.35" x2="644.14" y2="1039.5"/>
+  </g>
+  <g id="LWPOLYLINE-313" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="641.11" y1="1070.36" x2="641.11" y2="1067.33"/>
+  </g>
+  <g id="LWPOLYLINE-314" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="720.38" y1="1253.99" x2="720.38" y2="1186.83"/>
+  </g>
+  <g id="LWPOLYLINE-315" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="730.66" y1="1257.62" x2="730.66" y2="1252.48"/>
+  </g>
+  <g id="LWPOLYLINE-316" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="720.38" y1="1128.14" x2="720.38" y2="1067.33"/>
+  </g>
+  <g id="LWPOLYLINE-317" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="911.27" y1="1253.99" x2="911.27" y2="1106.97"/>
+  </g>
+  <g id="LWPOLYLINE-318" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="1253.99" x2="915.5" y2="1106.97"/>
+  </g>
+  <g id="LWPOLYLINE-319" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1719.31 1237.65 1640.96 1237.65 1640.96 1134.8"/>
+  </g>
+  <g id="LWPOLYLINE-320" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1715.08 1233.42 1645.19 1233.42 1645.19 1138.73"/>
+  </g>
+  <g id="LWPOLYLINE-321" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1648.52" y1="1138.73" x2="1648.52" y2="1134.79"/>
+  </g>
+  <g id="LWPOLYLINE-322" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1715.08 1138.73 1684.52 1138.73 1684.52 1134.79"/>
+  </g>
+  <g id="LWPOLYLINE-323" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1916.56" y1="1257.92" x2="1916.56" y2="1137.22"/>
+  </g>
+  <g id="LWPOLYLINE-324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1926.54" y1="1141.45" x2="1926.54" y2="1137.22"/>
+  </g>
+  <g id="LWPOLYLINE-325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1922.61" y1="1257.92" x2="1922.61" y2="1141.45"/>
+  </g>
+  <g id="LWPOLYLINE-326" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1890.84" y1="1257.92" x2="1890.84" y2="1233.72"/>
+  </g>
+  <g id="LWPOLYLINE-327" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1885.7" y1="1263.07" x2="1885.7" y2="1233.72"/>
+  </g>
+  <g id="LWPOLYLINE-328" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1723.85" y1="1263.07" x2="1723.85" y2="1233.42"/>
+  </g>
+  <g id="LWPOLYLINE-329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1720.22" y1="1253.99" x2="1720.22" y2="1237.65"/>
+  </g>
+  <g id="LWPOLYLINE-330" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1715.08" y1="1233.42" x2="1715.08" y2="1138.73"/>
+  </g>
+  <g id="LWPOLYLINE-331" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="1070.96" x2="915.5" y2="1036.17"/>
+  </g>
+  <g id="LWPOLYLINE-332" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="1000.17" x2="915.5" y2="869.18"/>
+  </g>
+  <g id="LWPOLYLINE-333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="831.67" x2="915.5" y2="657.11"/>
+  </g>
+  <g id="LWPOLYLINE-334" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1114.57" y1="755.13" x2="1114.57" y2="591.46"/>
+  </g>
+  <g id="LWPOLYLINE-335" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1114.57 755.13 1089.15 755.13 1089.15 751.19"/>
+  </g>
+  <g id="LWPOLYLINE-336" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1053.15" y1="755.13" x2="1053.15" y2="751.19"/>
+  </g>
+  <g id="LWPOLYLINE-337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1110.63" y1="751.19" x2="1110.63" y2="592.97"/>
+  </g>
+  <g id="LWPOLYLINE-338" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="911.27" y1="991.1" x2="911.27" y2="989.28"/>
+  </g>
+  <g id="LWPOLYLINE-339" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="911.27" y1="982.02" x2="911.27" y2="869.18"/>
+  </g>
+  <g id="LWPOLYLINE-340" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="911.27" y1="704.3" x2="911.27" y2="658.32"/>
+  </g>
+  <g id="LWPOLYLINE-341" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="801.15" y1="877.04" x2="801.15" y2="873.11"/>
+  </g>
+  <g id="LWPOLYLINE-342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="704.64" y1="877.04" x2="704.64" y2="873.11"/>
+  </g>
+  <g id="LWPOLYLINE-343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="748.21" y1="904.57" x2="748.21" y2="877.04"/>
+  </g>
+  <g id="LWPOLYLINE-344" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="744.28" y1="900.94" x2="744.28" y2="877.05"/>
+  </g>
+  <g id="LWPOLYLINE-345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="910.66" y1="1062.49" x2="910.66" y2="1036.17"/>
+  </g>
+  <g id="LWPOLYLINE-346" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="1234.93" x2="2044.53" y2="1097.59"/>
+  </g>
+  <g id="LWPOLYLINE-347" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.89 1053.72 2048.46 1053.72 2048.46 1028.61"/>
+  </g>
+  <g id="LWPOLYLINE-348" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2048.46 845.58 2044.53 845.58 2044.53 834.39"/>
+  </g>
+  <g id="LWPOLYLINE-349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2048.46" y1="992.31" x2="2048.46" y2="883.1"/>
+  </g>
+  <g id="LWPOLYLINE-350" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2048.46" y1="845.58" x2="2048.46" y2="838.93"/>
+  </g>
+  <g id="LWPOLYLINE-351" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2022.14" y1="1261.55" x2="2022.14" y2="1234.93"/>
+  </g>
+  <g id="LWPOLYLINE-352" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2028.19" y1="1261.55" x2="2028.19" y2="1240.68"/>
+  </g>
+  <g id="LWPOLYLINE-353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2050.58" y1="1240.68" x2="2050.58" y2="1097.59"/>
+  </g>
+  <g id="LWPOLYLINE-354" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2050.58" y1="1061.58" x2="2050.58" y2="1057.95"/>
+  </g>
+  <g id="LWPOLYLINE-355" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.47 679.5 2044.53 675.87 2044.53 627.46"/>
+  </g>
+  <g id="LWPOLYLINE-356" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2049.37 591.46 2044.53 591.46 2044.53 484.06"/>
+  </g>
+  <g id="LWPOLYLINE-357" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2111.08 677.38 2049.37 670.42 2049.37 627.46"/>
+  </g>
+  <g id="LWPOLYLINE-358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2049.37" y1="591.46" x2="2049.37" y2="483.46"/>
+  </g>
+  <g id="LWPOLYLINE-359" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1925.33 584.81 1918.37 584.81 1918.37 505.55"/>
+  </g>
+  <g id="LWPOLYLINE-360" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1925.33" y1="584.81" x2="1925.33" y2="580.87"/>
+  </g>
+  <g id="LWPOLYLINE-361" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2044.53 584.81 1961.33 584.81 1961.33 580.87"/>
+  </g>
+  <g id="LWPOLYLINE-362" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1925.33 580.87 1922.31 580.87 1922.31 504.33"/>
+  </g>
+  <g id="LWPOLYLINE-363" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1822.17" y1="584.81" x2="1822.17" y2="536.7"/>
+  </g>
+  <g id="LWPOLYLINE-364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1818.24" y1="580.87" x2="1818.24" y2="534.28"/>
+  </g>
+  <g id="LWPOLYLINE-365" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="681.35" y="1235.23" width="29.95" height="6.05"/>
+  </g>
+  <g id="LWPOLYLINE-366" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="509.52 1263.37 509.52 1217.69 502.56 1217.69 502.56 1253.99"/>
+  </g>
+  <g id="LWPOLYLINE-367" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.66" y1="1232.51" x2="406.66" y2="1210.42"/>
+  </g>
+  <g id="LWPOLYLINE-368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="401.51" y1="1261.86" x2="401.51" y2="1210.42"/>
+  </g>
+  <g id="LWPOLYLINE-369" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="401.51" y1="1164.14" x2="401.51" y2="1155.37"/>
+  </g>
+  <g id="LWPOLYLINE-370" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="398.19" y="1207.4" width="9.68" height="3.02"/>
+  </g>
+  <g id="LWPOLYLINE-371" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="398.19 1207.4 398.19 1167.17 407.86 1167.17 407.86 1164.14 398.19 1164.14 398.19 1167.17"/>
+  </g>
+  <g id="LWPOLYLINE-372" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="383.97 1167.17 319.23 1167.17 319.23 1237.05 383.97 1237.05 383.97 1207.4 395.46 1207.4 395.46 1239.77 316.2 1239.77 316.2 1164.14 395.46 1164.14 395.46 1167.17 383.97 1167.17"/>
+  </g>
+  <g id="LWPOLYLINE-373" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="332.54 1196.51 323.76 1196.51 323.76 1182.59 332.54 1182.59"/>
+  </g>
+  <g id="LWPOLYLINE-374" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="323.76" y1="1189.25" x2="329.21" y2="1189.25"/>
+  </g>
+  <g id="LWPOLYLINE-375" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="336.47 1182.59 336.47 1196.51 344.34 1196.51"/>
+  </g>
+  <g id="LWPOLYLINE-376" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="356.44 1196.51 347.66 1196.51 347.66 1182.59 356.44 1182.59"/>
+  </g>
+  <g id="LWPOLYLINE-377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="347.66" y1="1189.25" x2="353.11" y2="1189.25"/>
+  </g>
+  <g id="LWPOLYLINE-378" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="360.37 1182.59 365.82 1196.51 371.26 1182.59"/>
+  </g>
+  <g id="LWPOLYLINE-379" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="374.59 1195.3 373.68 1195.91 374.59 1196.51 375.19 1195.91"/>
+  </g>
+  <g id="LWPOLYLINE-380" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="380.64 1185.02 381.85 1184.41 383.97 1182.59 383.97 1196.51"/>
+  </g>
+  <g id="LWPOLYLINE-381" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="885.86 1096.37 911.27 1070.96 912.78 1072.17 887.06 1097.58"/>
+  </g>
+  <g id="LWPOLYLINE-382" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="885.25 1095.77 888.58 1099.1 892.82 1101.82 897.05 1103.94 901.59 1105.75 906.42 1106.66 911.27 1106.97"/>
+  </g>
+  <g id="LWPOLYLINE-383" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="750.32 1121.18 720.38 1121.18 720.38 1128.14 720.38 1186.83 720.38 1193.49 750.32 1193.49 750.32 1121.18"/>
+  </g>
+  <g id="LWPOLYLINE-384" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1118.46 711.9 1118.46 712.21 1124.21 712.21 1118.46"/>
+  </g>
+  <g id="LWPOLYLINE-385" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1118.46 712.21 1124.21 711.9 1124.21 711.9 1118.46"/>
+  </g>
+  <g id="LWPOLYLINE-386" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1127.23 711.9 1127.23 712.21 1133.28 712.21 1127.23"/>
+  </g>
+  <g id="LWPOLYLINE-387" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1127.23 712.21 1133.28 711.9 1133.28 711.9 1127.23"/>
+  </g>
+  <g id="LWPOLYLINE-388" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1136.31 711.9 1136.31 712.21 1142.36 712.21 1136.31"/>
+  </g>
+  <g id="LWPOLYLINE-389" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1136.31 712.21 1142.36 711.9 1142.36 711.9 1136.31"/>
+  </g>
+  <g id="LWPOLYLINE-390" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1145.38 711.9 1145.38 712.21 1151.13 712.21 1145.38"/>
+  </g>
+  <g id="LWPOLYLINE-391" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1145.38 712.21 1151.13 711.9 1151.13 711.9 1145.38"/>
+  </g>
+  <g id="LWPOLYLINE-392" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1154.16 711.9 1154.16 712.21 1160.2 712.21 1154.16"/>
+  </g>
+  <g id="LWPOLYLINE-393" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1154.16 712.21 1160.2 711.9 1160.2 711.9 1154.16"/>
+  </g>
+  <g id="LWPOLYLINE-394" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1163.23 711.9 1163.23 712.21 1169.28 712.21 1163.23"/>
+  </g>
+  <g id="LWPOLYLINE-395" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1163.23 712.21 1169.28 711.9 1169.28 711.9 1163.23"/>
+  </g>
+  <g id="LWPOLYLINE-396" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1172.31 711.9 1172.31 712.21 1178.36 712.21 1172.31"/>
+  </g>
+  <g id="LWPOLYLINE-397" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1172.31 712.21 1178.36 711.9 1178.36 711.9 1172.31"/>
+  </g>
+  <g id="LWPOLYLINE-398" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1181.38 711.9 1181.38 712.21 1187.43 712.21 1181.38"/>
+  </g>
+  <g id="LWPOLYLINE-399" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1181.38 712.21 1187.43 711.9 1187.43 711.9 1181.38"/>
+  </g>
+  <g id="LWPOLYLINE-400" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.21 1190.46 711.9 1190.46 712.21 1195.91 712.21 1190.46"/>
+  </g>
+  <g id="LWPOLYLINE-401" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="711.9 1190.46 712.21 1195.91 711.9 1195.91 711.9 1190.46"/>
+  </g>
+  <g id="LWPOLYLINE-402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="712.21" y1="1195.91" x2="711.9" y2="1195.91"/>
+  </g>
+  <g id="LWPOLYLINE-403" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.51 1118.46 714.93 1118.46 711.61 1118.46 711.61 1120.88 711.9 1120.88 711.9 1118.46 712.21 1118.46 712.21 1120.88 712.51 1120.88 712.51 1118.46"/>
+  </g>
+  <g id="LWPOLYLINE-404" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="712.51 1195.91 714.93 1195.91 714.93 1196.21 711.61 1196.21 711.61 1193.79 711.9 1193.79 711.9 1195.91 712.21 1195.91 712.21 1193.79 712.51 1193.79 712.51 1195.91"/>
+  </g>
+  <g id="LWPOLYLINE-405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="718.26" y1="1157.49" x2="718.56" y2="1157.49"/>
+  </g>
+  <g id="LWPOLYLINE-406" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="717.65 1149.92 717.35 1149.92 717.35 1180.47"/>
+  </g>
+  <g id="LWPOLYLINE-407" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="717.65" y1="1149.92" x2="717.65" y2="1180.47"/>
+  </g>
+  <g id="LWPOLYLINE-408" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="718.26" y1="1128.14" x2="718.26" y2="1157.49"/>
+  </g>
+  <g id="LWPOLYLINE-409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="718.56" y1="1128.14" x2="718.56" y2="1157.49"/>
+  </g>
+  <g id="LWPOLYLINE-410" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="717.35" y1="1180.48" x2="717.65" y2="1180.48"/>
+  </g>
+  <g id="LWPOLYLINE-411" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="467.77 1113.02 470.49 1117.25 456.57 1126.32"/>
+  </g>
+  <g id="LWPOLYLINE-412" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="427.53 1077.62 453.85 1118.46 452.03 1119.66"/>
+  </g>
+  <g id="LWPOLYLINE-413" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="427.53" y1="1077.62" x2="384.27" y2="1105.45"/>
+  </g>
+  <g id="LWPOLYLINE-414" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="421.79 1139.03 426.02 1145.69 406.65 1158.39"/>
+  </g>
+  <g id="LWPOLYLINE-415" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="421.78" y1="1139.03" x2="405.75" y2="1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-416" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="460.51 963.26 502.56 1090.93 498.33 1093.65"/>
+  </g>
+  <g id="LWPOLYLINE-417" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="467.77" y1="1113.01" x2="462.32" y2="1116.64"/>
+  </g>
+  <g id="LWPOLYLINE-418" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="501.04" y1="1097.89" x2="498.32" y2="1093.66"/>
+  </g>
+  <g id="LWPOLYLINE-419" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="456.57" y1="1126.32" x2="452.03" y2="1119.67"/>
+  </g>
+  <g id="LWPOLYLINE-420" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="453.85 927.56 449.01 929.08 413.01 819.87"/>
+  </g>
+  <g id="LWPOLYLINE-421" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="414.52 824.1 409.98 825.61 408.78 821.08"/>
+  </g>
+  <g id="LWPOLYLINE-422" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="453.85" y1="927.57" x2="417.85" y2="818.05"/>
+  </g>
+  <g id="LWPOLYLINE-423" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="439.02 883.1 444.77 881.28 444.47 880.07"/>
+  </g>
+  <g id="LWPOLYLINE-424" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M444.77,881.28l32.2,15.99c4.28-8.54,5-18.42,1.99-27.49l-.3-.91,66.86-22.09"/>
+  </g>
+  <g id="LWPOLYLINE-425" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="498.62" y1="901.85" x2="496.81" y2="895.8"/>
+  </g>
+  <g id="LWPOLYLINE-426" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="489.25" y1="873.11" x2="487.13" y2="867.06"/>
+  </g>
+  <g id="LWPOLYLINE-427" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="499.23" y1="900.64" x2="497.71" y2="895.5"/>
+  </g>
+  <g id="LWPOLYLINE-428" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="489.25 873.11 490.15 872.81 488.03 866.76"/>
+  </g>
+  <g id="LWPOLYLINE-429" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="493.18 1132.98 501.04 1097.89 499.23 1097.28 491.36 1132.68"/>
+  </g>
+  <g id="LWPOLYLINE-430" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="494.39 1133.28 489.55 1132.08 485.01 1130.26 480.77 1127.84 476.84 1124.81 473.51 1121.18 470.49 1117.25"/>
+  </g>
+  <g id="LWPOLYLINE-431" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="448.71 1161.72 456.57 1126.33 454.76 1126.02 446.89 1161.11"/>
+  </g>
+  <g id="LWPOLYLINE-432" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="449.92 1161.72 445.08 1160.51 440.54 1158.7 436.3 1156.27 432.37 1153.25 429.04 1149.62 426.02 1145.69"/>
+  </g>
+  <g id="LWPOLYLINE-433" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="269.92" y1="1155.37" x2="401.51" y2="1155.37"/>
+  </g>
+  <g id="LWPOLYLINE-434" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="384.27" y1="1105.45" x2="318.32" y2="1105.45"/>
+  </g>
+  <g id="LWPOLYLINE-435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="405.75" y1="1149.32" x2="270.52" y2="1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-436" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="465.04 1120.88 430.25 1066.42 382.15 1097.28 327.7 1097.28"/>
+  </g>
+  <g id="LWPOLYLINE-437" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="276.27 1100.61 318.32 1105.45 318.32 1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-438" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="329.51" y1="1105.45" x2="329.51" y2="1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="340.4" y1="1105.45" x2="340.4" y2="1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="351.6" y1="1105.45" x2="351.6" y2="1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-441" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="362.49" y1="1105.45" x2="362.49" y2="1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="319.83" y1="1094.26" x2="277.48" y2="1089.72"/>
+  </g>
+  <g id="LWPOLYLINE-443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="321.04" y1="1083.37" x2="278.69" y2="1078.52"/>
+  </g>
+  <g id="LWPOLYLINE-444" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="322.25" y1="1072.47" x2="279.9" y2="1067.63"/>
+  </g>
+  <g id="LWPOLYLINE-445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="323.46" y1="1061.58" x2="281.11" y2="1056.74"/>
+  </g>
+  <g id="LWPOLYLINE-446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="324.67" y1="1050.69" x2="282.32" y2="1045.85"/>
+  </g>
+  <g id="LWPOLYLINE-447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="325.88" y1="1039.5" x2="283.84" y2="1034.96"/>
+  </g>
+  <g id="LWPOLYLINE-448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="336.47" y1="1021.05" x2="327.7" y2="1097.28"/>
+  </g>
+  <g id="LWPOLYLINE-449" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="318.32 1105.45 328.3 1020.14 285.95 1015.3"/>
+  </g>
+  <g id="LWPOLYLINE-450" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="320.74 1032.24 321.65 1025.28 285.34 1021.05"/>
+  </g>
+  <g id="LWPOLYLINE-451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="328.3" y1="1020.14" x2="336.47" y2="1021.04"/>
+  </g>
+  <g id="LWPOLYLINE-452" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="362.49 1127.53 295.63 1127.53 305.01 1037.38"/>
+  </g>
+  <g id="LWPOLYLINE-453" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="364.61 1127.53 364 1126.02 362.79 1125.41 361.28 1126.02 360.67 1127.53 361.28 1128.74 362.79 1129.35 364 1128.74 364.61 1127.53"/>
+  </g>
+  <g id="LWPOLYLINE-454" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="369.45 1123.3 369.45 1132.07 370.05 1133.59 371.26 1134.79 372.77 1135.4 373.98 1135.4 375.8 1134.79 377.01 1133.59 377.61 1132.07 377.61 1123.3"/>
+  </g>
+  <g id="LWPOLYLINE-455" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="382.15 1135.4 382.15 1123.3 387.3 1123.3 388.81 1123.91 389.41 1124.51 390.02 1125.72 390.02 1127.53 389.41 1128.44 388.81 1129.05 387.3 1129.65 382.15 1129.65"/>
+  </g>
+  <g id="LWPOLYLINE-456" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="311.36 1044.64 305.01 1037.38 297.75 1043.44"/>
+  </g>
+  <g id="LWPOLYLINE-457" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="325.28 1039.5 310.76 1032.54 306.83 1035.27 305.91 1025.58 301.98 1028.31 288.37 1021.35"/>
+  </g>
+  <g id="LWPOLYLINE-458" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="417.24 959.94 299.56 946.32 296.23 974.16 414.22 987.77 417.24 959.94"/>
+  </g>
+  <g id="LWPOLYLINE-459" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="390.32 853.14 362.48 862.22 378.52 910.33 406.05 901.25 390.32 853.14"/>
+  </g>
+  <g id="CIRCLE-14" data-name="CIRCLE">
+    <circle class="cls-3" cx="339.95" cy="895.04" r="4.08"/>
+  </g>
+  <g id="LWPOLYLINE-460" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="358.86 883.09 366.43 886.72 362.49 894.59 354.92 890.66 358.86 883.09"/>
+  </g>
+  <g id="LWPOLYLINE-461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="460.51" y1="963.26" x2="465.04" y2="961.75"/>
+  </g>
+  <g id="LWPOLYLINE-462" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="341.31" y1="843.46" x2="485.31" y2="795.97"/>
+  </g>
+  <g id="LWPOLYLINE-463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="534.02" y1="779.93" x2="678.02" y2="732.14"/>
+  </g>
+  <g id="LWPOLYLINE-464" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="481.38 929.68 465.04 961.75 463.53 961.15 479.87 928.78"/>
+  </g>
+  <g id="LWPOLYLINE-465" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="482.29 929.99 477.75 928.17 473.21 926.66 468.37 925.75 463.53 925.75 458.69 926.36 453.85 927.56"/>
+  </g>
+  <g id="LWPOLYLINE-466" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="335.56 1009.55 337.68 1010.16 338.28 1010.76 338.89 1012.27 338.89 1014.09 338.28 1015.6 337.68 1016.2 335.56 1016.81 329.52 1016.81 329.52 1002.9 335.56 1002.9 337.68 1003.5 338.28 1004.1 338.89 1005.62 338.89 1006.83 338.28 1008.04 337.68 1008.94 335.56 1009.55 329.52 1009.55"/>
+  </g>
+  <g id="LWPOLYLINE-467" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="347.66 1002.89 346.46 1003.5 344.94 1004.71 344.34 1006.22 343.73 1008.04 343.73 1011.37 344.34 1013.49 344.94 1014.69 346.46 1016.21 347.66 1016.81 350.38 1016.81 351.6 1016.21 353.11 1014.69 353.71 1013.49 354.32 1011.37 354.32 1008.04 353.71 1006.22 353.11 1004.71 351.6 1003.5 350.38 1002.89 347.66 1002.89"/>
+  </g>
+  <g id="LWPOLYLINE-468" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="358.25" y1="1016.81" x2="358.25" y2="1002.89"/>
+  </g>
+  <g id="LWPOLYLINE-469" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="363.7 1002.89 363.7 1016.81 371.56 1016.81"/>
+  </g>
+  <g id="LWPOLYLINE-470" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="383.66 1016.81 374.89 1016.81 374.89 1002.89 383.66 1002.89"/>
+  </g>
+  <g id="LWPOLYLINE-471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="374.89" y1="1009.55" x2="380.34" y2="1009.55"/>
+  </g>
+  <g id="LWPOLYLINE-472" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="387.6 1016.81 387.6 1002.89 393.64 1002.89 395.76 1003.5 396.37 1004.11 396.97 1005.62 396.97 1006.83 396.37 1008.04 395.76 1008.94 393.64 1009.55 387.6 1009.55"/>
+  </g>
+  <g id="LWPOLYLINE-473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="392.44" y1="1009.55" x2="396.98" y2="1016.81"/>
+  </g>
+  <g id="LWPOLYLINE-474" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="414.52 1016.81 414.52 1002.89 420.57 1002.89 422.39 1003.5 422.99 1004.11 423.9 1005.62 423.9 1006.83 422.99 1008.04 422.39 1008.94 420.57 1009.55 414.52 1009.55"/>
+  </g>
+  <g id="LWPOLYLINE-475" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="419.06" y1="1009.55" x2="423.9" y2="1016.81"/>
+  </g>
+  <g id="LWPOLYLINE-476" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="432.37 1002.89 431.16 1003.5 429.95 1004.71 429.04 1006.22 428.44 1008.04 428.44 1011.37 429.04 1013.49 429.95 1014.69 431.16 1016.21 432.37 1016.81 435.09 1016.81 436.6 1016.21 437.82 1014.69 438.42 1013.49 439.03 1011.37 439.03 1008.04 438.42 1006.22 437.82 1004.71 436.6 1003.5 435.09 1002.89 432.37 1002.89"/>
+  </g>
+  <g id="LWPOLYLINE-477" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="447.19 1002.89 445.68 1003.5 444.47 1004.71 443.87 1006.22 443.26 1008.04 443.26 1011.37 443.87 1013.49 444.47 1014.69 445.68 1016.21 447.19 1016.81 449.92 1016.81 451.13 1016.21 452.64 1014.69 453.24 1013.49 453.85 1011.37 453.85 1008.04 453.24 1006.22 452.64 1004.71 451.13 1003.5 449.92 1002.89 447.19 1002.89"/>
+  </g>
+  <g id="LWPOLYLINE-478" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="457.78 1016.81 457.78 1002.89 463.23 1016.81 468.68 1002.89 468.68 1016.81"/>
+  </g>
+  <g id="LWPOLYLINE-479" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="320.44" y1="1034.96" x2="319.83" y2="1041.01"/>
+  </g>
+  <g id="LWPOLYLINE-480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="319.53" y1="1044.04" x2="318.62" y2="1050.09"/>
+  </g>
+  <g id="LWPOLYLINE-481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="318.32" y1="1053.11" x2="317.71" y2="1058.86"/>
+  </g>
+  <g id="LWPOLYLINE-482" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="317.41" y1="1061.89" x2="316.81" y2="1067.93"/>
+  </g>
+  <g id="LWPOLYLINE-483" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="316.2" y1="1070.96" x2="315.6" y2="1077.01"/>
+  </g>
+  <g id="LWPOLYLINE-484" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="315.29" y1="1080.04" x2="314.69" y2="1085.79"/>
+  </g>
+  <g id="LWPOLYLINE-485" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="314.39" y1="1088.81" x2="313.48" y2="1094.86"/>
+  </g>
+  <g id="LWPOLYLINE-486" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="313.18" y1="1097.89" x2="312.57" y2="1104.54"/>
+  </g>
+  <g id="LWPOLYLINE-487" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="586.05" y1="1062.49" x2="570.03" y2="1013.79"/>
+  </g>
+  <g id="LWPOLYLINE-488" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="658.05" y1="947.53" x2="656.85" y2="943.6"/>
+  </g>
+  <g id="LWPOLYLINE-489" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="658.05 947.53 662.9 946.02 659.87 937.25"/>
+  </g>
+  <g id="LWPOLYLINE-490" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="553.99 981.12 558.52 979.6 557.62 976.27"/>
+  </g>
+  <g id="LWPOLYLINE-491" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="580.61" y1="1062.49" x2="578.18" y2="1054.32"/>
+  </g>
+  <g id="LWPOLYLINE-492" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="573.05 1062.49 573.05 1039.2 565.18 1015.6"/>
+  </g>
+  <g id="LWPOLYLINE-493" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="553.99" y1="981.11" x2="551.26" y2="973.25"/>
+  </g>
+  <g id="LWPOLYLINE-494" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="583.63" y1="962.36" x2="526.45" y2="789.31"/>
+  </g>
+  <g id="LWPOLYLINE-495" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="587.26" y1="961.45" x2="530.08" y2="788.1"/>
+  </g>
+  <g id="LWPOLYLINE-496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="545.82" y1="924.24" x2="545.52" y2="923.33"/>
+  </g>
+  <g id="LWPOLYLINE-497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="570.02" y1="1013.79" x2="565.18" y2="1015.6"/>
+  </g>
+  <g id="LWPOLYLINE-498" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="656.84" y1="943.6" x2="557.61" y2="976.27"/>
+  </g>
+  <g id="LWPOLYLINE-499" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="659.87" y1="937.25" x2="551.26" y2="973.25"/>
+  </g>
+  <g id="LWPOLYLINE-500" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="635.07 853.75 636.27 857.68 579.09 876.44"/>
+  </g>
+  <g id="LWPOLYLINE-501" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="635.06" y1="853.75" x2="577.88" y2="872.5"/>
+  </g>
+  <g id="LWPOLYLINE-502" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="671.97" y1="802.62" x2="664.11" y2="805.05"/>
+  </g>
+  <g id="LWPOLYLINE-503" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="629.31 815.64 629.62 816.54 566.39 837.41"/>
+  </g>
+  <g id="LWPOLYLINE-504" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="621.45 819.26 622.66 822.89 621.76 823.19"/>
+  </g>
+  <g id="LWPOLYLINE-505" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="630.22" y1="845.88" x2="629.32" y2="846.19"/>
+  </g>
+  <g id="LWPOLYLINE-506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="671.67" y1="801.72" x2="663.8" y2="804.14"/>
+  </g>
+  <g id="LWPOLYLINE-507" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="629.32" y1="815.63" x2="565.78" y2="836.51"/>
+  </g>
+  <g id="LWPOLYLINE-508" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="557.31" y1="882.49" x2="498.63" y2="901.86"/>
+  </g>
+  <g id="LWPOLYLINE-509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="557.01" y1="881.58" x2="499.23" y2="900.64"/>
+  </g>
+  <g id="LWPOLYLINE-510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="568.51" y1="916.67" x2="545.82" y2="924.24"/>
+  </g>
+  <g id="LWPOLYLINE-511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="568.2" y1="915.77" x2="545.51" y2="923.33"/>
+  </g>
+  <g id="LWPOLYLINE-512" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="653.52" y1="747.26" x2="419.97" y2="824.4"/>
+  </g>
+  <g id="LWPOLYLINE-513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="444.47" y1="880.07" x2="438.72" y2="882.19"/>
+  </g>
+  <g id="LWPOLYLINE-514" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="545.82" y1="847.7" x2="478.96" y2="869.79"/>
+  </g>
+  <g id="LWPOLYLINE-515" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="674.09" y1="980.2" x2="669.25" y2="982.02"/>
+  </g>
+  <g id="LWPOLYLINE-516" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="715.23 933.61 715.23 970.22 675.3 983.53"/>
+  </g>
+  <g id="LWPOLYLINE-517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="715.23" y1="974.46" x2="704.04" y2="978.09"/>
+  </g>
+  <g id="LWPOLYLINE-518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="690.73" y1="982.62" x2="676.51" y2="987.17"/>
+  </g>
+  <g id="LWPOLYLINE-519" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="590.89 995.94 558.52 979.6 557.92 981.42 589.99 997.45"/>
+  </g>
+  <g id="LWPOLYLINE-520" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="591.5 995.03 589.08 999.26 586.05 1003.2 582.73 1006.52 578.8 1009.55 574.56 1011.97 570.02 1013.78"/>
+  </g>
+  <g id="LWPOLYLINE-521" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="641.72 979.9 658.06 947.53 659.57 948.44 643.54 980.51"/>
+  </g>
+  <g id="LWPOLYLINE-522" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="640.81 979.3 645.35 981.42 650.19 982.93 655.03 983.53 659.87 983.84 664.71 983.23 669.25 982.02"/>
+  </g>
+  <g id="LWPOLYLINE-523" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="578.19" y1="1054.32" x2="578.19" y2="1062.49"/>
+  </g>
+  <g id="LWPOLYLINE-524" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M490.03,872.51c6.05-1.94,12.63-1.4,18.28,1.51l-10.59,21.48-.9.3"/>
+  </g>
+  <g id="LWPOLYLINE-525" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M620.55,819.56l1.21,3.63-10.89,21.48c5.72,2.81,12.31,3.24,18.34,1.19"/>
+  </g>
+  <g id="LWPOLYLINE-526" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="539.77 876.74 553.69 872.2 552.47 868.27 551.57 865.55 550.66 862.52 549.45 858.9 535.23 863.43"/>
+  </g>
+  <g id="LWPOLYLINE-527" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="530.09" y1="876.44" x2="530.09" y2="876.44"/>
+  </g>
+  <g id="ARC">
+    <path class="cls-3" d="M530.05,876.46c.38.2.77.37,1.18.51"/>
+  </g>
+  <g id="LWPOLYLINE-528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="532.21" y1="874.32" x2="532.21" y2="874.32"/>
+  </g>
+  <g id="ARC-2" data-name="ARC">
+    <path class="cls-3" d="M531.46,877.16c1.03.35,2.11.51,3.19.48"/>
+  </g>
+  <g id="ARC-3" data-name="ARC">
+    <path class="cls-3" d="M530.96,865.08c-1.04.68-1.97,1.52-2.75,2.48"/>
+  </g>
+  <g id="ARC-4" data-name="ARC">
+    <path class="cls-3" d="M534.96,863.37c-1.39.46-2.71,1.09-3.93,1.89"/>
+  </g>
+  <g id="SPLINE">
+    <path class="cls-3" d="M527.73,869.57c.09.13.23.22.39.22"/>
+  </g>
+  <g id="ARC-5" data-name="ARC">
+    <path class="cls-3" d="M527.72,869.12c-.08.14-.07.31.01.44"/>
+  </g>
+  <g id="LWPOLYLINE-529" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="528.27" y1="869.78" x2="530.69" y2="869.78"/>
+  </g>
+  <g id="SPLINE-2" data-name="SPLINE">
+    <path class="cls-3" d="M530.54,869.78c.15,0,.27-.07.37-.19"/>
+  </g>
+  <g id="LWPOLYLINE-530" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M532.21,874.62l-2.12,1.21c-.25.13-.34.44-.21.69.04.07.09.13.15.17-.6-.23-1.17-.53-1.69-.89"/>
+  </g>
+  <g id="LWPOLYLINE-531" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M538.1,877.02c1.21-.41,2.36-.99,3.4-1.73.91-.62,1.71-1.4,2.36-2.3.42-.51.78-1.08,1.04-1.69l1.51-.3-2.42-6.65-1.52.3c-.54-.35-1.13-.63-1.74-.84-1.01-.31-2.07-.43-3.13-.37"/>
+  </g>
+  <g id="ARC-6" data-name="ARC">
+    <path class="cls-3" d="M537.56,863.13c-1.86.04-3.7.49-5.37,1.32"/>
+  </g>
+  <g id="ARC-7" data-name="ARC">
+    <path class="cls-3" d="M529.28,874.62c.45.36.94.67,1.46.9"/>
+  </g>
+  <g id="ARC-8" data-name="ARC">
+    <path class="cls-3" d="M528.77,869.76c-.25.48-.45.98-.59,1.5"/>
+  </g>
+  <g id="SPLINE-3" data-name="SPLINE">
+    <path class="cls-3" d="M575.04,941.73c.55-.18.86-.78.67-1.33"/>
+  </g>
+  <g id="ARC-9" data-name="ARC">
+    <path class="cls-3" d="M575.71,940.39c-.18-.55-.78-.85-1.33-.67s-.85.78-.67,1.33.78.85,1.33.67c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="574.86" y1="936.04" x2="571.84" y2="936.94"/>
+  </g>
+  <g id="LWPOLYLINE-533" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="566.69 949.34 567.3 949.34 568.51 949.34 569.42 949.34 570.32 949.04 571.24 949.04 572.14 948.74 573.65 948.44 575.47 948.14 578.49 946.93 576.37 940.57 574.26 933.92 571.24 934.83"/>
+  </g>
+  <g id="LWPOLYLINE-534" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="577.89 945.11 574.86 946.02 573.35 941.48"/>
+  </g>
+  <g id="LWPOLYLINE-535" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="574.26 943.9 574.26 944.2 574.26 944.51 574.26 944.81 574.26 945.11 573.95 945.11 573.95 945.42 573.65 945.42 573.35 945.42 573.35 945.72 573.05 945.72 572.74 946.02 572.44 946.02 572.13 946.02 572.13 946.32 571.83 946.32 571.53 946.32 571.23 946.62 570.93 946.62 570.63 946.93 570.32 946.93 570.02 946.93 569.72 947.23 569.41 947.23 569.11 947.53 568.81 947.53 568.51 947.53 568.21 947.83 567.9 947.83 567.6 947.83 567.3 947.83 567 947.83 566.69 947.83 566.39 947.83 566.09 947.83 566.09 947.53 565.78 947.53 565.78 947.23 565.48 947.23 565.48 946.93 565.18 946.93 565.18 946.62 564.88 946.32 564.88 946.02 564.58 945.72 564.58 945.11 564.27 944.51"/>
+  </g>
+  <g id="LWPOLYLINE-536" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="574.86 946.02 574.25 946.32 573.65 946.63 573.35 946.92 572.74 946.92 572.14 947.23 571.84 947.53 571.23 947.53 570.93 947.84 570.63 948.14 570.02 948.14 569.72 948.44 569.41 948.44 569.11 948.74 568.81 948.74 568.51 949.04 568.21 949.04 567.9 949.04 567.6 949.35 567.29 949.35 566.99 949.35 566.69 949.35 566.39 949.35 566.09 949.35 565.78 949.35 565.48 949.35 565.18 949.04 564.88 948.74 564.58 948.14 563.97 947.53 563.67 946.32 563.06 944.81 562.76 943.3 562.46 942.09 562.16 941.18 562.16 940.57 562.46 939.97 562.46 939.67 562.76 939.37 563.06 939.06 563.36 938.76 563.67 938.76 563.97 938.76 564.27 938.45 564.58 938.45 564.88 938.45 565.18 938.15 565.48 938.15 566.09 938.15 566.39 938.15 566.69 937.85 567.29 937.85 567.6 937.85 568.21 937.55 568.51 937.55 569.11 937.55 569.41 937.25 570.02 937.25 570.63 936.94 571.23 936.94 571.84 936.94"/>
+  </g>
+  <g id="LWPOLYLINE-537" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="571.23 934.83 569.41 935.73 568.21 936.34 567 936.64 566.09 937.25 565.48 937.55 564.58 937.85 563.97 938.46 563.37 939.06"/>
+  </g>
+  <g id="LWPOLYLINE-538" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="572.44 939.06 572.44 938.76 572.14 938.46 572.14 938.16 571.83 938.16 571.54 937.86 571.54 938.16 571.23 938.16 570.93 938.16 570.62 938.16 570.32 938.16 570.02 938.16 569.72 938.46 569.42 938.46 569.11 938.46 568.81 938.46 568.51 938.46 568.21 938.76 567.9 938.76 567.6 938.76 567.3 938.76 566.99 939.06 566.69 939.06 566.39 939.06 566.09 939.06 566.09 939.37 565.79 939.37 565.48 939.37 565.18 939.67 564.87 939.67 564.57 939.67 564.57 939.97 564.27 939.97 564.27 940.27 563.97 940.27 563.97 940.58 563.67 940.58 563.67 940.88 563.67 941.18 563.67 941.49 563.67 941.78 563.67 942.09 563.67 942.39 563.67 942.69 563.97 943.29 563.97 943.9 564.27 944.51"/>
+  </g>
+  <g id="LWPOLYLINE-539" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="571.83" y1="936.94" x2="573.35" y2="941.49"/>
+  </g>
+  <g id="SPLINE-4" data-name="SPLINE">
+    <path class="cls-3" d="M561.13,899.98c.55-.18.86-.78.67-1.33"/>
+  </g>
+  <g id="ARC-10" data-name="ARC">
+    <path class="cls-3" d="M561.8,898.65c-.18-.55-.78-.85-1.33-.67s-.85.78-.67,1.33.78.85,1.33.67c0,0,0,0,.01,0"/>
+  </g>
+  <g id="LWPOLYLINE-540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="560.94" y1="893.99" x2="557.92" y2="895.19"/>
+  </g>
+  <g id="LWPOLYLINE-541" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="553.08 907.6 553.68 907.6 554.59 907.6 555.5 907.6 556.4 907.29 557.31 907.29 558.52 906.99 560.03 906.69 561.85 906.09 564.57 905.18 562.46 898.52 560.34 892.17 557.31 893.08"/>
+  </g>
+  <g id="LWPOLYLINE-542" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="563.97 903.06 560.95 904.27 559.43 899.73"/>
+  </g>
+  <g id="LWPOLYLINE-543" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="560.34 901.85 560.34 902.46 560.34 902.75 560.34 903.06 560.34 903.36 560.04 903.36 560.04 903.67 559.73 903.67 559.44 903.67 559.44 903.97 559.13 903.97 558.83 903.97 558.83 904.27 558.52 904.27 558.22 904.27 557.92 904.57 557.62 904.57 557.32 904.87 557.01 904.87 556.71 904.87 556.41 905.18 556.11 905.48 555.8 905.48 555.5 905.48 555.2 905.78 554.89 905.78 554.59 905.78 554.29 905.78 554.29 906.08 553.98 906.08 553.69 906.08 553.38 906.08 553.08 906.08 552.77 906.08 552.47 906.08 552.17 905.78 551.87 905.48 551.57 905.18 551.26 904.87 551.26 904.57 550.96 904.27 550.96 903.67 550.66 903.36 550.36 902.75"/>
+  </g>
+  <g id="LWPOLYLINE-544" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="560.94 904.27 560.34 904.57 560.04 904.88 559.43 904.88 558.82 905.17 558.52 905.48 557.92 905.79 557.62 905.79 557.01 906.09 556.71 906.09 556.41 906.39 556.1 906.39 555.5 906.69 555.19 906.69 554.9 906.99 554.59 906.99 554.29 907.29 553.99 907.29 553.68 907.29 553.68 907.6 553.38 907.6 553.08 907.6 552.78 907.6 552.47 907.6 552.17 907.6 551.87 907.6 551.57 907.29 551.27 906.99 550.66 906.39 550.35 905.48 549.75 904.57 549.15 903.06 548.84 901.55 548.54 900.34 548.54 899.43 548.54 898.82 548.54 898.22 548.54 897.92 548.84 897.62 549.15 897.62 549.15 897.31 549.45 897.31 549.75 897.01 550.05 897.01 550.35 896.7 550.66 896.7 550.96 896.7 551.27 896.7 551.57 896.41 551.87 896.41 552.17 896.41 552.47 896.1 553.08 896.1 553.38 896.1 553.68 895.8 554.29 895.8 554.59 895.8 555.19 895.5 555.8 895.5 556.1 895.5 556.71 895.19 557.31 895.19 557.92 895.19"/>
+  </g>
+  <g id="LWPOLYLINE-545" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="557.31 893.08 555.8 893.68 554.29 894.28 553.38 894.89 552.47 895.2 551.56 895.8 550.96 896.1 550.05 896.71 549.45 897.01"/>
+  </g>
+  <g id="LWPOLYLINE-546" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="558.83 897.31 558.52 897.01 558.52 896.71 558.22 896.41 558.22 896.11 557.92 896.11 557.62 896.11 557.31 896.11 557.01 896.41 556.71 896.41 556.4 896.41 556.11 896.41 555.8 896.41 555.5 896.71 555.2 896.71 554.89 896.71 554.6 896.71 554.29 897.01 553.99 897.01 553.68 897.01 553.38 897.01 553.08 897.31 552.78 897.31 552.48 897.31 552.17 897.31 551.87 897.62 551.57 897.62 551.26 897.92 550.96 897.92 550.66 897.92 550.66 898.22 550.36 898.22 550.36 898.52 550.05 898.52 550.05 898.83 550.05 899.13 549.75 899.13 549.75 899.43 549.75 899.74 549.75 900.03 549.75 900.34 550.05 900.64 550.05 900.94 550.05 901.54 550.36 901.86 550.36 902.76"/>
+  </g>
+  <g id="LWPOLYLINE-547" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="557.92" y1="895.2" x2="559.43" y2="899.74"/>
+  </g>
+  <g id="LWPOLYLINE-548" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M507.12,858.28s0,0,0-.01c-.08-.24.05-.5.28-.58l29.04-9.37"/>
+  </g>
+  <g id="LWPOLYLINE-549" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="536.14" y1="846.79" x2="507.09" y2="856.47"/>
+  </g>
+  <g id="LWPOLYLINE-550" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M522.62,841.95c1.25-.02,2.5-.24,3.69-.63,1.21-.41,2.36-.99,3.4-1.74.91-.62,1.71-1.4,2.36-2.3.42-.51.77-1.08,1.04-1.69l1.51-.3-2.42-6.65-1.52.3c-.54-.35-1.13-.63-1.74-.83"/>
+  </g>
+  <g id="SPLINE-5" data-name="SPLINE">
+    <path class="cls-3" d="M515.92,833.12c-.08.14-.06.31.01.44"/>
+  </g>
+  <g id="SPLINE-6" data-name="SPLINE">
+    <path class="cls-3" d="M515.93,833.56c.09.13.23.22.39.22"/>
+  </g>
+  <g id="LWPOLYLINE-551" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="516.47" y1="834.09" x2="518.9" y2="834.09"/>
+  </g>
+  <g id="SPLINE-7" data-name="SPLINE">
+    <path class="cls-3" d="M518.74,833.78c.15,0,.28-.07.36-.18"/>
+  </g>
+  <g id="ARC-11" data-name="ARC">
+    <path class="cls-3" d="M529.04,831.49c-.33-.21-.68-.39-1.05-.51"/>
+  </g>
+  <g id="ARC-12" data-name="ARC">
+    <path class="cls-3" d="M520.75,838.63c.67.21,1.36.31,2.06.29"/>
+  </g>
+  <g id="SPLINE-8" data-name="SPLINE">
+    <path class="cls-3" d="M520.69,838.64c-.14-.04-.29-.02-.4.07"/>
+  </g>
+  <g id="LWPOLYLINE-552" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="520.41" y1="838.93" x2="518.29" y2="840.13"/>
+  </g>
+  <g id="ARC-13" data-name="ARC">
+    <path class="cls-3" d="M523.16,827.67c-1.39.46-2.71,1.09-3.93,1.89"/>
+  </g>
+  <g id="ARC-14" data-name="ARC">
+    <path class="cls-3" d="M517.49,838.62c.44.36.93.67,1.46.9"/>
+  </g>
+  <g id="ARC-15" data-name="ARC">
+    <path class="cls-3" d="M519.66,841.46c1.03.35,2.11.51,3.19.48"/>
+  </g>
+  <g id="LWPOLYLINE-553" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="520.41" y1="838.62" x2="520.41" y2="838.62"/>
+  </g>
+  <g id="ARC-16" data-name="ARC">
+    <path class="cls-3" d="M518.25,840.76c.38.2.77.37,1.18.51"/>
+  </g>
+  <g id="LWPOLYLINE-554" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="518.29" y1="840.74" x2="518.29" y2="840.74"/>
+  </g>
+  <g id="ARC-17" data-name="ARC">
+    <path class="cls-3" d="M516.97,833.76c-.25.48-.45.98-.59,1.5"/>
+  </g>
+  <g id="LWPOLYLINE-555" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="505.89" y1="859.19" x2="507.4" y2="858.59"/>
+  </g>
+  <g id="LWPOLYLINE-556" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="505.28 859.19 505.28 859.5 505.28 860.1 508.3 859.19 508 858.59 507.7 858.59 507.4 858.59 507.1 858.59"/>
+  </g>
+  <g id="LWPOLYLINE-557" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="505.89 858.89 505.89 859.19 505.28 859.19"/>
+  </g>
+  <g id="ARC-18" data-name="ARC">
+    <path class="cls-3" d="M506.93,856.27c-1.03.34-1.59,1.45-1.25,2.48,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-558" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="540.98" y1="838.32" x2="531.6" y2="809.28"/>
+  </g>
+  <g id="LWPOLYLINE-559" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M530.09,809.88l9.37,28.74c.41,1.02,1.56,1.52,2.58,1.11,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-560" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="531.6 807.16 531.9 808.67 532.2 808.98 532.51 809.28 533.11 808.98 531.9 806.25 531.6 806.25 531.3 806.55 531.6 807.16 531.3 807.16"/>
+  </g>
+  <g id="ARC-19" data-name="ARC">
+    <path class="cls-3" d="M531.61,808.39c-.24.07-.37.32-.29.56,0,0,0,0,0,.01"/>
+  </g>
+  <g id="ARC-20" data-name="ARC">
+    <path class="cls-3" d="M531.14,806.96c-1.03.34-1.59,1.45-1.25,2.48,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-21" data-name="ARC">
+    <path class="cls-3" d="M526.17,841.21c.49-.11.98-.25,1.47-.41"/>
+  </g>
+  <g id="LWPOLYLINE-561" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="527.97" y1="841.04" x2="539.16" y2="837.41"/>
+  </g>
+  <g id="LWPOLYLINE-562" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="534.62" y1="824.1" x2="523.43" y2="827.73"/>
+  </g>
+  <g id="LWPOLYLINE-563" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="540.67 836.81 541.88 836.51 540.67 832.58 539.77 829.85 538.86 826.83 537.65 823.19 536.14 823.5"/>
+  </g>
+  <g id="LWPOLYLINE-564" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="542.49" y1="839.83" x2="541.88" y2="838.63"/>
+  </g>
+  <g id="LWPOLYLINE-565" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="542.49 840.44 542.79 840.44 543.39 840.44"/>
+  </g>
+  <g id="LWPOLYLINE-566" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="541.89" y1="838.62" x2="541.58" y2="838.62"/>
+  </g>
+  <g id="LWPOLYLINE-567" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="542.19 840.14 542.49 839.83 542.49 840.44"/>
+  </g>
+  <g id="LWPOLYLINE-568" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="543.4 840.44 542.49 837.41 541.88 837.72 541.88 838.02 541.88 838.62"/>
+  </g>
+  <g id="ARC-22" data-name="ARC">
+    <path class="cls-3" d="M541,838.01c.07.24.32.37.56.29,0,0,0,0,.01,0"/>
+  </g>
+  <g id="LWPOLYLINE-569" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="537.04 848.61 537.35 848.91 536.74 848.91 536.74 849.21 536.74 849.81 539.47 848.91 539.47 848.3 539.17 848.3 538.56 848.3 538.56 848"/>
+  </g>
+  <g id="ARC-23" data-name="ARC">
+    <path class="cls-3" d="M537.02,848.31c-.08-.24-.33-.37-.57-.29,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-570" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="537.35" y1="848.91" x2="538.55" y2="848.3"/>
+  </g>
+  <g id="ARC-24" data-name="ARC">
+    <path class="cls-3" d="M538.46,847.84c-.34-1.03-1.45-1.59-2.48-1.25,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-571" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="558.22" y1="1055.23" x2="556.4" y2="1055.23"/>
+  </g>
+  <g id="ARC-25" data-name="ARC">
+    <path class="cls-3" d="M563.07,1055.03c-2.22-.24-4.45-.37-6.69-.4"/>
+  </g>
+  <g id="LWPOLYLINE-572" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="558.22" y1="1057.35" x2="553.38" y2="1057.35"/>
+  </g>
+  <g id="LWPOLYLINE-573" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="547.63 1057.65 555.8 1057.65 563.97 1057.65"/>
+  </g>
+  <g id="ARC-26" data-name="ARC">
+    <path class="cls-3" d="M564.87,1049.84c-.46-1.48-1.18-2.86-2.12-4.09"/>
+  </g>
+  <g id="ARC-27" data-name="ARC">
+    <path class="cls-3" d="M562.91,1054.93c.58,0,1.05-.47,1.06-1.05,0,0,0,0,0,0"/>
+  </g>
+  <g id="SPLINE-9" data-name="SPLINE">
+    <path class="cls-3" d="M558.22,1055.38c0-.08-.07-.15-.15-.15"/>
+  </g>
+  <g id="SPLINE-10" data-name="SPLINE">
+    <path class="cls-3" d="M558.07,1057.05c.08,0,.15-.07.15-.15"/>
+  </g>
+  <g id="LWPOLYLINE-574" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="558.52" y1="1055.53" x2="558.52" y2="1057.05"/>
+  </g>
+  <g id="LWPOLYLINE-575" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M556.41,1052.51l.3,3.63c-.01-.15-.07-.3-.17-.42"/>
+  </g>
+  <g id="LWPOLYLINE-576" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="554.89" y1="1055.23" x2="553.38" y2="1055.23"/>
+  </g>
+  <g id="SPLINE-11" data-name="SPLINE">
+    <path class="cls-3" d="M553.08,1056.89c0,.08.07.15.15.15"/>
+  </g>
+  <g id="SPLINE-12" data-name="SPLINE">
+    <path class="cls-3" d="M553.23,1055.23c-.08,0-.15.07-.15.15"/>
+  </g>
+  <g id="LWPOLYLINE-577" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="553.08" y1="1055.53" x2="553.08" y2="1057.05"/>
+  </g>
+  <g id="SPLINE-13" data-name="SPLINE">
+    <path class="cls-3" d="M556.41,1056.29c0-.06,0-.11-.02-.17"/>
+  </g>
+  <g id="ARC-28" data-name="ARC">
+    <path class="cls-3" d="M556.35,1056.58c.04-.09.06-.19.06-.29"/>
+  </g>
+  <g id="SPLINE-14" data-name="SPLINE">
+    <path class="cls-3" d="M556.19,1056.82c.07-.07.13-.15.17-.25"/>
+  </g>
+  <g id="SPLINE-15" data-name="SPLINE">
+    <path class="cls-3" d="M555.94,1056.99c.09-.04.18-.09.25-.17"/>
+  </g>
+  <g id="SPLINE-16" data-name="SPLINE">
+    <path class="cls-3" d="M555.65,1057.05c.1,0,.2-.02.29-.06"/>
+  </g>
+  <g id="ARC-29" data-name="ARC">
+    <path class="cls-3" d="M555.36,1056.99c.09.04.19.06.29.06"/>
+  </g>
+  <g id="SPLINE-17" data-name="SPLINE">
+    <path class="cls-3" d="M555.12,1056.82c.07.07.15.13.25.17"/>
+  </g>
+  <g id="ARC-30" data-name="ARC">
+    <path class="cls-3" d="M554.89,1056.29c0,.1.02.2.06.29"/>
+  </g>
+  <g id="LWPOLYLINE-578" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M556.1,1052.36c-.04-.25-.28-.42-.53-.38s-.42.28-.38.53c0,0,0,0,0,0l-.3,3.93c.05.14.13.27.22.38"/>
+  </g>
+  <g id="ARC-31" data-name="ARC">
+    <path class="cls-3" d="M545.54,1055.07c-.17,1.22.66,2.35,1.87,2.56"/>
+  </g>
+  <g id="ARC-32" data-name="ARC">
+    <path class="cls-3" d="M548.54,1045.75c-.93,1.23-1.65,2.62-2.12,4.09"/>
+  </g>
+  <g id="ARC-33" data-name="ARC">
+    <path class="cls-3" d="M546.6,1049.97c-.52,1.65-.78,3.38-.78,5.11"/>
+  </g>
+  <g id="LWPOLYLINE-579" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="401.51" y1="1080.95" x2="396.67" y2="1083.97"/>
+  </g>
+  <g id="CIRCLE-15" data-name="CIRCLE">
+    <circle class="cls-3" cx="398.65" cy="1074.75" r="1.35"/>
+  </g>
+  <g id="LWPOLYLINE-580" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="404.24" y1="1081.25" x2="402.12" y2="1082.45"/>
+  </g>
+  <g id="SPLINE-18" data-name="SPLINE">
+    <path class="cls-3" d="M400.65,1081.68c-.35.22-.45.69-.23,1.04"/>
+  </g>
+  <g id="SPLINE-19" data-name="SPLINE">
+    <path class="cls-3" d="M403.98,1079.56c-.35.22-.45.69-.23,1.04"/>
+  </g>
+  <g id="LWPOLYLINE-581" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="403.63 1080.34 400.3 1076.71 399.7 1077.32 401.81 1081.86"/>
+  </g>
+  <g id="ARC-34" data-name="ARC">
+    <path class="cls-3" d="M394.47,1087.58c.4.63,1.24.82,1.87.42,0,0,0,0,.01,0"/>
+  </g>
+  <g id="LWPOLYLINE-582" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="396.37" y1="1088.21" x2="411.8" y2="1078.23"/>
+  </g>
+  <g id="LWPOLYLINE-583" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="386.39" y1="1074.9" x2="394.86" y2="1087.6"/>
+  </g>
+  <g id="ARC-35" data-name="ARC">
+    <path class="cls-3" d="M386.71,1072.69c-.63.4-.82,1.24-.42,1.87,0,0,0,0,0,.01"/>
+  </g>
+  <g id="LWPOLYLINE-584" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="402.12" y1="1063.4" x2="386.69" y2="1073.08"/>
+  </g>
+  <g id="ARC-36" data-name="ARC">
+    <path class="cls-3" d="M403.72,1063.42c-.4-.63-1.24-.82-1.87-.42,0,0,0,0-.01,0"/>
+  </g>
+  <g id="LWPOLYLINE-585" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="412.1" y1="1076.71" x2="403.63" y2="1063.71"/>
+  </g>
+  <g id="ARC-37" data-name="ARC">
+    <path class="cls-3" d="M411.48,1078.31c.63-.4.82-1.24.42-1.87,0,0,0,0,0-.01"/>
+  </g>
+  <g id="ARC-38" data-name="ARC">
+    <path class="cls-3" d="M393.15,1083.39c.76,1.19,2.35,1.54,3.54.78,0,0,0,0,.01,0"/>
+  </g>
+  <g id="LWPOLYLINE-586" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="393.35" y1="1083.37" x2="388.81" y2="1076.11"/>
+  </g>
+  <g id="ARC-39" data-name="ARC">
+    <path class="cls-3" d="M389.39,1072.58c-1.19.77-1.54,2.36-.77,3.55,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-587" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="389.41" y1="1072.78" x2="400.6" y2="1065.52"/>
+  </g>
+  <g id="ARC-40" data-name="ARC">
+    <path class="cls-3" d="M404.13,1066.09c-.77-1.19-2.36-1.54-3.55-.77,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-588" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="403.93" y1="1066.43" x2="408.47" y2="1073.38"/>
+  </g>
+  <g id="LWPOLYLINE-589" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M408.66,1073.35s0,0,0,0c.79,1.23.43,2.87-.8,3.65l-4.84,3.02"/>
+  </g>
+  <g id="LWPOLYLINE-590" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="512.54" y1="1055.23" x2="514.36" y2="1055.23"/>
+  </g>
+  <g id="ARC-41" data-name="ARC">
+    <path class="cls-3" d="M514.06,1054.63c-2.23.02-4.47.16-6.69.4"/>
+  </g>
+  <g id="LWPOLYLINE-591" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="512.54" y1="1057.35" x2="517.68" y2="1057.35"/>
+  </g>
+  <g id="LWPOLYLINE-592" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M524.92,1055.07c.2,1.21-.59,2.35-1.79,2.59h-16.03"/>
+  </g>
+  <g id="ARC-42" data-name="ARC">
+    <path class="cls-3" d="M506.49,1053.87c0,.58.47,1.05,1.05,1.06,0,0,0,0,0,0"/>
+  </g>
+  <g id="SPLINE-20" data-name="SPLINE">
+    <path class="cls-3" d="M512.39,1055.23c-.08,0-.15.07-.15.15"/>
+  </g>
+  <g id="SPLINE-21" data-name="SPLINE">
+    <path class="cls-3" d="M512.24,1056.89c0,.08.07.15.15.15"/>
+  </g>
+  <g id="LWPOLYLINE-593" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="512.54" y1="1055.53" x2="512.54" y2="1057.05"/>
+  </g>
+  <g id="LWPOLYLINE-594" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="514.66" y1="1052.51" x2="514.36" y2="1056.14"/>
+  </g>
+  <g id="LWPOLYLINE-595" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="515.87" y1="1055.23" x2="517.69" y2="1055.23"/>
+  </g>
+  <g id="SPLINE-22" data-name="SPLINE">
+    <path class="cls-3" d="M517.53,1057.05c.08,0,.15-.07.15-.15"/>
+  </g>
+  <g id="SPLINE-23" data-name="SPLINE">
+    <path class="cls-3" d="M517.68,1055.38c0-.08-.07-.15-.15-.15"/>
+  </g>
+  <g id="LWPOLYLINE-596" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="517.68" y1="1055.53" x2="517.68" y2="1057.05"/>
+  </g>
+  <g id="SPLINE-24" data-name="SPLINE">
+    <path class="cls-3" d="M514.07,1056.12c-.01.06-.02.11-.02.17"/>
+  </g>
+  <g id="SPLINE-25" data-name="SPLINE">
+    <path class="cls-3" d="M514.27,1056.82c.07.07.15.13.25.17"/>
+  </g>
+  <g id="SPLINE-26" data-name="SPLINE">
+    <path class="cls-3" d="M515.34,1056.82c.07-.07.13-.15.17-.25"/>
+  </g>
+  <g id="ARC-43" data-name="ARC">
+    <path class="cls-3" d="M515.51,1056.58c.04-.09.06-.19.06-.29"/>
+  </g>
+  <g id="ARC-44" data-name="ARC">
+    <path class="cls-3" d="M513.92,1055.72c-.11.17-.17.37-.17.57"/>
+  </g>
+  <g id="SPLINE-27" data-name="SPLINE">
+    <path class="cls-3" d="M513.75,1056.29c0,.14.02.28.08.41"/>
+  </g>
+  <g id="SPLINE-28" data-name="SPLINE">
+    <path class="cls-3" d="M515.79,1056.7c.13-.31.1-.68-.08-.97"/>
+  </g>
+  <g id="ARC-45" data-name="ARC">
+    <path class="cls-3" d="M515.26,1052.36c0-.25-.2-.45-.45-.45s-.45.2-.45.45c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="515.57" y1="1052.51" x2="515.87" y2="1056.44"/>
+  </g>
+  <g id="ARC-46" data-name="ARC">
+    <path class="cls-3" d="M521.92,1046.06c-.89-1.17-2.02-2.15-3.31-2.85"/>
+  </g>
+  <g id="ARC-47" data-name="ARC">
+    <path class="cls-3" d="M524.02,1049.84c-.46-1.48-1.18-2.86-2.12-4.09"/>
+  </g>
+  <g id="ARC-48" data-name="ARC">
+    <path class="cls-3" d="M524.64,1055.08c0-1.73-.26-3.46-.79-5.11"/>
+  </g>
+  <g id="CIRCLE-16" data-name="CIRCLE">
+    <circle class="cls-3" cx="1688.3" cy="707.78" r="8.92"/>
+  </g>
+  <g id="CIRCLE-17" data-name="CIRCLE">
+    <circle class="cls-3" cx="1688.3" cy="985.2" r="8.92"/>
+  </g>
+  <g id="CIRCLE-18" data-name="CIRCLE">
+    <circle class="cls-3" cx="1490.75" cy="985.5" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-598" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="764.85" y1="996.24" x2="764.85" y2="991.09"/>
+  </g>
+  <g id="LWPOLYLINE-599" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="790.26 965.68 764.85 991.1 766.06 992.3 791.47 966.89"/>
+  </g>
+  <g id="LWPOLYLINE-600" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="789.35 964.78 792.68 968.41 795.7 972.34 797.82 976.88 799.33 981.42 800.54 986.25 800.85 991.1"/>
+  </g>
+  <g id="LWPOLYLINE-601" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="715.23" y1="991.1" x2="715.23" y2="974.46"/>
+  </g>
+  <g id="LWPOLYLINE-602" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="720.07" y1="991.1" x2="720.07" y2="933.01"/>
+  </g>
+  <g id="LWPOLYLINE-603" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="715.23" y1="933.62" x2="653.52" y2="747.26"/>
+  </g>
+  <g id="LWPOLYLINE-604" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="664.11" y1="805.04" x2="663.8" y2="804.14"/>
+  </g>
+  <g id="LWPOLYLINE-605" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="720.07" y1="933.01" x2="656.24" y2="739.4"/>
+  </g>
+  <g id="LWPOLYLINE-606" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="605.11" y1="955.4" x2="547.93" y2="782.36"/>
+  </g>
+  <g id="LWPOLYLINE-607" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="632.95" y1="854.35" x2="630.22" y2="845.88"/>
+  </g>
+  <g id="LWPOLYLINE-608" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="632.04" y1="854.66" x2="629.32" y2="846.19"/>
+  </g>
+  <g id="LWPOLYLINE-609" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="601.48" y1="956.61" x2="544.6" y2="783.26"/>
+  </g>
+  <g id="LWPOLYLINE-610" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="826.86 847.7 801.15 873.11 802.36 874.32 828.07 848.91"/>
+  </g>
+  <g id="LWPOLYLINE-611" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="825.96 846.79 829.28 850.42 832 854.36 834.43 858.89 835.94 863.43 836.85 868.27 837.15 873.11"/>
+  </g>
+  <g id="LWPOLYLINE-612" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="730.36 847.7 704.64 873.11 706.16 874.32 731.57 848.91"/>
+  </g>
+  <g id="LWPOLYLINE-613" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="729.45 846.79 732.78 850.42 735.5 854.36 737.92 858.89 739.43 863.43 740.64 868.27 740.95 873.11"/>
+  </g>
+  <g id="LWPOLYLINE-614" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="700.11 730.02 703.13 739.09 660.78 753.01"/>
+  </g>
+  <g id="LWPOLYLINE-615" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="696.47 731.22 698.29 736.67 659.57 749.37"/>
+  </g>
+  <g id="LWPOLYLINE-616" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="899.77 652.87 900.98 656.5 901.59 656.5 899.17 648.94 898.57 648.94 899.77 652.57 893.12 654.69 891.91 651.06 891.3 651.36 894.02 658.92 894.33 658.92 893.12 655.3 899.77 652.87"/>
+  </g>
+  <g id="LWPOLYLINE-617" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="885.25 1025.58 910.66 1000.17 911.87 1001.38 886.46 1026.79"/>
+  </g>
+  <g id="LWPOLYLINE-618" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="884.34 1024.68 887.97 1028 891.91 1031.03 896.44 1033.15 900.98 1034.96 905.82 1035.87 910.66 1036.17"/>
+  </g>
+  <g id="LWPOLYLINE-619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="755.13" x2="1053.15" y2="755.13"/>
+  </g>
+  <g id="LWPOLYLINE-620" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1114.57" y1="688.87" x2="1239.21" y2="688.87"/>
+  </g>
+  <g id="LWPOLYLINE-621" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1276.72 684.94 1276.72 688.87 1302.43 688.87"/>
+  </g>
+  <g id="LWPOLYLINE-622" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.43" y1="642.28" x2="1315.14" y2="642.28"/>
+  </g>
+  <g id="LWPOLYLINE-623" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1387.44 638.35 1387.44 642.28 1424.65 642.28"/>
+  </g>
+  <g id="LWPOLYLINE-624" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1460.65 638.35 1460.65 642.28 1571.38 642.28"/>
+  </g>
+  <g id="LWPOLYLINE-625" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1601.33 638.35 1601.33 642.28 1706.3 642.28"/>
+  </g>
+  <g id="LWPOLYLINE-626" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1706.3" y1="584.81" x2="1730.2" y2="584.81"/>
+  </g>
+  <g id="LWPOLYLINE-627" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1767.72" y1="584.81" x2="1822.17" y2="584.81"/>
+  </g>
+  <g id="LWPOLYLINE-628" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1822.17" y1="536.7" x2="1918.37" y2="536.7"/>
+  </g>
+  <g id="LWPOLYLINE-629" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2038.47 466.21 1836.09 532.77 1918.37 532.77"/>
+  </g>
+  <g id="LWPOLYLINE-630" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1706.3" y1="580.87" x2="1730.2" y2="580.87"/>
+  </g>
+  <g id="LWPOLYLINE-631" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1767.72" y1="580.87" x2="1818.24" y2="580.87"/>
+  </g>
+  <g id="LWPOLYLINE-632" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1702.37" y1="635.02" x2="1706.3" y2="635.02"/>
+  </g>
+  <g id="LWPOLYLINE-633" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1702.37 398.15 1702.37 599.02 1706.3 599.02"/>
+  </g>
+  <g id="LWPOLYLINE-634" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.43" y1="638.35" x2="1315.14" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1387.44" y1="638.35" x2="1424.65" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-636" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.43" y1="610.22" x2="1404.08" y2="610.22"/>
+  </g>
+  <g id="LWPOLYLINE-637" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.43" y1="614.45" x2="1400.15" y2="614.45"/>
+  </g>
+  <g id="LWPOLYLINE-638" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1460.65" y1="638.35" x2="1571.38" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-639" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1605.26 624.13 1605.26 638.35 1702.37 638.35"/>
+  </g>
+  <g id="LWPOLYLINE-640" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1562.91" y1="624.13" x2="1605.26" y2="624.13"/>
+  </g>
+  <g id="LWPOLYLINE-641" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1566.54" y1="627.76" x2="1601.33" y2="627.76"/>
+  </g>
+  <g id="LWPOLYLINE-642" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1114.57" y1="684.94" x2="1239.21" y2="684.94"/>
+  </g>
+  <g id="LWPOLYLINE-643" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1276.72" y1="684.94" x2="1298.5" y2="684.94"/>
+  </g>
+  <g id="LWPOLYLINE-644" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="751.19" x2="1053.15" y2="751.19"/>
+  </g>
+  <g id="LWPOLYLINE-645" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1089.15" y1="751.19" x2="1110.63" y2="751.19"/>
+  </g>
+  <g id="LWPOLYLINE-646" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="885.86 843.46 911.27 869.18 912.78 867.67 887.06 842.26"/>
+  </g>
+  <g id="LWPOLYLINE-647" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="885.25 844.37 888.58 841.04 892.82 838.32 897.05 835.9 901.59 834.39 906.42 833.48 911.27 832.88"/>
+  </g>
+  <g id="LWPOLYLINE-648" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="911.27" y="831.67" width="4.23" height="1.21"/>
+  </g>
+  <g id="LWPOLYLINE-649" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="913.39 780.54 913.39 831.67 913.39 780.54"/>
+  </g>
+  <g id="LWPOLYLINE-650" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="911.27" y="779.03" width="4.23" height="1.51"/>
+  </g>
+  <g id="LWPOLYLINE-651" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1076.75" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-652" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1074.63" y1="1264.58" x2="1041.36" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-653" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1074.63" y1="1263.37" x2="1041.36" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-654" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1074.63" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-655" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="924.88" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-656" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="925.79" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-657" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1000.82" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-658" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="998.7" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-659" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1001.72" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-660" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1039.23" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-661" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1037.12" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-662" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1003.84" y1="1264.58" x2="1037.12" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-663" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1003.84" y1="1263.37" x2="1037.12" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-664" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="927.91" y1="1264.58" x2="961.49" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-665" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="927.91" y1="1263.37" x2="961.49" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-666" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="961.49" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-667" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="963.3" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-668" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="998.7" y1="1264.58" x2="965.42" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-669" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="998.7" y1="1263.37" x2="965.42" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-670" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1077.66" y1="1257.62" x2="924.89" y2="1257.62"/>
+  </g>
+  <g id="LWPOLYLINE-671" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="919.13" y1="641.38" x2="1066.77" y2="592.67"/>
+  </g>
+  <g id="LWPOLYLINE-672" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="920.04 644.1 920.65 645.61 921.56 645.31 921.25 643.8 920.04 644.1"/>
+  </g>
+  <g id="LWPOLYLINE-673" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="923.07" y1="643.49" x2="955.13" y2="632.9"/>
+  </g>
+  <g id="LWPOLYLINE-674" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="923.37" y1="644.4" x2="955.44" y2="633.81"/>
+  </g>
+  <g id="LWPOLYLINE-675" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="921.25 643.8 921.55 645.31 923.67 644.7 923.07 643.19 921.25 643.8"/>
+  </g>
+  <g id="LWPOLYLINE-676" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1067.67 595.7 1068.28 597.21 1067.37 597.51 1066.77 596 1067.67 595.7"/>
+  </g>
+  <g id="LWPOLYLINE-677" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1066.77 596 1067.37 597.51 1065.25 598.12 1064.95 596.6 1066.77 596"/>
+  </g>
+  <g id="LWPOLYLINE-678" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="993.55 619.9 993.86 621.71 995.07 621.41 994.46 619.59 993.55 619.9"/>
+  </g>
+  <g id="LWPOLYLINE-679" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="994.72" y="619.24" width="1.92" height="1.91" transform="translate(-145.03 346.69) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-680" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="993.55 619.9 993.86 621.71 992.04 622.32 991.43 620.5 993.55 619.9"/>
+  </g>
+  <g id="LWPOLYLINE-681" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="955.13 632.6 955.74 634.12 957.56 633.51 956.95 632 955.13 632.6"/>
+  </g>
+  <g id="LWPOLYLINE-682" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="959.07 631.39 959.37 632.91 957.55 633.51 956.95 632 959.07 631.39"/>
+  </g>
+  <g id="LWPOLYLINE-683" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="991.74" y1="621.11" x2="959.07" y2="631.7"/>
+  </g>
+  <g id="LWPOLYLINE-684" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="992.04" y1="622.01" x2="959.37" y2="632.61"/>
+  </g>
+  <g id="LWPOLYLINE-685" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="922.46" y1="651.06" x2="1070.09" y2="602.35"/>
+  </g>
+  <g id="LWPOLYLINE-686" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="983.57" y="751.19" width="1.51" height="3.93"/>
+  </g>
+  <g id="LWPOLYLINE-687" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="983.57" y1="753.31" x2="917.02" y2="753.31"/>
+  </g>
+  <g id="LWPOLYLINE-688" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="983.57" y1="753.01" x2="917.02" y2="753.01"/>
+  </g>
+  <g id="LWPOLYLINE-689" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="915.5" y="751.19" width="1.51" height="3.93"/>
+  </g>
+  <g id="LWPOLYLINE-690" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1063.74 725.48 1089.15 751.2 1087.94 752.4 1062.53 726.99"/>
+  </g>
+  <g id="LWPOLYLINE-691" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1064.35 724.87 1061.02 728.5 1058.3 732.44 1056.18 736.67 1054.37 741.51 1053.45 746.35 1053.15 751.2"/>
+  </g>
+  <g id="LWPOLYLINE-692" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="985.08" y1="753.31" x2="1051.64" y2="753.31"/>
+  </g>
+  <g id="LWPOLYLINE-693" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="985.08" y1="753.01" x2="1051.64" y2="753.01"/>
+  </g>
+  <g id="LWPOLYLINE-694" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1051.64" y="751.19" width="1.51" height="3.93"/>
+  </g>
+  <g id="LWPOLYLINE-695" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1064.95" y1="596.91" x2="1032.88" y2="607.5"/>
+  </g>
+  <g id="LWPOLYLINE-696" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1065.25" y1="597.81" x2="1033.19" y2="608.41"/>
+  </g>
+  <g id="LWPOLYLINE-697" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1032.58 607.19 1033.19 608.71 1031.37 609.31 1030.76 607.8 1032.58 607.19"/>
+  </g>
+  <g id="LWPOLYLINE-698" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1028.95 608.4 1029.56 609.92 1031.37 609.31 1030.77 607.8 1028.95 608.4"/>
+  </g>
+  <g id="LWPOLYLINE-699" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="996.28" y1="619.29" x2="1028.95" y2="608.7"/>
+  </g>
+  <g id="LWPOLYLINE-700" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="996.88" y1="620.5" x2="1029.25" y2="609.61"/>
+  </g>
+  <g id="LWPOLYLINE-701" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.43" y1="688.87" x2="1302.43" y2="529.74"/>
+  </g>
+  <g id="LWPOLYLINE-702" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1404.08" y1="638.35" x2="1404.08" y2="610.21"/>
+  </g>
+  <g id="LWPOLYLINE-703" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1400.15" y1="638.35" x2="1400.15" y2="614.45"/>
+  </g>
+  <g id="LWPOLYLINE-704" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1706.3" y1="642.28" x2="1706.3" y2="635.02"/>
+  </g>
+  <g id="LWPOLYLINE-705" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1706.3" y1="599.02" x2="1706.3" y2="396.94"/>
+  </g>
+  <g id="LWPOLYLINE-706" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1730.2" y1="584.81" x2="1730.2" y2="580.87"/>
+  </g>
+  <g id="LWPOLYLINE-707" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1571.38" y1="642.28" x2="1571.38" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-708" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1702.37" y1="638.35" x2="1702.37" y2="635.02"/>
+  </g>
+  <g id="LWPOLYLINE-709" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1601.33" y1="638.35" x2="1601.33" y2="627.76"/>
+  </g>
+  <g id="LWPOLYLINE-710" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1562.91" y1="638.35" x2="1562.91" y2="624.13"/>
+  </g>
+  <g id="LWPOLYLINE-711" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1566.54" y1="638.35" x2="1566.54" y2="627.76"/>
+  </g>
+  <g id="LWPOLYLINE-712" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1424.65" y1="642.28" x2="1424.65" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-713" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1315.14" y1="642.28" x2="1315.14" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-714" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1298.5" y1="684.94" x2="1298.5" y2="530.96"/>
+  </g>
+  <g id="LWPOLYLINE-715" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1240.72" y1="688.87" x2="1240.72" y2="684.94"/>
+  </g>
+  <g id="LWPOLYLINE-716" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1176.88" y="684.94" width="1.51" height="3.93"/>
+  </g>
+  <g id="LWPOLYLINE-717" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1176.88" y1="687.06" x2="1116.08" y2="687.06"/>
+  </g>
+  <g id="LWPOLYLINE-718" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1176.88" y1="686.76" x2="1116.08" y2="686.76"/>
+  </g>
+  <g id="LWPOLYLINE-719" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1114.56" y="684.94" width="1.51" height="3.93"/>
+  </g>
+  <g id="LWPOLYLINE-720" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1178.4" y1="687.06" x2="1239.2" y2="687.06"/>
+  </g>
+  <g id="LWPOLYLINE-721" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1178.4" y1="686.76" x2="1239.2" y2="686.76"/>
+  </g>
+  <g id="LWPOLYLINE-722" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1239.2" y="684.94" width="1.51" height="3.93"/>
+  </g>
+  <g id="LWPOLYLINE-723" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1251.31 659.53 1276.72 684.94 1275.51 686.15 1250.1 660.74"/>
+  </g>
+  <g id="LWPOLYLINE-724" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1252.21 658.62 1248.89 662.25 1245.86 666.49 1243.74 670.72 1241.93 675.26 1241.02 680.1 1240.72 684.94"/>
+  </g>
+  <g id="LWPOLYLINE-725" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1261.59 524.6 1310 508.57 1315.75 525.51 1267.04 541.24 1261.59 524.6"/>
+  </g>
+  <g id="LWPOLYLINE-726" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1285.19 526.42 1286.4 529.74 1286.09 530.05 1283.67 522.48 1283.98 522.19 1285.19 525.81 1291.84 523.7 1290.64 520.07 1291.24 519.76 1293.66 527.62 1293.36 527.62 1292.15 523.99 1285.19 526.42"/>
+  </g>
+  <g id="LWPOLYLINE-727" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1262.8" y1="528.23" x2="1115.17" y2="576.64"/>
+  </g>
+  <g id="LWPOLYLINE-728" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1263.71 531.26 1264.32 532.77 1263.41 533.08 1262.81 531.56 1263.71 531.26"/>
+  </g>
+  <g id="LWPOLYLINE-729" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1260.99" y1="532.47" x2="1228.92" y2="543.06"/>
+  </g>
+  <g id="LWPOLYLINE-730" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1261.29" y1="533.38" x2="1229.22" y2="543.97"/>
+  </g>
+  <g id="LWPOLYLINE-731" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1262.8 531.56 1263.41 533.07 1261.6 533.68 1260.99 532.17 1262.8 531.56"/>
+  </g>
+  <g id="LWPOLYLINE-732" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1116.38 579.66 1116.68 581.18 1117.59 580.87 1117.28 579.36 1116.38 579.66"/>
+  </g>
+  <g id="LWPOLYLINE-733" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1117.29 579.36 1117.59 580.87 1119.71 580.26 1119.11 578.75 1117.29 579.36"/>
+  </g>
+  <g id="LWPOLYLINE-734" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1189.87" y="555.26" width=".96" height="1.91" transform="translate(-114.81 404.96) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-735" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1189.59 555.46 1190.2 557.28 1188.08 557.88 1187.77 556.07 1189.59 555.46"/>
+  </g>
+  <g id="LWPOLYLINE-736" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1190.75" y="554.81" width="1.92" height="1.91" transform="translate(-114.59 405.37) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-737" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1228.92 542.75 1229.22 544.27 1227.41 544.87 1226.8 543.36 1228.92 542.75"/>
+  </g>
+  <g id="LWPOLYLINE-738" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1224.99 543.96 1225.59 545.48 1227.41 544.87 1226.8 543.36 1224.99 543.96"/>
+  </g>
+  <g id="LWPOLYLINE-739" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1192.62" y1="554.86" x2="1224.99" y2="544.26"/>
+  </g>
+  <g id="LWPOLYLINE-740" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1192.92" y1="556.06" x2="1225.29" y2="545.18"/>
+  </g>
+  <g id="LWPOLYLINE-741" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1266.13" y1="537.91" x2="1118.5" y2="586.62"/>
+  </g>
+  <g id="LWPOLYLINE-742" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1119.1" y1="579.06" x2="1151.47" y2="568.47"/>
+  </g>
+  <g id="LWPOLYLINE-743" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1119.41" y1="579.96" x2="1151.78" y2="569.37"/>
+  </g>
+  <g id="LWPOLYLINE-744" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1151.17 568.17 1151.78 569.68 1153.59 569.07 1152.99 567.56 1151.17 568.17"/>
+  </g>
+  <g id="LWPOLYLINE-745" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1155.1 566.96 1155.71 568.47 1153.59 569.08 1152.98 567.56 1155.1 566.96"/>
+  </g>
+  <g id="LWPOLYLINE-746" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1187.78" y1="556.67" x2="1155.1" y2="567.26"/>
+  </g>
+  <g id="LWPOLYLINE-747" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1188.08" y1="557.58" x2="1155.41" y2="568.17"/>
+  </g>
+  <g id="LWPOLYLINE-748" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1361.73 668 1387.44 642.28 1385.93 641.08 1360.52 666.49"/>
+  </g>
+  <g id="LWPOLYLINE-749" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1362.64 668.6 1359.31 664.97 1356.28 661.04 1354.16 656.81 1352.66 651.96 1351.44 647.43 1351.14 642.28"/>
+  </g>
+  <g id="LWPOLYLINE-750" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1340.55 668 1315.14 642.28 1316.35 641.08 1341.76 666.49"/>
+  </g>
+  <g id="LWPOLYLINE-751" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1339.95 668.6 1343.27 664.97 1345.99 661.04 1348.42 656.81 1349.93 651.96 1350.84 647.43 1351.14 642.28"/>
+  </g>
+  <g id="LWPOLYLINE-752" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1435.24 612.94 1460.66 638.35 1459.44 639.56 1434.04 614.15"/>
+  </g>
+  <g id="LWPOLYLINE-753" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1435.85 612.03 1432.52 615.66 1429.8 619.9 1427.68 624.13 1425.87 628.67 1424.96 633.51 1424.66 638.35"/>
+  </g>
+  <g id="LWPOLYLINE-754" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1496.05" y1="638.35" x2="1496.05" y2="476.81"/>
+  </g>
+  <g id="LWPOLYLINE-755" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1499.98" y1="638.35" x2="1499.98" y2="475.59"/>
+  </g>
+  <g id="LWPOLYLINE-756" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1515.11 470.75 1489.7 478.92 1486.67 469.24"/>
+  </g>
+  <g id="LWPOLYLINE-757" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1509.66 468.03 1492.42 474.08 1490.3 468.03"/>
+  </g>
+  <g id="LWPOLYLINE-758" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1515.11" y1="470.75" x2="1511.78" y2="461.07"/>
+  </g>
+  <g id="LWPOLYLINE-759" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1509.66" y1="468.03" x2="1507.85" y2="462.28"/>
+  </g>
+  <g id="LWPOLYLINE-760" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1676.96 609.61 1702.37 635.02 1703.58 633.81 1678.17 608.4"/>
+  </g>
+  <g id="LWPOLYLINE-761" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1676.05 610.52 1679.68 607.19 1683.62 604.16 1688.15 602.05 1692.69 600.54 1697.54 599.33 1702.37 599.03"/>
+  </g>
+  <g id="LWPOLYLINE-762" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1601.33" y1="642.28" x2="1573.19" y2="652.57"/>
+  </g>
+  <g id="ARC-49" data-name="ARC">
+    <path class="cls-3" d="M1571.08,642.13c0,3.51.61,7,1.82,10.29"/>
+  </g>
+  <g id="LWPOLYLINE-763" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1755.62 555.16 1730.2 580.87 1731.41 582.08 1756.82 556.67"/>
+  </g>
+  <g id="LWPOLYLINE-764" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1755.01 554.55 1758.34 558.18 1761.06 562.12 1763.18 566.35 1764.99 571.19 1765.91 576.03 1766.2 580.87"/>
+  </g>
+  <g id="LWPOLYLINE-765" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1817.94" y1="584.81" x2="1817.94" y2="580.87"/>
+  </g>
+  <g id="LWPOLYLINE-766" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1766.2" y="580.87" width="1.51" height="3.94"/>
+  </g>
+  <g id="LWPOLYLINE-767" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1767.72" y1="582.99" x2="1816.42" y2="582.99"/>
+  </g>
+  <g id="LWPOLYLINE-768" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1767.72" y1="582.69" x2="1816.42" y2="582.69"/>
+  </g>
+  <g id="LWPOLYLINE-769" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1816.42" y="580.87" width="1.51" height="3.94"/>
+  </g>
+  <g id="LWPOLYLINE-770" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="627.46" x2="2049.37" y2="627.46"/>
+  </g>
+  <g id="LWPOLYLINE-771" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1961.33" y1="580.87" x2="2044.53" y2="580.87"/>
+  </g>
+  <g id="LWPOLYLINE-772" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1907.78 332.8 1901.13 334.92 1900.52 333.1"/>
+  </g>
+  <g id="LWPOLYLINE-773" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1907.79" y1="332.8" x2="1906.27" y2="327.66"/>
+  </g>
+  <g id="LWPOLYLINE-774" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="484.06" x2="2035.45" y2="456.84"/>
+  </g>
+  <g id="LWPOLYLINE-775" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2028.8 421.14 2024.26 422.65 2015.18 395.43"/>
+  </g>
+  <g id="LWPOLYLINE-776" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2049.37" y1="483.46" x2="2039.99" y2="455.32"/>
+  </g>
+  <g id="LWPOLYLINE-777" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2028.8" y1="421.14" x2="1996.12" y2="322.21"/>
+  </g>
+  <g id="LWPOLYLINE-778" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2084.46 375.15 2076.9 377.57 2046.34 285.3"/>
+  </g>
+  <g id="LWPOLYLINE-779" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2084.46" y1="375.15" x2="2061.17" y2="304.06"/>
+  </g>
+  <g id="LWPOLYLINE-780" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.53" y1="348.84" x2="2079.01" y2="344.3"/>
+  </g>
+  <g id="LWPOLYLINE-781" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2141.94 404.8 2145.87 370.92 2144.97 368.2"/>
+  </g>
+  <g id="LWPOLYLINE-782" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2138.01 332.2 2133.47 333.71 2132.86 331.59"/>
+  </g>
+  <g id="LWPOLYLINE-783" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2146.78 405.11 2150.71 370.31 2149.51 366.68"/>
+  </g>
+  <g id="LWPOLYLINE-784" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.01" y1="332.2" x2="2137.4" y2="330.08"/>
+  </g>
+  <g id="LWPOLYLINE-785" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2206.99 307.39 2114.71 337.64 2113.2 333.1"/>
+  </g>
+  <g id="LWPOLYLINE-786" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1950.74 555.16 1925.33 580.87 1926.54 582.08 1951.95 556.67"/>
+  </g>
+  <g id="LWPOLYLINE-787" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1950.14 554.55 1953.46 558.18 1956.19 562.12 1958.31 566.35 1960.12 571.19 1961.03 576.03 1961.33 580.87"/>
+  </g>
+  <g id="LWPOLYLINE-788" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.78 616.87 2049.37 591.46 2048.16 592.67 2073.57 618.08"/>
+  </g>
+  <g id="LWPOLYLINE-789" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2075.69 615.97 2072.06 619.29 2068.12 622.32 2063.58 624.44 2059.05 625.95 2054.2 627.15 2049.37 627.46"/>
+  </g>
+  <g id="LWPOLYLINE-790" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1273.69" y="1253.99" width="42.96" height="17.85"/>
+  </g>
+  <g id="LWPOLYLINE-791" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1120.92" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-792" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1123.64" y1="1264.58" x2="1157.22" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-793" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1123.64" y1="1263.37" x2="1157.22" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-794" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1121.83" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-795" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1272.49" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-796" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1270.67" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-797" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1196.55" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-798" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1197.76" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-799" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1194.73" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-800" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1157.22" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-801" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1159.34" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-802" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1194.73" y1="1264.58" x2="1161.15" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-803" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1194.73" y1="1263.37" x2="1161.15" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-804" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1270.67" y1="1264.58" x2="1237.09" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-805" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1270.67" y1="1263.37" x2="1237.09" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-806" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1234.97" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-807" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1233.15" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-808" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1199.57" y1="1264.58" x2="1233.16" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-809" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1199.57" y1="1263.37" x2="1233.16" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-810" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1120.92" y1="1257.62" x2="1273.69" y2="1257.62"/>
+  </g>
+  <g id="LWPOLYLINE-811" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1487.58 1263.07 1487.58 1266.7 1486.97 1266.7 1486.97 1258.84 1487.58 1258.84 1487.58 1262.46 1494.54 1262.46 1494.54 1258.84 1495.15 1258.84 1495.15 1266.7 1494.54 1266.7 1494.54 1263.07 1487.58 1263.07"/>
+  </g>
+  <g id="LWPOLYLINE-812" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1469.43" y="1253.99" width="42.96" height="17.85"/>
+  </g>
+  <g id="LWPOLYLINE-813" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1316.65 1267.91 1469.42 1267.91 1316.65 1267.91"/>
+  </g>
+  <g id="LWPOLYLINE-814" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1468.52" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-815" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1466.4" y1="1264.58" x2="1433.13" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-816" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1466.4" y1="1263.37" x2="1433.13" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-817" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1466.4" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-818" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1316.65" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-819" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1317.56" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-820" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1392.59" y="1263.06" width=".9" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-821" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1390.47" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-822" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1393.49" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-823" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1431" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-824" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1428.89" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-825" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1395.61" y1="1264.58" x2="1428.88" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-826" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1395.61" y1="1263.37" x2="1428.88" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-827" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1319.68" y1="1264.58" x2="1352.95" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-828" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1319.68" y1="1263.37" x2="1352.95" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-829" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1352.96" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-830" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1355.07" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-831" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1390.47" y1="1264.58" x2="1357.19" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-832" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1390.47" y1="1263.37" x2="1357.19" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-833" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1469.43" y1="1257.62" x2="1316.65" y2="1257.62"/>
+  </g>
+  <g id="LWPOLYLINE-834" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1512.39" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-835" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1515.41" y1="1264.58" x2="1548.99" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-836" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1515.41" y1="1263.37" x2="1548.99" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-837" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1513.6" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-838" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1664.26" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-839" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1662.44" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-840" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1588.32" y="1263.06" width="1.21" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-841" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1589.53" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-842" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1586.5" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-843" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1548.99" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-844" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1551.11" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-845" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1586.5" y1="1264.58" x2="1552.93" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-846" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1586.5" y1="1263.37" x2="1552.93" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-847" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1662.44" y1="1264.58" x2="1628.86" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-848" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1662.44" y1="1263.37" x2="1628.86" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-849" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1626.74" y="1263.06" width="2.12" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-850" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1624.92" y="1263.06" width="1.82" height="1.82"/>
+  </g>
+  <g id="LWPOLYLINE-851" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1591.35" y1="1264.58" x2="1624.92" y2="1264.58"/>
+  </g>
+  <g id="LWPOLYLINE-852" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1591.35" y1="1263.37" x2="1624.92" y2="1263.37"/>
+  </g>
+  <g id="LWPOLYLINE-853" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1512.39" y1="1257.62" x2="1665.47" y2="1257.62"/>
+  </g>
+  <g id="LWPOLYLINE-854" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1640.96" y1="1134.8" x2="1648.53" y2="1134.8"/>
+  </g>
+  <g id="LWPOLYLINE-855" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1684.52" y1="1134.8" x2="1719.32" y2="1134.8"/>
+  </g>
+  <g id="LWPOLYLINE-856" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1645.19" y1="1138.73" x2="1648.52" y2="1138.73"/>
+  </g>
+  <g id="LWPOLYLINE-857" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1673.93 1164.14 1648.52 1138.73 1649.73 1137.52 1675.45 1162.93"/>
+  </g>
+  <g id="LWPOLYLINE-858" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1673.33 1165.05 1676.66 1161.42 1679.38 1157.48 1681.8 1152.95 1683.31 1148.41 1684.22 1143.57 1684.52 1138.73"/>
+  </g>
+  <g id="LWPOLYLINE-859" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1665.46" y1="1253.99" x2="1665.46" y2="1237.65"/>
+  </g>
+  <g id="LWPOLYLINE-860" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1669.4" y1="1253.99" x2="1669.4" y2="1237.65"/>
+  </g>
+  <g id="LWPOLYLINE-861" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1890.84" y1="1233.72" x2="1885.7" y2="1233.72"/>
+  </g>
+  <g id="LWPOLYLINE-862" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1951.95 1166.86 1926.54 1141.45 1927.75 1139.94 1953.47 1165.66"/>
+  </g>
+  <g id="LWPOLYLINE-863" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1951.35 1167.47 1954.68 1164.14 1957.4 1159.9 1959.82 1155.67 1961.33 1151.13 1962.24 1146.3 1962.54 1141.45"/>
+  </g>
+  <g id="LWPOLYLINE-864" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2050.58" y1="1057.95" x2="2172.19" y2="1057.95"/>
+  </g>
+  <g id="LWPOLYLINE-865" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2048.46" y1="966.59" x2="2182.48" y2="966.59"/>
+  </g>
+  <g id="LWPOLYLINE-866" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2048.46" y1="962.66" x2="2182.78" y2="962.66"/>
+  </g>
+  <g id="LWPOLYLINE-867" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2075.99 1087 2050.58 1061.58 2049.36 1062.79 2074.78 1088.2"/>
+  </g>
+  <g id="LWPOLYLINE-868" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2076.9 1086.39 2073.27 1089.72 2069.33 1092.44 2064.8 1094.56 2060.26 1096.37 2055.42 1097.29 2050.57 1097.59"/>
+  </g>
+  <g id="LWPOLYLINE-869" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.17 1002.89 2048.46 1028.61 2047.25 1027.1 2072.66 1001.69"/>
+  </g>
+  <g id="LWPOLYLINE-870" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.78 1003.8 2071.15 1000.47 2067.21 997.75 2062.98 995.33 2058.14 993.82 2053.61 992.91 2048.46 992.31"/>
+  </g>
+  <g id="LWPOLYLINE-871" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.17 871.3 2048.46 845.58 2047.25 846.8 2072.66 872.5"/>
+  </g>
+  <g id="LWPOLYLINE-872" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.78 870.39 2071.15 873.71 2067.21 876.44 2062.98 878.86 2058.14 880.37 2053.61 881.28 2048.46 881.58"/>
+  </g>
+  <g id="LWPOLYLINE-873" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="956.31" x2="2048.46" y2="956.31"/>
+  </g>
+  <g id="LWPOLYLINE-874" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2044.53" y="881.58" width="3.93" height="1.51"/>
+  </g>
+  <g id="LWPOLYLINE-875" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2046.34" y1="883.09" x2="2046.34" y2="954.8"/>
+  </g>
+  <g id="LWPOLYLINE-876" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2046.64" y1="883.09" x2="2046.64" y2="954.8"/>
+  </g>
+  <g id="LWPOLYLINE-877" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2044.53" y="954.79" width="3.93" height="1.51"/>
+  </g>
+  <g id="LWPOLYLINE-878" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2087.79 812.61 2064.19 831.36 2063.29 830.15 2086.58 811.4"/>
+  </g>
+  <g id="LWPOLYLINE-879" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2088.09 813.21 2085.67 810.19 2082.64 807.46 2079.01 805.35 2075.39 803.53 2071.45 802.32 2067.52 801.41"/>
+  </g>
+  <g id="LWPOLYLINE-880" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2068.12" y1="795.97" x2="2101.4" y2="799.9"/>
+  </g>
+  <g id="LWPOLYLINE-881" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2069.03" y1="789.01" x2="2102.3" y2="792.94"/>
+  </g>
+  <g id="LWPOLYLINE-882" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2069.64" y1="782.05" x2="2103.22" y2="785.68"/>
+  </g>
+  <g id="LWPOLYLINE-883" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2070.54" y1="775.09" x2="2103.82" y2="778.72"/>
+  </g>
+  <g id="LWPOLYLINE-884" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2071.45" y1="768.13" x2="2104.72" y2="771.76"/>
+  </g>
+  <g id="LWPOLYLINE-885" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2072.06" y1="761.18" x2="2105.64" y2="764.81"/>
+  </g>
+  <g id="LWPOLYLINE-886" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2072.97" y1="754.22" x2="2089.6" y2="756.04"/>
+  </g>
+  <g id="LWPOLYLINE-887" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2086.88 797.78 2086.27 796.58 2085.06 795.97 2083.55 796.58 2082.95 797.78 2083.55 799.3 2085.06 799.9 2086.27 799.3 2086.88 797.78"/>
+  </g>
+  <g id="LWPOLYLINE-888" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.48 801.11 2073.57 809.58 2074.17 811.4 2075.08 812.6 2076.6 813.51 2077.8 813.51 2079.62 813.21 2080.84 812 2081.74 810.48 2082.64 802.01"/>
+  </g>
+  <g id="LWPOLYLINE-889" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2085.97 814.42 2087.18 802.32 2092.32 802.93 2093.83 803.53 2094.44 804.44 2094.75 805.65 2094.75 807.16 2093.83 808.37 2093.24 808.67 2091.42 809.28 2086.58 808.67"/>
+  </g>
+  <g id="LWPOLYLINE-890" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2094.75 770.55 2088.7 762.99 2081.13 769.04"/>
+  </g>
+  <g id="LWPOLYLINE-891" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2088.69" y1="762.99" x2="2084.76" y2="797.78"/>
+  </g>
+  <g id="LWPOLYLINE-892" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2105.64 764.81 2094.14 759.36 2090.21 762.09 2089.3 752.4 2085.37 755.13 2073.57 749.68"/>
+  </g>
+  <g id="LWPOLYLINE-893" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1893.87 754.82 1892.66 753.62 1890.54 753.01 1887.82 753.01 1886 753.62 1884.49 754.82 1884.49 756.34 1885.1 757.55 1886 758.15 1887.21 759.05 1891.15 760.27 1892.66 760.87 1893.26 761.48 1893.87 762.99 1893.87 764.8 1892.66 766.32 1890.54 766.92 1887.82 766.92 1886 766.32 1884.49 764.8"/>
+  </g>
+  <g id="LWPOLYLINE-894" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1902.64" y1="753.01" x2="1902.64" y2="766.93"/>
+  </g>
+  <g id="LWPOLYLINE-895" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1897.8" y1="753.01" x2="1907.18" y2="753.01"/>
+  </g>
+  <g id="LWPOLYLINE-896" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1909.9 766.92 1915.35 753.01 1920.49 766.92"/>
+  </g>
+  <g id="LWPOLYLINE-897" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1912.02" y1="762.39" x2="1918.68" y2="762.39"/>
+  </g>
+  <g id="LWPOLYLINE-898" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1924.73" y1="766.92" x2="1924.73" y2="753.01"/>
+  </g>
+  <g id="LWPOLYLINE-899" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1929.87 766.92 1929.87 753.01 1935.92 753.01 1938.04 753.61 1938.64 754.22 1939.25 755.43 1939.25 756.94 1938.64 758.15 1938.04 759.06 1935.92 759.67 1929.87 759.67"/>
+  </g>
+  <g id="LWPOLYLINE-900" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1934.71" y1="759.66" x2="1939.25" y2="766.92"/>
+  </g>
+  <g id="LWPOLYLINE-901" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1961.33" y1="753.01" x2="1961.33" y2="766.93"/>
+  </g>
+  <g id="LWPOLYLINE-902" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1956.8" y1="753.01" x2="1966.17" y2="753.01"/>
+  </g>
+  <g id="LWPOLYLINE-903" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1972.83 753.01 1971.31 753.61 1970.11 754.83 1969.5 756.34 1968.6 758.15 1968.6 761.48 1969.5 763.6 1970.11 764.81 1971.31 766.32 1972.83 766.93 1975.55 766.93 1976.77 766.32 1977.97 764.81 1978.88 763.6 1979.49 761.48 1979.49 758.15 1978.88 756.34 1977.97 754.83 1976.77 753.61 1975.55 753.01 1972.83 753.01"/>
+  </g>
+  <g id="LWPOLYLINE-904" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1893.26 788.71 1884.49 788.71 1884.49 774.79 1893.26 774.79"/>
+  </g>
+  <g id="LWPOLYLINE-905" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1884.49" y1="781.45" x2="1889.94" y2="781.45"/>
+  </g>
+  <g id="LWPOLYLINE-906" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1897.2 774.79 1897.2 788.71 1905.36 788.71"/>
+  </g>
+  <g id="LWPOLYLINE-907" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1917.16 788.71 1908.69 788.71 1908.69 774.79 1917.16 774.79"/>
+  </g>
+  <g id="LWPOLYLINE-908" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1908.69" y1="781.45" x2="1913.84" y2="781.45"/>
+  </g>
+  <g id="LWPOLYLINE-909" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1921.4 774.79 1926.54 788.71 1931.99 774.79"/>
+  </g>
+  <g id="LWPOLYLINE-910" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1935.31 787.5 1934.71 788.1 1935.31 788.7 1935.92 788.1"/>
+  </g>
+  <g id="LWPOLYLINE-911" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1954.07 788.71 1954.07 774.79 1959.52 788.71 1964.66 774.79 1964.66 788.71"/>
+  </g>
+  <g id="LWPOLYLINE-912" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1970.11 788.71 1975.54 774.79 1980.69 788.71"/>
+  </g>
+  <g id="LWPOLYLINE-913" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1971.92" y1="784.17" x2="1978.88" y2="784.17"/>
+  </g>
+  <g id="LWPOLYLINE-914" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1994.91 778.12 1994.01 776.91 1992.79 775.4 1991.59 774.79 1988.87 774.79 1987.35 775.4 1986.14 776.91 1985.53 778.12 1984.63 780.24 1984.63 783.56 1985.53 785.38 1986.14 786.89 1987.35 788.1 1988.87 788.71 1991.59 788.71 1992.79 788.1 1994.01 786.89 1994.91 785.38"/>
+  </g>
+  <g id="LWPOLYLINE-915" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1998.85" y1="788.71" x2="1998.85" y2="774.79"/>
+  </g>
+  <g id="LWPOLYLINE-916" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2008.22" y1="774.79" x2="2008.22" y2="788.71"/>
+  </g>
+  <g id="LWPOLYLINE-917" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1998.85" y1="781.45" x2="2008.22" y2="781.45"/>
+  </g>
+  <g id="LWPOLYLINE-918" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2014.27 787.5 2013.37 788.1 2014.27 788.7 2014.88 788.1"/>
+  </g>
+  <g id="LWPOLYLINE-919" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2032.73 788.71 2032.73 774.79 2038.78 774.79 2040.89 775.39 2041.5 776 2042.1 777.51 2042.1 778.73 2041.5 780.24 2040.89 780.84 2038.78 781.45 2032.73 781.45"/>
+  </g>
+  <g id="LWPOLYLINE-920" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2037.57" y1="781.45" x2="2042.11" y2="788.71"/>
+  </g>
+  <g id="LWPOLYLINE-921" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2046.95 788.71 2046.95 774.79 2052.09 788.71 2057.54 774.79 2057.54 788.71"/>
+  </g>
+  <g id="LWPOLYLINE-922" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2063.58 787.5 2062.98 788.1 2063.58 788.7 2064.19 788.1"/>
+  </g>
+  <g id="ARC-50" data-name="ARC">
+    <path class="cls-3" d="M1889.33,795.67c-5.93,5.13-6.58,14.1-1.44,20.03.45.51.93,1,1.44,1.44"/>
+  </g>
+  <g id="LWPOLYLINE-923" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1893.87 812.3 1893.87 798.38 1899.32 812.3 1904.46 798.38 1904.46 812.3"/>
+  </g>
+  <g id="LWPOLYLINE-924" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1918.68 812.3 1909.9 812.3 1909.9 798.38 1918.68 798.38"/>
+  </g>
+  <g id="LWPOLYLINE-925" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909.9" y1="805.04" x2="1915.35" y2="805.04"/>
+  </g>
+  <g id="LWPOLYLINE-926" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1922.61 798.39 1931.99 798.39 1922.61 812.31 1931.99 812.31"/>
+  </g>
+  <g id="LWPOLYLINE-927" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1935.92 798.39 1945.3 798.39 1935.92 812.31 1945.3 812.31"/>
+  </g>
+  <g id="LWPOLYLINE-928" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1950.14 811.09 1949.23 811.7 1950.14 812.3 1950.74 811.7"/>
+  </g>
+  <g id="LWPOLYLINE-929" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1974.64" y1="800.51" x2="1974.64" y2="812.3"/>
+  </g>
+  <g id="LWPOLYLINE-930" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1968.59" y1="806.56" x2="1980.69" y2="806.56"/>
+  </g>
+  <g id="LWPOLYLINE-931" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1994.91 802.93 1994.01 805.05 1992.79 806.56 1990.67 807.16 1990.07 807.16 1987.95 806.56 1986.75 805.05 1986.14 802.93 1986.14 802.32 1986.75 800.5 1987.95 798.99 1990.07 798.39 1990.67 798.39 1992.79 798.99 1994.01 800.5 1994.91 802.93 1994.91 806.56 1994.01 809.88 1992.79 811.7 1990.67 812.3 1989.47 812.3 1987.35 811.7 1986.75 810.49"/>
+  </g>
+  <g id="LWPOLYLINE-932" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2000.66 796.27 2000.05 797.17 1999.45 796.27 2000.05 795.66 2000.66 796.27 2000.66 797.78 2000.05 798.99 1999.45 799.6"/>
+  </g>
+  <g id="LWPOLYLINE-933" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2005.5" y1="806.56" x2="2017.61" y2="806.56"/>
+  </g>
+  <g id="LWPOLYLINE-934" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2029.4 812.3 2029.4 798.38 2022.75 807.76 2032.73 807.76"/>
+  </g>
+  <g id="LWPOLYLINE-935" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2037.57 796.27 2036.96 797.17 2036.06 796.27 2036.96 795.66 2037.57 796.27 2037.57 797.78 2036.96 798.99 2036.06 799.6"/>
+  </g>
+  <g id="LWPOLYLINE-936" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2041.5 796.27 2040.9 797.17 2040.29 796.27 2040.9 795.66 2041.5 796.27 2041.5 797.78 2040.9 798.99 2040.29 799.6"/>
+  </g>
+  <g id="ARC-51" data-name="ARC">
+    <path class="cls-3" d="M2046.34,817.14c5.93-5.65,6.16-15.04.51-20.97-.17-.17-.34-.34-.51-.51"/>
+  </g>
+  <g id="LWPOLYLINE-937" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2184.9,781.75l-5.75-.61s0,0,0,0c-1.46-.14-2.53-1.43-2.39-2.89"/>
+  </g>
+  <g id="SPLINE-29" data-name="SPLINE">
+    <path class="cls-3" d="M2186.73,773.89c-.75-.09-1.43.44-1.52,1.18"/>
+  </g>
+  <g id="LWPOLYLINE-938" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2187.01" y1="783.56" x2="2184.59" y2="783.26"/>
+  </g>
+  <g id="CIRCLE-19" data-name="CIRCLE">
+    <circle class="cls-3" cx="2183.54" cy="782.81" r=".75"/>
+  </g>
+  <g id="SPLINE-30" data-name="SPLINE">
+    <path class="cls-3" d="M2188.22,783.21c.05-.42-.25-.8-.65-.84"/>
+  </g>
+  <g id="LWPOLYLINE-939" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2187.01 782.96 2186.71 777.81 2186.11 777.81 2184.59 782.66"/>
+  </g>
+  <g id="LWPOLYLINE-940" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2175.23,782.34c-.09.75.45,1.44,1.2,1.53l18.15,2.42"/>
+  </g>
+  <g id="LWPOLYLINE-941" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2177.33" y1="767.53" x2="2175.52" y2="782.65"/>
+  </g>
+  <g id="ARC-52" data-name="ARC">
+    <path class="cls-3" d="M2178.56,766.03c-.75-.09-1.43.44-1.52,1.18,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-942" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2196.7" y1="768.44" x2="2178.55" y2="766.32"/>
+  </g>
+  <g id="ARC-53" data-name="ARC">
+    <path class="cls-3" d="M2197.59,769.66c.09-.75-.44-1.43-1.18-1.52,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-943" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2194.26,786.28c.75.09,1.44-.45,1.53-1.2,0,0,0,0,0,0l1.82-15.12"/>
+  </g>
+  <g id="LWPOLYLINE-944" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2177.03" y1="778.42" x2="2178.24" y2="769.95"/>
+  </g>
+  <g id="ARC-54" data-name="ARC">
+    <path class="cls-3" d="M2180.83,767.55c-1.41-.17-2.69.82-2.87,2.23"/>
+  </g>
+  <g id="LWPOLYLINE-945" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2180.97" y1="767.83" x2="2193.97" y2="769.35"/>
+  </g>
+  <g id="LWPOLYLINE-946" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2193.84,769.06s0,0,0,0c1.45.21,2.46,1.55,2.25,3l-.9,8.47s0,0,0,0c-.17,1.34-1.39,2.28-2.73,2.11l-5.75-.61"/>
+  </g>
+  <g id="LWPOLYLINE-947" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2003.38 440.5 2035.45 456.84 2036.35 455.32 2004.29 438.99"/>
+  </g>
+  <g id="LWPOLYLINE-948" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2002.78 441.41 2005.2 437.17 2008.22 433.24 2011.55 429.91 2015.48 426.89 2019.72 424.47 2024.26 422.65"/>
+  </g>
+  <g id="LWPOLYLINE-949" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2043.02 267.46 2091.72 251.73 2097.16 268.66 2048.45 284.4 2043.02 267.46"/>
+  </g>
+  <g id="LWPOLYLINE-950" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2063.28 270.48 2064.49 274.11 2064.19 274.11 2061.47 266.55 2062.08 266.55 2063.28 270.18 2069.94 267.76 2068.72 264.43 2069.03 264.12 2071.76 271.69 2071.15 272 2069.94 268.36 2063.28 270.48"/>
+  </g>
+  <g id="LWPOLYLINE-951" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="260.54 1086.39 244.81 1225.25 240.87 1224.95"/>
+  </g>
+  <g id="LWPOLYLINE-952" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.48" y1="1088.21" x2="256.6" y2="1086.09"/>
+  </g>
+  <g id="LWPOLYLINE-953" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.53" y1="1037.38" x2="262.36" y2="1034.96"/>
+  </g>
+  <g id="LWPOLYLINE-954" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="235.13" y1="1275.77" x2="240.88" y2="1224.95"/>
+  </g>
+  <g id="LWPOLYLINE-955" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="178.7" y="1160.11" width="96.52" height="29.23" transform="translate(-965.97 1266.52) rotate(-83.47)"/>
+  </g>
+  <g id="LWPOLYLINE-956" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="235.13 1223.13 208.2 1220.11 218.78 1126.33 245.72 1129.35 235.13 1223.13"/>
+  </g>
+  <g id="LWPOLYLINE-957" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.72" y1="1253.99" x2="303.19" y2="863.73"/>
+  </g>
+  <g id="LWPOLYLINE-958" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="266.59" y1="1130.56" x2="271.73" y2="1087.6"/>
+  </g>
+  <g id="LWPOLYLINE-959" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.48" y1="1036.78" x2="293.21" y2="897.92"/>
+  </g>
+  <g id="LWPOLYLINE-960" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="256.6" y1="1086.09" x2="262.35" y2="1034.96"/>
+  </g>
+  <g id="LWPOLYLINE-961" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="266.59 1035.26 282.32 896.41 278.38 896.1 284.13 845.88 336.47 828.64"/>
+  </g>
+  <g id="LWPOLYLINE-962" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="239.06 885.21 230.59 859.19 352.21 819.26"/>
+  </g>
+  <g id="LWPOLYLINE-963" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="239.06" y1="885.21" x2="281.1" y2="871.29"/>
+  </g>
+  <g id="LWPOLYLINE-964" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="93.85" y1="938.46" x2="111.39" y2="932.71"/>
+  </g>
+  <g id="LWPOLYLINE-965" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="198.22" y1="904.27" x2="270.52" y2="880.37"/>
+  </g>
+  <g id="LWPOLYLINE-966" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="93.85" y1="939.36" x2="111.69" y2="933.61"/>
+  </g>
+  <g id="LWPOLYLINE-967" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="198.52" y1="905.18" x2="270.83" y2="881.28"/>
+  </g>
+  <g id="LWPOLYLINE-968" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M530.39,769.04l144.31-47.49-144.31,47.49Z"/>
+  </g>
+  <g id="LWPOLYLINE-969" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="676.51" y1="727.29" x2="532.2" y2="774.79"/>
+  </g>
+  <g id="LWPOLYLINE-970" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="604.21" y1="747.26" x2="604.51" y2="746.36"/>
+  </g>
+  <g id="LWPOLYLINE-971" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="604.51 746.35 607.84 748.17 609.65 744.54"/>
+  </g>
+  <g id="LWPOLYLINE-972" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="609.65 744.54 612.98 746.35 614.49 743.03"/>
+  </g>
+  <g id="LWPOLYLINE-973" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="614.49 743.02 618.12 744.84 619.64 741.51"/>
+  </g>
+  <g id="LWPOLYLINE-974" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="619.64 741.51 622.96 743.02 624.78 739.7"/>
+  </g>
+  <g id="LWPOLYLINE-975" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="624.78 739.7 628.1 741.51 629.92 738.19"/>
+  </g>
+  <g id="LWPOLYLINE-976" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="629.92 738.18 633.25 739.7 634.76 736.37"/>
+  </g>
+  <g id="LWPOLYLINE-977" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="634.76 736.37 638.09 738.18 639.91 734.86"/>
+  </g>
+  <g id="LWPOLYLINE-978" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="639.9 734.86 643.23 736.37 645.05 733.04"/>
+  </g>
+  <g id="LWPOLYLINE-979" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="645.05 733.04 648.37 734.86 649.89 731.53"/>
+  </g>
+  <g id="LWPOLYLINE-980" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="649.89 731.53 653.21 733.34 655.03 729.71"/>
+  </g>
+  <g id="LWPOLYLINE-981" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="655.03 729.71 658.36 731.53 660.18 728.2"/>
+  </g>
+  <g id="LWPOLYLINE-982" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="660.17 728.2 663.5 730.02 665.02 726.69"/>
+  </g>
+  <g id="LWPOLYLINE-983" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="665.01 726.69 668.64 728.2 670.16 724.87"/>
+  </g>
+  <g id="LWPOLYLINE-984" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="670.16 724.87 673.48 726.69 673.79 725.78"/>
+  </g>
+  <g id="LWPOLYLINE-985" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="676.21 726.39 674.39 726.99 672.58 722.16 674.69 721.55 676.21 726.39"/>
+  </g>
+  <g id="LWPOLYLINE-986" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="605.11 749.68 602.99 750.29 601.48 745.75 603.6 745.14 605.11 749.68"/>
+  </g>
+  <g id="LWPOLYLINE-987" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="533.72 773.28 531.9 773.88 530.39 769.05 532.2 768.44 533.72 773.28"/>
+  </g>
+  <g id="LWPOLYLINE-988" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="674.39" y1="726.99" x2="531.9" y2="773.88"/>
+  </g>
+  <g id="LWPOLYLINE-989" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="672.58" y1="722.15" x2="530.39" y2="769.04"/>
+  </g>
+  <g id="LWPOLYLINE-990" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="533.11" y1="770.86" x2="533.72" y2="769.34"/>
+  </g>
+  <g id="LWPOLYLINE-991" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="533.72 769.34 537.04 771.16 538.86 767.83"/>
+  </g>
+  <g id="LWPOLYLINE-992" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="538.86 767.84 542.19 769.34 544.01 766.02"/>
+  </g>
+  <g id="LWPOLYLINE-993" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="544 766.02 547.33 767.83 548.85 764.51"/>
+  </g>
+  <g id="LWPOLYLINE-994" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="548.84 764.5 552.17 766.32 553.99 762.69"/>
+  </g>
+  <g id="LWPOLYLINE-995" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="553.99 762.69 557.31 764.5 559.13 761.18"/>
+  </g>
+  <g id="LWPOLYLINE-996" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="559.13 761.17 562.46 762.99 563.97 759.66"/>
+  </g>
+  <g id="LWPOLYLINE-997" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="563.97 759.66 567.6 761.18 569.11 757.85"/>
+  </g>
+  <g id="LWPOLYLINE-998" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="569.11 757.85 572.44 759.66 574.26 756.34"/>
+  </g>
+  <g id="LWPOLYLINE-999" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="574.26 756.33 577.58 757.85 579.4 754.52"/>
+  </g>
+  <g id="LWPOLYLINE-1000" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="579.4 754.52 582.73 756.34 584.24 753.01"/>
+  </g>
+  <g id="LWPOLYLINE-1001" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="584.24 753.01 587.57 754.52 589.38 751.19"/>
+  </g>
+  <g id="LWPOLYLINE-1002" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="589.38 751.19 592.71 753.01 594.53 749.68"/>
+  </g>
+  <g id="LWPOLYLINE-1003" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="594.53 749.68 597.85 751.19 599.37 747.87"/>
+  </g>
+  <g id="LWPOLYLINE-1004" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="599.37 747.86 602.69 749.68 603 749.68"/>
+  </g>
+  <g id="LWPOLYLINE-1005" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="880.41" y1="668.6" x2="911.27" y2="762.39"/>
+  </g>
+  <g id="LWPOLYLINE-1006" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="884.34" y1="667.09" x2="895.84" y2="702.49"/>
+  </g>
+  <g id="LWPOLYLINE-1007" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="900.38" y1="716.71" x2="911.27" y2="749.68"/>
+  </g>
+  <g id="LWPOLYLINE-1008" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="870.73" y1="657.11" x2="867.71" y2="658.01"/>
+  </g>
+  <g id="LWPOLYLINE-1009" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="835.64" y1="668.6" x2="758.19" y2="694.32"/>
+  </g>
+  <g id="LWPOLYLINE-1010" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="726.12" y1="704.61" x2="723.1" y2="705.81"/>
+  </g>
+  <g id="LWPOLYLINE-1011" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="871.64 660.13 872.24 661.65 871.33 661.95 870.73 660.44 871.64 660.13"/>
+  </g>
+  <g id="LWPOLYLINE-1012" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="870.73 660.44 871.34 661.95 869.22 662.56 868.61 661.04 870.73 660.44"/>
+  </g>
+  <g id="LWPOLYLINE-1013" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="724.28" y="708.34" width=".96" height="1.92" transform="translate(-187.11 265.59) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1014" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="724.91 708.24 725.52 710.05 727.34 709.14 727.03 707.63 724.91 708.24"/>
+  </g>
+  <g id="LWPOLYLINE-1015" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="798.43 684.03 798.73 685.85 797.82 686.15 797.52 684.34 798.43 684.03"/>
+  </g>
+  <g id="LWPOLYLINE-1016" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="797.52 684.34 797.82 686.15 796 686.76 795.4 684.94 797.52 684.34"/>
+  </g>
+  <g id="LWPOLYLINE-1017" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="798.43 684.03 798.73 685.85 800.85 685.24 800.24 683.43 798.43 684.03"/>
+  </g>
+  <g id="LWPOLYLINE-1018" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="836.54 671.63 837.15 673.14 835.34 673.75 834.73 672.23 836.54 671.63"/>
+  </g>
+  <g id="LWPOLYLINE-1019" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="832.91 672.84 833.52 674.35 835.34 673.74 834.73 672.23 832.91 672.84"/>
+  </g>
+  <g id="LWPOLYLINE-1020" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.24" y1="683.73" x2="832.91" y2="673.14"/>
+  </g>
+  <g id="LWPOLYLINE-1021" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.54" y1="684.94" x2="833.22" y2="674.05"/>
+  </g>
+  <g id="LWPOLYLINE-1022" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="873.76" y1="667.09" x2="871.03" y2="668"/>
+  </g>
+  <g id="LWPOLYLINE-1023" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="838.96" y1="678.59" x2="835.03" y2="679.79"/>
+  </g>
+  <g id="LWPOLYLINE-1024" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="765.15" y1="702.79" x2="761.22" y2="704"/>
+  </g>
+  <g id="LWPOLYLINE-1025" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="729.15" y1="714.59" x2="726.43" y2="715.49"/>
+  </g>
+  <g id="LWPOLYLINE-1026" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="759.1 697.04 759.7 698.86 761.52 697.95 760.92 696.44 759.1 697.04"/>
+  </g>
+  <g id="LWPOLYLINE-1027" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="762.73 695.83 763.33 697.35 761.52 697.95 760.91 696.44 762.73 695.83"/>
+  </g>
+  <g id="LWPOLYLINE-1028" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="795.7" y1="685.55" x2="763.03" y2="696.14"/>
+  </g>
+  <g id="LWPOLYLINE-1029" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="796.01" y1="686.45" x2="763.33" y2="697.04"/>
+  </g>
+  <g id="LWPOLYLINE-1030" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1480.62 461.98 1481.83 465.61 1481.23 465.91 1478.8 458.35 1479.11 458.04 1480.32 461.68 1487.27 459.56 1486.07 455.93 1486.37 455.62 1488.78 463.19 1488.49 463.49 1487.27 459.86 1480.62 461.98"/>
+  </g>
+  <g id="LWPOLYLINE-1031" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1457.63 460.16 1506.33 444.14 1511.78 461.07 1463.08 476.8 1457.63 460.16"/>
+  </g>
+  <g id="LWPOLYLINE-1032" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.51" y1="512.2" x2="1458.83" y2="463.79"/>
+  </g>
+  <g id="LWPOLYLINE-1033" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1312.42 515.23 1312.72 516.74 1313.93 516.43 1313.32 514.92 1312.42 515.23"/>
+  </g>
+  <g id="LWPOLYLINE-1034" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1315.14" y1="514.62" x2="1347.51" y2="504.03"/>
+  </g>
+  <g id="LWPOLYLINE-1035" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1315.74" y1="515.53" x2="1347.81" y2="504.94"/>
+  </g>
+  <g id="LWPOLYLINE-1036" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1313.32 514.92 1313.93 516.44 1315.75 515.83 1315.14 514.32 1313.32 514.92"/>
+  </g>
+  <g id="LWPOLYLINE-1037" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1459.75 466.82 1460.35 468.33 1459.44 468.64 1458.84 467.12 1459.75 466.82"/>
+  </g>
+  <g id="LWPOLYLINE-1038" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1458.84 467.12 1459.44 468.64 1457.63 469.24 1457.02 467.73 1458.84 467.12"/>
+  </g>
+  <g id="LWPOLYLINE-1039" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1385.91" y="490.82" width=".96" height="1.92" transform="translate(-84.37 463.65) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1040" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1386.79" y="490.37" width="1.92" height="1.91" transform="translate(-84.16 464.06) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1041" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1385.63 491.02 1386.23 492.84 1384.11 493.45 1383.81 491.63 1385.63 491.02"/>
+  </g>
+  <g id="LWPOLYLINE-1042" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1347.21 503.73 1347.81 505.24 1349.63 504.63 1349.33 503.12 1347.21 503.73"/>
+  </g>
+  <g id="LWPOLYLINE-1043" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1351.14 502.52 1351.75 504.03 1349.63 504.64 1349.32 503.12 1351.14 502.52"/>
+  </g>
+  <g id="LWPOLYLINE-1044" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1383.81" y1="491.93" x2="1351.14" y2="502.81"/>
+  </g>
+  <g id="LWPOLYLINE-1045" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1384.11" y1="493.14" x2="1351.44" y2="503.73"/>
+  </g>
+  <g id="LWPOLYLINE-1046" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1314.53" y1="522.18" x2="1462.17" y2="473.48"/>
+  </g>
+  <g id="LWPOLYLINE-1047" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1457.02" y1="468.03" x2="1424.96" y2="478.62"/>
+  </g>
+  <g id="LWPOLYLINE-1048" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1457.33" y1="468.94" x2="1425.26" y2="479.53"/>
+  </g>
+  <g id="LWPOLYLINE-1049" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1424.96 478.32 1425.56 479.83 1423.44 480.44 1422.84 478.92 1424.96 478.32"/>
+  </g>
+  <g id="LWPOLYLINE-1050" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1421.02 479.53 1421.63 481.04 1423.45 480.43 1422.84 478.92 1421.02 479.53"/>
+  </g>
+  <g id="LWPOLYLINE-1051" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1388.65" y1="490.42" x2="1421.32" y2="479.83"/>
+  </g>
+  <g id="LWPOLYLINE-1052" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1388.96" y1="491.32" x2="1421.63" y2="480.73"/>
+  </g>
+  <g id="LWPOLYLINE-1053" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1702.37 379.69 1653.67 395.42 1659.41 412.36 1707.82 396.63 1702.37 379.69"/>
+  </g>
+  <g id="LWPOLYLINE-1054" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1684.22 395.12 1685.43 398.75 1685.73 398.45 1683.32 390.89 1683.01 391.19 1684.22 394.82 1677.26 396.94 1676.05 393.3 1675.75 393.61 1678.17 401.17 1678.77 400.87 1677.57 397.24 1684.22 395.12"/>
+  </g>
+  <g id="LWPOLYLINE-1055" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1654.88" y1="399.36" x2="1507.54" y2="447.76"/>
+  </g>
+  <g id="LWPOLYLINE-1056" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1656.08 402.08 1656.39 403.9 1655.48 404.2 1654.88 402.68 1656.08 402.08"/>
+  </g>
+  <g id="LWPOLYLINE-1057" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1653.06" y1="403.59" x2="1620.99" y2="414.18"/>
+  </g>
+  <g id="LWPOLYLINE-1058" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1653.36" y1="404.5" x2="1621.29" y2="415.09"/>
+  </g>
+  <g id="LWPOLYLINE-1059" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1654.88 402.68 1655.48 404.2 1653.67 404.8 1653.06 403.29 1654.88 402.68"/>
+  </g>
+  <g id="LWPOLYLINE-1060" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1508.45 450.79 1509.06 452.3 1509.97 451.99 1509.36 450.48 1508.45 450.79"/>
+  </g>
+  <g id="LWPOLYLINE-1061" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1509.36 450.48 1509.96 452 1511.78 451.39 1511.18 449.88 1509.36 450.48"/>
+  </g>
+  <g id="LWPOLYLINE-1062" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1581.94" y="426.38" width=".96" height="1.91" transform="translate(-53.93 522.34) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1063" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1580.1" y="426.84" width="1.91" height="1.92" transform="translate(-54.15 521.93) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1064" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1582.57 426.28 1583.18 428.1 1584.99 427.49 1584.69 425.68 1582.57 426.28"/>
+  </g>
+  <g id="LWPOLYLINE-1065" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1620.99 413.58 1621.6 415.39 1619.48 416 1619.17 414.48 1620.99 413.58"/>
+  </g>
+  <g id="LWPOLYLINE-1066" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1617.06 415.09 1617.67 416.6 1619.48 415.99 1619.18 414.48 1617.06 415.09"/>
+  </g>
+  <g id="LWPOLYLINE-1067" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1584.69" y1="425.98" x2="1617.36" y2="415.39"/>
+  </g>
+  <g id="LWPOLYLINE-1068" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1584.99" y1="426.89" x2="1617.66" y2="416.3"/>
+  </g>
+  <g id="LWPOLYLINE-1069" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1658.2" y1="409.04" x2="1510.57" y2="457.74"/>
+  </g>
+  <g id="LWPOLYLINE-1070" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1511.48" y1="450.18" x2="1543.54" y2="439.59"/>
+  </g>
+  <g id="LWPOLYLINE-1071" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1511.78" y1="451.09" x2="1543.85" y2="440.5"/>
+  </g>
+  <g id="LWPOLYLINE-1072" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1543.24 439.29 1543.85 440.81 1545.96 440.19 1545.36 438.69 1543.24 439.29"/>
+  </g>
+  <g id="LWPOLYLINE-1073" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1547.17 438.08 1547.78 439.59 1545.97 440.2 1545.36 438.69 1547.17 438.08"/>
+  </g>
+  <g id="LWPOLYLINE-1074" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1579.85" y1="427.49" x2="1547.17" y2="438.39"/>
+  </g>
+  <g id="LWPOLYLINE-1075" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1580.15" y1="428.7" x2="1547.48" y2="439.29"/>
+  </g>
+  <g id="LWPOLYLINE-1076" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1880.26 330.68 1881.46 334.31 1882.07 334.01 1879.35 326.44 1879.05 326.75 1880.26 330.38 1873.3 332.5 1872.39 328.87 1871.79 328.87 1874.21 336.73 1874.81 336.43 1873.6 332.8 1880.26 330.68"/>
+  </g>
+  <g id="LWPOLYLINE-1077" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1898.41 315.26 1849.7 330.99 1855.45 347.93 1903.85 331.89 1898.41 315.26"/>
+  </g>
+  <g id="LWPOLYLINE-1078" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1703.58" y1="383.32" x2="1851.21" y2="334.92"/>
+  </g>
+  <g id="LWPOLYLINE-1079" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1704.49 386.35 1705.09 387.86 1706 387.56 1705.39 386.05 1704.49 386.35"/>
+  </g>
+  <g id="LWPOLYLINE-1080" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1707.51" y1="385.74" x2="1739.58" y2="375.15"/>
+  </g>
+  <g id="LWPOLYLINE-1081" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1707.82" y1="386.65" x2="1739.88" y2="376.06"/>
+  </g>
+  <g id="LWPOLYLINE-1082" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1705.4 386.05 1706 387.56 1707.82 386.95 1707.21 385.44 1705.4 386.05"/>
+  </g>
+  <g id="LWPOLYLINE-1083" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1852.12 337.64 1852.42 339.46 1851.51 339.76 1850.91 337.94 1852.12 337.64"/>
+  </g>
+  <g id="LWPOLYLINE-1084" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1850.91 337.95 1851.52 339.76 1849.7 340.37 1849.09 338.85 1850.91 337.95"/>
+  </g>
+  <g id="LWPOLYLINE-1085" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1777.98" y="361.94" width=".96" height="1.92" transform="translate(-23.5 581.02) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1086" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1778.61 361.84 1779.21 363.66 1781.03 362.75 1780.73 361.24 1778.61 361.84"/>
+  </g>
+  <g id="LWPOLYLINE-1087" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1776.14" y="362.4" width="1.91" height="1.92" transform="translate(-23.71 580.61) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1088" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1739.58 374.85 1739.88 376.37 1742 375.76 1741.4 374.25 1739.58 374.85"/>
+  </g>
+  <g id="LWPOLYLINE-1089" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1743.21 373.64 1743.82 375.16 1742.01 375.76 1741.4 374.25 1743.21 373.64"/>
+  </g>
+  <g id="LWPOLYLINE-1090" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1775.89" y1="363.05" x2="1743.52" y2="373.95"/>
+  </g>
+  <g id="LWPOLYLINE-1091" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1776.19" y1="363.96" x2="1743.82" y2="374.85"/>
+  </g>
+  <g id="LWPOLYLINE-1092" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1706.61" y1="392.7" x2="1854.24" y2="344.29"/>
+  </g>
+  <g id="LWPOLYLINE-1093" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1849.4" y1="339.15" x2="1817.03" y2="349.74"/>
+  </g>
+  <g id="LWPOLYLINE-1094" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1849.7" y1="340.06" x2="1817.33" y2="350.65"/>
+  </g>
+  <g id="LWPOLYLINE-1095" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1815.47" y="349.39" width="1.91" height="1.92" transform="translate(-17.58 592.38) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-1096" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1813.1 350.65 1813.7 352.17 1815.82 351.55 1815.22 349.75 1813.1 350.65"/>
+  </g>
+  <g id="LWPOLYLINE-1097" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1780.73" y1="361.54" x2="1813.4" y2="350.95"/>
+  </g>
+  <g id="LWPOLYLINE-1098" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1781.03" y1="362.45" x2="1813.7" y2="351.86"/>
+  </g>
+  <g id="LWPOLYLINE-1099" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="250.25 1268.51 246.62 1267.9 246.62 1268.51 254.48 1269.41 254.48 1268.81 250.86 1268.51 251.46 1261.55 255.4 1261.86 255.4 1261.55 247.53 1260.65 247.23 1260.94 251.16 1261.55 250.25 1268.51"/>
+  </g>
+  <g id="LWPOLYLINE-1100" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="303.19" y1="863.73" x2="343.73" y2="850.42"/>
+  </g>
+  <g id="LWPOLYLINE-1101" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="529.18 765.41 480.47 781.14 486.82 800.21 535.53 784.17 529.18 765.41"/>
+  </g>
+  <g id="LWPOLYLINE-1102" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="753.05 679.19 720.98 689.78 732.48 724.26 764.54 713.68 753.05 679.19"/>
+  </g>
+  <g id="LWPOLYLINE-1103" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="752.44 680.4 722.19 690.38 733.08 723.06 763.34 713.07 752.44 680.4"/>
+  </g>
+  <g id="LWPOLYLINE-1104" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="840.78 697.04 833.52 674.35 763.33 697.34 770.9 720.04 840.78 697.04"/>
+  </g>
+  <g id="LWPOLYLINE-1105" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="839.57 696.44 832.61 675.86 764.54 698.25 771.5 718.83 839.57 696.44"/>
+  </g>
+  <g id="LWPOLYLINE-1106" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="830.8 653.78 862.86 643.19 874.36 677.68 841.99 688.27 830.8 653.78"/>
+  </g>
+  <g id="LWPOLYLINE-1107" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="832.01 654.39 862.26 644.41 872.85 677.08 842.6 686.76 832.01 654.39"/>
+  </g>
+  <g id="LWPOLYLINE-1108" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="841.08 674.05 845.62 661.95 850.16 674.05"/>
+  </g>
+  <g id="LWPOLYLINE-1109" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="842.9" y1="670.12" x2="848.34" y2="670.12"/>
+  </g>
+  <g id="LWPOLYLINE-1110" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="862.26 664.97 861.65 663.77 860.44 662.55 859.23 661.95 857.11 661.95 855.91 662.55 854.69 663.77 854.09 664.97 853.79 666.79 853.79 669.52 854.09 671.32 854.69 672.23 855.91 673.44 857.11 674.05 859.23 674.05 860.44 673.44 861.65 672.23 862.26 671.32"/>
+  </g>
+  <g id="LWPOLYLINE-1111" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="731.57 707.63 736.11 695.53 740.65 707.63"/>
+  </g>
+  <g id="LWPOLYLINE-1112" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="733.38" y1="703.7" x2="739.13" y2="703.7"/>
+  </g>
+  <g id="LWPOLYLINE-1113" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="752.75 698.55 752.14 697.35 750.93 696.13 750.02 695.53 747.6 695.53 746.39 696.13 745.18 697.35 744.58 698.55 744.27 700.37 744.27 703.09 744.58 704.91 745.18 705.82 746.39 707.03 747.6 707.63 750.02 707.63 750.93 707.03 752.14 705.82 752.75 704.91"/>
+  </g>
+  <g id="LWPOLYLINE-1114" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="660.13" x2="921.86" y2="658.01"/>
+  </g>
+  <g id="LWPOLYLINE-1115" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="924.88" y1="657.11" x2="930.33" y2="655.29"/>
+  </g>
+  <g id="LWPOLYLINE-1116" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="933.35" y1="654.39" x2="939.1" y2="652.27"/>
+  </g>
+  <g id="LWPOLYLINE-1117" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="941.82" y1="651.36" x2="947.57" y2="649.54"/>
+  </g>
+  <g id="LWPOLYLINE-1118" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="950.29" y1="648.64" x2="956.04" y2="646.82"/>
+  </g>
+  <g id="LWPOLYLINE-1119" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="959.07" y1="645.91" x2="964.82" y2="644.1"/>
+  </g>
+  <g id="LWPOLYLINE-1120" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="967.54" y1="642.89" x2="973.29" y2="641.07"/>
+  </g>
+  <g id="LWPOLYLINE-1121" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="976.01" y1="640.17" x2="981.76" y2="638.35"/>
+  </g>
+  <g id="LWPOLYLINE-1122" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="984.78" y1="637.44" x2="990.53" y2="635.63"/>
+  </g>
+  <g id="LWPOLYLINE-1123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="993.25" y1="634.72" x2="999" y2="632.6"/>
+  </g>
+  <g id="LWPOLYLINE-1124" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1001.72" y1="631.7" x2="1007.47" y2="629.88"/>
+  </g>
+  <g id="LWPOLYLINE-1125" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1010.5" y1="628.97" x2="1016.85" y2="626.85"/>
+  </g>
+  <g id="LWPOLYLINE-1126" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="915.5" y1="666.49" x2="918.53" y2="665.58"/>
+  </g>
+  <g id="LWPOLYLINE-1127" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="921.25" y1="664.67" x2="927" y2="662.55"/>
+  </g>
+  <g id="LWPOLYLINE-1128" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="930.02" y1="661.65" x2="935.77" y2="659.83"/>
+  </g>
+  <g id="LWPOLYLINE-1129" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="938.5" y1="658.92" x2="944.25" y2="657.11"/>
+  </g>
+  <g id="LWPOLYLINE-1130" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="946.97" y1="656.2" x2="952.72" y2="654.08"/>
+  </g>
+  <g id="LWPOLYLINE-1131" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="955.74" y1="653.18" x2="961.49" y2="651.36"/>
+  </g>
+  <g id="LWPOLYLINE-1132" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="964.21" y1="650.45" x2="969.96" y2="648.64"/>
+  </g>
+  <g id="LWPOLYLINE-1133" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="972.68" y1="647.73" x2="978.43" y2="645.61"/>
+  </g>
+  <g id="LWPOLYLINE-1134" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="981.45" y1="644.7" x2="987.2" y2="642.89"/>
+  </g>
+  <g id="LWPOLYLINE-1135" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="989.93" y1="641.98" x2="995.68" y2="640.16"/>
+  </g>
+  <g id="LWPOLYLINE-1136" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="998.39" y1="639.26" x2="1004.14" y2="637.44"/>
+  </g>
+  <g id="LWPOLYLINE-1137" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1007.17" y1="636.23" x2="1012.92" y2="634.42"/>
+  </g>
+  <g id="LWPOLYLINE-1138" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1015.64 633.51 1018.66 632.61 1016.85 626.86"/>
+  </g>
+  <g id="LWPOLYLINE-1139" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1298.5" y1="534.28" x2="1293.96" y2="535.8"/>
+  </g>
+  <g id="LWPOLYLINE-1140" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1291.24" y1="536.7" x2="1285.49" y2="538.52"/>
+  </g>
+  <g id="LWPOLYLINE-1141" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1282.47" y1="539.43" x2="1276.72" y2="541.24"/>
+  </g>
+  <g id="LWPOLYLINE-1142" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1274" y1="542.45" x2="1268.25" y2="544.27"/>
+  </g>
+  <g id="LWPOLYLINE-1143" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1265.52" y1="545.18" x2="1259.77" y2="546.99"/>
+  </g>
+  <g id="LWPOLYLINE-1144" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1256.75" y1="547.9" x2="1251" y2="549.71"/>
+  </g>
+  <g id="LWPOLYLINE-1145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1248.28" y1="550.62" x2="1242.53" y2="552.74"/>
+  </g>
+  <g id="LWPOLYLINE-1146" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1239.81" y1="553.64" x2="1234.06" y2="555.46"/>
+  </g>
+  <g id="LWPOLYLINE-1147" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1231.04" y1="556.37" x2="1225.29" y2="558.18"/>
+  </g>
+  <g id="LWPOLYLINE-1148" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1222.57" y1="559.09" x2="1216.82" y2="561.21"/>
+  </g>
+  <g id="LWPOLYLINE-1149" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1214.1" y1="562.12" x2="1208.35" y2="563.93"/>
+  </g>
+  <g id="LWPOLYLINE-1150" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1205.32" y1="564.84" x2="1199.57" y2="566.66"/>
+  </g>
+  <g id="LWPOLYLINE-1151" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1196.85" y1="567.56" x2="1191.1" y2="569.38"/>
+  </g>
+  <g id="LWPOLYLINE-1152" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1188.38" y1="570.59" x2="1182.63" y2="572.4"/>
+  </g>
+  <g id="LWPOLYLINE-1153" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1179.61" y1="573.31" x2="1175.38" y2="574.82"/>
+  </g>
+  <g id="LWPOLYLINE-1154" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1298.5" y1="540.64" x2="1294.87" y2="541.84"/>
+  </g>
+  <g id="LWPOLYLINE-1155" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1292.15" y1="542.75" x2="1286.4" y2="544.57"/>
+  </g>
+  <g id="LWPOLYLINE-1156" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1283.37" y1="545.48" x2="1277.62" y2="547.3"/>
+  </g>
+  <g id="LWPOLYLINE-1157" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1274.9" y1="548.2" x2="1269.15" y2="550.32"/>
+  </g>
+  <g id="LWPOLYLINE-1158" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1266.43" y1="551.22" x2="1260.68" y2="553.04"/>
+  </g>
+  <g id="LWPOLYLINE-1159" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1257.66" y1="553.95" x2="1252.21" y2="555.76"/>
+  </g>
+  <g id="LWPOLYLINE-1160" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.19" y1="556.67" x2="1243.44" y2="558.79"/>
+  </g>
+  <g id="LWPOLYLINE-1161" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1240.72" y1="559.7" x2="1234.97" y2="561.51"/>
+  </g>
+  <g id="LWPOLYLINE-1162" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1231.94" y1="562.42" x2="1226.5" y2="564.24"/>
+  </g>
+  <g id="LWPOLYLINE-1163" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1223.47" y1="565.14" x2="1217.72" y2="566.96"/>
+  </g>
+  <g id="LWPOLYLINE-1164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1215" y1="568.17" x2="1209.25" y2="569.98"/>
+  </g>
+  <g id="LWPOLYLINE-1165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1206.23" y1="570.89" x2="1200.78" y2="572.7"/>
+  </g>
+  <g id="LWPOLYLINE-1166" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1197.76" y1="573.61" x2="1192.01" y2="575.43"/>
+  </g>
+  <g id="LWPOLYLINE-1167" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1189.29" y1="576.33" x2="1183.54" y2="578.45"/>
+  </g>
+  <g id="LWPOLYLINE-1168" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1180.82 579.36 1177.19 580.57 1175.37 574.82"/>
+  </g>
+  <g id="LWPOLYLINE-1169" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.4" y1="538.22" x2="1290.63" y2="536.7"/>
+  </g>
+  <g id="LWPOLYLINE-1170" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1293.66" y1="535.79" x2="1299.41" y2="533.98"/>
+  </g>
+  <g id="LWPOLYLINE-1171" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.13" y1="533.07" x2="1307.88" y2="531.25"/>
+  </g>
+  <g id="LWPOLYLINE-1172" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1310.6" y1="530.35" x2="1316.35" y2="528.23"/>
+  </g>
+  <g id="LWPOLYLINE-1173" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1319.37" y1="527.33" x2="1325.12" y2="525.51"/>
+  </g>
+  <g id="LWPOLYLINE-1174" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1327.85" y1="524.6" x2="1333.6" y2="522.79"/>
+  </g>
+  <g id="LWPOLYLINE-1175" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1336.32" y1="521.88" x2="1342.07" y2="519.76"/>
+  </g>
+  <g id="LWPOLYLINE-1176" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1345.09" y1="518.85" x2="1350.84" y2="517.04"/>
+  </g>
+  <g id="LWPOLYLINE-1177" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1353.56" y1="516.13" x2="1359.31" y2="514.31"/>
+  </g>
+  <g id="LWPOLYLINE-1178" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1362.03" y1="513.41" x2="1367.78" y2="511.59"/>
+  </g>
+  <g id="LWPOLYLINE-1179" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1370.8" y1="510.38" x2="1376.55" y2="508.57"/>
+  </g>
+  <g id="LWPOLYLINE-1180" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1379.27" y1="507.66" x2="1385.02" y2="505.84"/>
+  </g>
+  <g id="LWPOLYLINE-1181" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1387.75" y1="504.94" x2="1393.49" y2="503.12"/>
+  </g>
+  <g id="LWPOLYLINE-1182" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1396.52" y1="502.22" x2="1401.97" y2="500.1"/>
+  </g>
+  <g id="LWPOLYLINE-1183" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1404.99" y1="499.19" x2="1409.22" y2="497.68"/>
+  </g>
+  <g id="LWPOLYLINE-1184" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1290.03" y1="543.36" x2="1293.66" y2="542.15"/>
+  </g>
+  <g id="LWPOLYLINE-1185" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1296.38" y1="541.24" x2="1302.13" y2="539.42"/>
+  </g>
+  <g id="LWPOLYLINE-1186" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1304.85" y1="538.52" x2="1310.6" y2="536.7"/>
+  </g>
+  <g id="LWPOLYLINE-1187" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1313.63" y1="535.49" x2="1319.38" y2="533.67"/>
+  </g>
+  <g id="LWPOLYLINE-1188" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1322.1" y1="532.77" x2="1327.85" y2="530.95"/>
+  </g>
+  <g id="LWPOLYLINE-1189" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1330.57" y1="530.05" x2="1336.32" y2="528.23"/>
+  </g>
+  <g id="LWPOLYLINE-1190" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1339.34" y1="527.33" x2="1345.09" y2="525.21"/>
+  </g>
+  <g id="LWPOLYLINE-1191" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1347.81" y1="524.3" x2="1353.56" y2="522.48"/>
+  </g>
+  <g id="LWPOLYLINE-1192" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1356.28" y1="521.58" x2="1362.03" y2="519.76"/>
+  </g>
+  <g id="LWPOLYLINE-1193" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1365.06" y1="518.85" x2="1370.81" y2="516.73"/>
+  </g>
+  <g id="LWPOLYLINE-1194" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1373.53" y1="515.83" x2="1379.28" y2="514.01"/>
+  </g>
+  <g id="LWPOLYLINE-1195" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1382" y1="513.11" x2="1387.75" y2="511.29"/>
+  </g>
+  <g id="LWPOLYLINE-1196" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1390.77" y1="510.38" x2="1396.22" y2="508.26"/>
+  </g>
+  <g id="LWPOLYLINE-1197" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1399.24" y1="507.36" x2="1404.99" y2="505.54"/>
+  </g>
+  <g id="LWPOLYLINE-1198" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1407.71 504.64 1411.34 503.43 1409.23 497.68"/>
+  </g>
+  <g id="LWPOLYLINE-1199" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1702.37" y1="401.48" x2="1695.41" y2="403.9"/>
+  </g>
+  <g id="LWPOLYLINE-1200" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1692.69" y1="404.8" x2="1686.94" y2="406.62"/>
+  </g>
+  <g id="LWPOLYLINE-1201" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1683.92" y1="407.52" x2="1678.47" y2="409.34"/>
+  </g>
+  <g id="LWPOLYLINE-1202" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1675.45" y1="410.25" x2="1669.7" y2="412.06"/>
+  </g>
+  <g id="LWPOLYLINE-1203" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1666.98" y1="413.27" x2="1661.23" y2="415.09"/>
+  </g>
+  <g id="LWPOLYLINE-1204" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1658.2" y1="416" x2="1652.76" y2="417.81"/>
+  </g>
+  <g id="LWPOLYLINE-1205" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1649.73" y1="418.72" x2="1643.98" y2="420.54"/>
+  </g>
+  <g id="LWPOLYLINE-1206" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1641.26" y1="421.44" x2="1635.51" y2="423.56"/>
+  </g>
+  <g id="LWPOLYLINE-1207" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1632.79" y1="424.47" x2="1627.04" y2="426.29"/>
+  </g>
+  <g id="LWPOLYLINE-1208" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.02" y1="427.19" x2="1618.27" y2="429.01"/>
+  </g>
+  <g id="LWPOLYLINE-1209" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1615.55" y1="429.91" x2="1609.8" y2="432.03"/>
+  </g>
+  <g id="LWPOLYLINE-1210" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1607.08" y1="432.94" x2="1601.33" y2="434.75"/>
+  </g>
+  <g id="LWPOLYLINE-1211" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1598.3" y1="435.66" x2="1592.55" y2="437.48"/>
+  </g>
+  <g id="LWPOLYLINE-1212" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1589.83" y1="438.38" x2="1584.08" y2="440.5"/>
+  </g>
+  <g id="LWPOLYLINE-1213" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1581.36" y1="441.41" x2="1575.61" y2="443.23"/>
+  </g>
+  <g id="LWPOLYLINE-1214" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1572.59" y1="444.13" x2="1565.63" y2="446.25"/>
+  </g>
+  <g id="LWPOLYLINE-1215" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1702.37" y1="407.83" x2="1696.32" y2="409.64"/>
+  </g>
+  <g id="LWPOLYLINE-1216" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1693.6" y1="410.85" x2="1687.85" y2="412.67"/>
+  </g>
+  <g id="LWPOLYLINE-1217" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1685.13" y1="413.58" x2="1679.38" y2="415.39"/>
+  </g>
+  <g id="LWPOLYLINE-1218" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1676.35" y1="416.3" x2="1670.6" y2="418.12"/>
+  </g>
+  <g id="LWPOLYLINE-1219" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1667.88" y1="419.02" x2="1662.13" y2="421.14"/>
+  </g>
+  <g id="LWPOLYLINE-1220" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.41" y1="422.05" x2="1653.66" y2="423.86"/>
+  </g>
+  <g id="LWPOLYLINE-1221" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1650.64" y1="424.77" x2="1644.89" y2="426.58"/>
+  </g>
+  <g id="LWPOLYLINE-1222" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1642.17" y1="427.49" x2="1636.42" y2="429.61"/>
+  </g>
+  <g id="LWPOLYLINE-1223" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1633.7" y1="430.52" x2="1627.95" y2="432.33"/>
+  </g>
+  <g id="LWPOLYLINE-1224" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.92" y1="433.24" x2="1619.17" y2="435.06"/>
+  </g>
+  <g id="LWPOLYLINE-1225" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1616.45" y1="435.96" x2="1610.7" y2="438.08"/>
+  </g>
+  <g id="LWPOLYLINE-1226" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1607.98" y1="438.99" x2="1602.23" y2="440.81"/>
+  </g>
+  <g id="LWPOLYLINE-1227" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1599.21" y1="441.71" x2="1593.76" y2="443.53"/>
+  </g>
+  <g id="LWPOLYLINE-1228" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1590.74" y1="444.43" x2="1584.99" y2="446.25"/>
+  </g>
+  <g id="LWPOLYLINE-1229" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1582.27" y1="447.46" x2="1576.52" y2="449.27"/>
+  </g>
+  <g id="LWPOLYLINE-1230" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1573.5 450.18 1567.75 452 1565.63 446.25"/>
+  </g>
+  <g id="LWPOLYLINE-1231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1818.24" y1="534.28" x2="2037.27" y2="462.28"/>
+  </g>
+  <g id="LWPOLYLINE-1232" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2035.45" y1="456.84" x2="2039.99" y2="455.32"/>
+  </g>
+  <g id="LWPOLYLINE-1233" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2018.21" y1="389.07" x2="2074.78" y2="370.62"/>
+  </g>
+  <g id="LWPOLYLINE-1234" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2014.27" y1="376.67" x2="2070.54" y2="358.21"/>
+  </g>
+  <g id="LWPOLYLINE-1235" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1987.35 318.58 1991.28 324.03 1989.47 325.54 2012.76 396.33 2015.19 395.43"/>
+  </g>
+  <g id="LWPOLYLINE-1236" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1976.76" y1="304.06" x2="1987.35" y2="318.58"/>
+  </g>
+  <g id="LWPOLYLINE-1237" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1987.35 318.59 1995.21 313.74 1991.59 307.69 1987.65 309.81"/>
+  </g>
+  <g id="LWPOLYLINE-1238" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2046.34 277.74 2037.87 280.46 2022.44 289.24 2026.38 295.59 2040.59 287.12 2048.46 284.4"/>
+  </g>
+  <g id="LWPOLYLINE-1239" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1990.37" y1="316.77" x2="1996.12" y2="322.21"/>
+  </g>
+  <g id="LWPOLYLINE-1240" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2111.08 677.38 2113.2 657.41 2118.04 658.02"/>
+  </g>
+  <g id="LWPOLYLINE-1241" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2118.34" y1="611.73" x2="2123.49" y2="612.33"/>
+  </g>
+  <g id="LWPOLYLINE-1242" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2122.88 655.6 2122.58 658.62 2111.68 657.41 2111.99 654.39 2122.88 655.6 2125.3 635.63"/>
+  </g>
+  <g id="LWPOLYLINE-1243" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2127.42 615.97 2116.52 614.45 2116.83 611.73 2128.02 612.94 2127.42 615.97"/>
+  </g>
+  <g id="LWPOLYLINE-1244" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2127.42 615.97 2131.65 616.27 2129.24 636.23 2125.3 635.63"/>
+  </g>
+  <g id="LWPOLYLINE-1245" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2144.66 617.78 2198.51 623.83 2192.16 679.19 2138.31 673.14 2140.12 657.72 2128.63 656.2 2126.51 674.66 2194.88 682.52 2201.84 621.41 2133.47 613.55 2133.17 616.57 2144.66 617.78"/>
+  </g>
+  <g id="LWPOLYLINE-1246" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2138.31 645 2129.84 644.1 2131.35 630.18 2139.82 631.1"/>
+  </g>
+  <g id="LWPOLYLINE-1247" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2130.44" y1="636.84" x2="2135.89" y2="637.45"/>
+  </g>
+  <g id="LWPOLYLINE-1248" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2144.06 631.7 2142.24 645.61 2150.41 646.52"/>
+  </g>
+  <g id="LWPOLYLINE-1249" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2162.21 647.73 2153.74 646.82 2155.25 632.91 2163.72 633.82"/>
+  </g>
+  <g id="LWPOLYLINE-1250" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2154.34" y1="639.56" x2="2159.79" y2="640.17"/>
+  </g>
+  <g id="LWPOLYLINE-1251" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.96 634.42 2171.59 648.94 2178.55 635.63"/>
+  </g>
+  <g id="LWPOLYLINE-1252" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2180.36 648.33 2179.46 648.94 2180.06 649.85 2180.97 649.24"/>
+  </g>
+  <g id="LWPOLYLINE-1253" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2187.92 639.86 2188.23 639.26 2188.83 638.05 2189.74 637.44 2190.95 636.84 2193.67 637.14 2194.88 638.05 2195.49 638.66 2196.09 640.17 2195.79 641.38 2195.18 642.89 2193.67 644.71 2186.11 650.46 2195.49 651.66"/>
+  </g>
+  <g id="LWPOLYLINE-1254" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2136.5" y1="452.9" x2="2146.78" y2="454.11"/>
+  </g>
+  <g id="LWPOLYLINE-1255" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2118.34 611.73 2132.26 488.9 2142.85 490.11"/>
+  </g>
+  <g id="LWPOLYLINE-1256" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2130.44" y1="598.72" x2="2229.97" y2="610.22"/>
+  </g>
+  <g id="LWPOLYLINE-1257" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2157.06" y1="583.59" x2="2206.68" y2="589.34"/>
+  </g>
+  <g id="LWPOLYLINE-1258" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2191.55 499.49 2183.69 569.68 2233.9 575.13"/>
+  </g>
+  <g id="LWPOLYLINE-1259" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2134.68" y1="561.81" x2="2183.99" y2="567.56"/>
+  </g>
+  <g id="LWPOLYLINE-1260" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2135.89" y1="552.13" x2="2185.2" y2="557.88"/>
+  </g>
+  <g id="LWPOLYLINE-1261" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2185.81" y1="560" x2="2235.12" y2="565.45"/>
+  </g>
+  <g id="LWPOLYLINE-1262" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2136.8" y1="542.45" x2="2186.11" y2="548.2"/>
+  </g>
+  <g id="LWPOLYLINE-1263" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2187.01" y1="550.32" x2="2236.33" y2="555.76"/>
+  </g>
+  <g id="LWPOLYLINE-1264" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.01" y1="532.77" x2="2187.32" y2="538.52"/>
+  </g>
+  <g id="LWPOLYLINE-1265" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2187.92" y1="540.64" x2="2237.24" y2="546.08"/>
+  </g>
+  <g id="LWPOLYLINE-1266" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2139.22" y1="523.09" x2="2188.23" y2="528.84"/>
+  </g>
+  <g id="LWPOLYLINE-1267" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2189.13" y1="530.95" x2="2238.45" y2="536.4"/>
+  </g>
+  <g id="LWPOLYLINE-1268" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.12" y1="513.41" x2="2189.44" y2="519.16"/>
+  </g>
+  <g id="LWPOLYLINE-1269" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2190.34" y1="520.97" x2="2239.66" y2="526.72"/>
+  </g>
+  <g id="LWPOLYLINE-1270" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2141.34" y1="503.73" x2="2190.65" y2="509.18"/>
+  </g>
+  <g id="LWPOLYLINE-1271" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2215.15" y1="514.01" x2="2240.56" y2="517.04"/>
+  </g>
+  <g id="LWPOLYLINE-1272" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2142.54" y1="494.05" x2="2191.55" y2="499.49"/>
+  </g>
+  <g id="LWPOLYLINE-1273" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.32" y1="682.52" x2="2220.29" y2="694.32"/>
+  </g>
+  <g id="LWPOLYLINE-1274" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2123.79" y1="604.17" x2="2229.37" y2="615.96"/>
+  </g>
+  <g id="LWPOLYLINE-1275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2142.55 441.11 2138.01 440.5 2136.5 452.9"/>
+  </g>
+  <g id="LWPOLYLINE-1276" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2142.54" y1="441.11" x2="2141.94" y2="445.95"/>
+  </g>
+  <g id="LWPOLYLINE-1277" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.08" y1="452.6" x2="2146.78" y2="454.12"/>
+  </g>
+  <g id="LWPOLYLINE-1278" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2142.85" y1="490.11" x2="2130.44" y2="598.72"/>
+  </g>
+  <g id="LWPOLYLINE-1279" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2136.8" y1="489.21" x2="2123.79" y2="604.16"/>
+  </g>
+  <g id="LWPOLYLINE-1280" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2241.47 221.16 2275.66 209.98 2249.04 443.53"/>
+  </g>
+  <g id="LWPOLYLINE-1281" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2246.61" y1="463.79" x2="2219.98" y2="697.64"/>
+  </g>
+  <g id="LWPOLYLINE-1282" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2219.99 697.65 2204.26 695.83 2201.84 715.5"/>
+  </g>
+  <g id="LWPOLYLINE-1283" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2217.87" y1="717.31" x2="2188.53" y2="975.97"/>
+  </g>
+  <g id="LWPOLYLINE-1284" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2170.38 994.12 2186.11 995.94 2156.46 1257.92"/>
+  </g>
+  <g id="LWPOLYLINE-1285" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2172.49" y1="974.15" x2="2170.37" y2="994.12"/>
+  </g>
+  <g id="LWPOLYLINE-1286" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2249.04 443.53 2233 441.71 2230.88 461.98"/>
+  </g>
+  <g id="LWPOLYLINE-1287" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2285.64" y1="191.52" x2="2162.51" y2="1275.77"/>
+  </g>
+  <g id="LWPOLYLINE-1288" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2124.39" y1="604.17" x2="2123.49" y2="612.33"/>
+  </g>
+  <g id="LWPOLYLINE-1289" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2118.04" y1="658.02" x2="2115.32" y2="682.52"/>
+  </g>
+  <g id="LWPOLYLINE-1290" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2108.36 475.59 2136.5 452.9 2137.71 454.42 2109.26 476.8"/>
+  </g>
+  <g id="LWPOLYLINE-1291" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2107.45 474.69 2110.78 478.32 2114.41 481.64 2118.64 484.36 2122.88 486.48 2127.72 487.99 2132.26 488.91"/>
+  </g>
+  <g id="LWPOLYLINE-1292" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2076.29" y1="350.35" x2="2080.53" y2="348.84"/>
+  </g>
+  <g id="LWPOLYLINE-1293" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2074.78" y1="345.81" x2="2079.01" y2="344.3"/>
+  </g>
+  <g id="LWPOLYLINE-1294" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.2" y1="333.1" x2="2206.38" y2="302.55"/>
+  </g>
+  <g id="LWPOLYLINE-1295" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2111.38" y1="266.85" x2="2186.11" y2="242.04"/>
+  </g>
+  <g id="LWPOLYLINE-1296" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2057.23" y1="288.63" x2="2112.59" y2="270.48"/>
+  </g>
+  <g id="LWPOLYLINE-1297" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2144.96" y1="368.2" x2="2149.5" y2="366.68"/>
+  </g>
+  <g id="LWPOLYLINE-1298" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2206.38" y1="302.55" x2="2264.16" y2="308.9"/>
+  </g>
+  <g id="LWPOLYLINE-1299" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2206.98" y1="307.39" x2="2263.86" y2="313.74"/>
+  </g>
+  <g id="LWPOLYLINE-1300" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.32" y1="896.41" x2="299.26" y2="898.53"/>
+  </g>
+  <g id="LWPOLYLINE-1301" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2095.35 312.23 2079.01 344.3 2080.53 345.21 2096.87 313.13"/>
+  </g>
+  <g id="LWPOLYLINE-1302" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2094.44 311.62 2098.68 314.05 2102.61 317.07 2105.94 320.4 2108.96 324.33 2111.39 328.57 2113.2 333.11"/>
+  </g>
+  <g id="LWPOLYLINE-1303" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.59" y1="270.48" x2="2111.39" y2="266.85"/>
+  </g>
+  <g id="LWPOLYLINE-1304" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2170.38 348.53 2138.01 332.19 2137.4 334.01 2169.47 350.05"/>
+  </g>
+  <g id="LWPOLYLINE-1305" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2170.68 347.63 2168.56 351.86 2165.54 355.79 2162.21 359.42 2158.28 362.14 2154.04 364.87 2149.51 366.69"/>
+  </g>
+  <g id="LWPOLYLINE-1306" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2149.5" y1="381.21" x2="2254.78" y2="393"/>
+  </g>
+  <g id="LWPOLYLINE-1307" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2148.9" y1="385.14" x2="2254.18" y2="396.94"/>
+  </g>
+  <g id="LWPOLYLINE-1308" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2137.4" y1="445.34" x2="2231.49" y2="455.93"/>
+  </g>
+  <g id="LWPOLYLINE-1309" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2136.8" y1="451.39" x2="2230.88" y2="461.98"/>
+  </g>
+  <g id="LWPOLYLINE-1310" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2141.94" y1="404.8" x2="2146.78" y2="405.1"/>
+  </g>
+  <g id="LWPOLYLINE-1311" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.81 427.19 2141.94 404.8 2143.15 406.02 2115.01 428.4"/>
+  </g>
+  <g id="LWPOLYLINE-1312" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.2 426.28 2116.22 429.91 2119.85 433.24 2124.09 435.96 2128.33 438.08 2133.17 439.59 2138.01 440.5"/>
+  </g>
+  <g id="LWPOLYLINE-1313" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1855.45" y1="347.93" x2="1907.18" y2="505.24"/>
+  </g>
+  <g id="LWPOLYLINE-1314" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1859.08" y1="346.72" x2="1910.82" y2="504.03"/>
+  </g>
+  <g id="LWPOLYLINE-1315" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2061.16" y1="304.06" x2="2057.23" y2="288.63"/>
+  </g>
+  <g id="LWPOLYLINE-1316" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2230.88" y1="461.98" x2="2246.61" y2="463.8"/>
+  </g>
+  <g id="LWPOLYLINE-1317" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2168.26 392.4 2166.45 392.09 2167.05 387.25 2180.96 388.77 2180.36 393.61 2178.24 393.61 2168.26 395.12"/>
+  </g>
+  <g id="ARC-55" data-name="ARC">
+    <path class="cls-3" d="M2168.02,392.3c-.1.88-.09,1.77.04,2.65"/>
+  </g>
+  <g id="LWPOLYLINE-1318" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2187.02 394.52 2184.89 394.21 2185.51 389.37 2199.42 390.89 2198.82 395.73 2197 395.73 2187.02 397.24"/>
+  </g>
+  <g id="ARC-56" data-name="ARC">
+    <path class="cls-3" d="M2186.78,394.42c-.1.88-.09,1.77.04,2.64"/>
+  </g>
+  <g id="LWPOLYLINE-1319" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2229.67,443.53l-.61,5.45c-.17,1.34-1.39,2.28-2.72,2.12l-8.47-.9c-1.45-.13-2.53-1.41-2.4-2.87"/>
+  </g>
+  <g id="SPLINE-31" data-name="SPLINE">
+    <path class="cls-3" d="M2224.52,441.71c.09-.75-.45-1.42-1.2-1.51"/>
+  </g>
+  <g id="SPLINE-32" data-name="SPLINE">
+    <path class="cls-3" d="M2223.01,442.92c.75.08,1.43-.45,1.51-1.2"/>
+  </g>
+  <g id="ARC-57" data-name="ARC">
+    <path class="cls-3" d="M2223.32,440.2c-.75-.08-1.42.46-1.5,1.2s.45,1.41,1.19,1.5"/>
+  </g>
+  <g id="LWPOLYLINE-1320" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2231.49" y1="441.41" x2="2231.18" y2="443.83"/>
+  </g>
+  <g id="SPLINE-33" data-name="SPLINE">
+    <path class="cls-3" d="M2231.18,444.37c.05-.42-.25-.79-.67-.84"/>
+  </g>
+  <g id="SPLINE-34" data-name="SPLINE">
+    <path class="cls-3" d="M2229.68,444.2c-.05.42.26.79.67.84"/>
+  </g>
+  <g id="ARC-58" data-name="ARC">
+    <path class="cls-3" d="M2230.51,443.53c-.42-.05-.79.25-.84.67"/>
+  </g>
+  <g id="ARC-59" data-name="ARC">
+    <path class="cls-3" d="M2230.34,445.03c.41.04.79-.25.84-.67"/>
+  </g>
+  <g id="SPLINE-35" data-name="SPLINE">
+    <path class="cls-3" d="M2231.79,440.43c.05-.42-.25-.79-.67-.84"/>
+  </g>
+  <g id="ARC-60" data-name="ARC">
+    <path class="cls-3" d="M2231.12,439.6c-.41-.05-.79.25-.84.66s.25.79.66.84.79-.25.84-.66"/>
+  </g>
+  <g id="LWPOLYLINE-1321" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2230.58 441.41 2225.74 441.41 2225.74 442.31 2230.28 443.83"/>
+  </g>
+  <g id="LWPOLYLINE-1322" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2230.27,452.9c.75.08,1.43-.45,1.52-1.2l2.12-17.85"/>
+  </g>
+  <g id="LWPOLYLINE-1323" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2215.45" y1="451.09" x2="2230.58" y2="452.91"/>
+  </g>
+  <g id="ARC-61" data-name="ARC">
+    <path class="cls-3" d="M2213.95,449.57c-.08.75.46,1.42,1.2,1.5"/>
+  </g>
+  <g id="LWPOLYLINE-1324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2216.36" y1="431.73" x2="2214.24" y2="449.88"/>
+  </g>
+  <g id="ARC-62" data-name="ARC">
+    <path class="cls-3" d="M2217.57,430.53c-.75-.09-1.42.45-1.5,1.19,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2233" y1="432.33" x2="2217.57" y2="430.82"/>
+  </g>
+  <g id="SPLINE-36" data-name="SPLINE">
+    <path class="cls-3" d="M2233.9,433.54c.09-.75-.45-1.42-1.2-1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1326" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2215.76" y1="447.46" x2="2217.27" y2="434.45"/>
+  </g>
+  <g id="ARC-63" data-name="ARC">
+    <path class="cls-3" d="M2219.83,431.74c-1.41-.16-2.68.85-2.85,2.26"/>
+  </g>
+  <g id="LWPOLYLINE-1327" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2219.99" y1="432.03" x2="2228.46" y2="433.24"/>
+  </g>
+  <g id="LWPOLYLINE-1328" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2228.3,432.95s0,0,0,0c1.46.2,2.48,1.55,2.27,3.01l-.61,5.45"/>
+  </g>
+  <g id="LWPOLYLINE-1329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2184.59" y1="569.68" x2="2190.34" y2="519.76"/>
+  </g>
+  <g id="LWPOLYLINE-1330" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2167.05" y1="496.77" x2="2157.07" y2="583.59"/>
+  </g>
+  <g id="LWPOLYLINE-1331" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2214.85" y1="524" x2="2206.68" y2="589.34"/>
+  </g>
+  <g id="LWPOLYLINE-1332" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2169.17 496.77 2168.56 495.26 2167.05 494.95 2165.84 495.26 2165.23 496.77 2165.84 498.29 2167.05 498.89 2168.56 498.29 2169.17 496.77"/>
+  </g>
+  <g id="LWPOLYLINE-1333" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2206.98 529.44 2214.84 524 2220.59 531.87"/>
+  </g>
+  <g id="LWPOLYLINE-1334" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2190.34 519.76 2210.31 515.52 2213.64 518.86 2216.66 509.78 2219.69 513.4 2241.47 508.57"/>
+  </g>
+  <g id="LWPOLYLINE-1335" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2159.79 478.92 2158.88 487.7 2159.48 489.51 2160.39 490.72 2161.91 491.33 2163.11 491.62 2164.93 491.02 2166.15 490.11 2167.05 488.3 2167.96 479.83"/>
+  </g>
+  <g id="LWPOLYLINE-1336" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2170.98 492.23 2172.5 480.44 2177.64 481.04 2179.15 481.64 2179.76 482.25 2180.06 483.46 2180.06 485.27 2179.15 486.19 2178.55 486.79 2176.73 487.09 2171.59 486.48"/>
+  </g>
+  <g id="LWPOLYLINE-1337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2210.61" y1="718.82" x2="2181.57" y2="973.85"/>
+  </g>
+  <g id="LWPOLYLINE-1338" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2201.84" y1="697.34" x2="2199.42" y2="717.61"/>
+  </g>
+  <g id="LWPOLYLINE-1339" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2179.15" y1="996.54" x2="2149.2" y2="1257.92"/>
+  </g>
+  <g id="LWPOLYLINE-1340" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2181.57 973.85 2168.57 972.34 2166.14 995.02 2179.15 996.54"/>
+  </g>
+  <g id="LWPOLYLINE-1341" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2048.46" y1="838.93" x2="2101.7" y2="844.97"/>
+  </g>
+  <g id="LWPOLYLINE-1342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2107.45" y1="792.64" x2="2200.93" y2="803.23"/>
+  </g>
+  <g id="LWPOLYLINE-1343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2111.08" y1="789.31" x2="2201.54" y2="799.6"/>
+  </g>
+  <g id="LWPOLYLINE-1344" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2044.53" y1="834.39" x2="2056.63" y2="835.59"/>
+  </g>
+  <g id="LWPOLYLINE-1345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2067.52" y1="739.4" x2="2074.48" y2="740.3"/>
+  </g>
+  <g id="LWPOLYLINE-1346" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2074.17" y1="742.12" x2="2115.93" y2="746.96"/>
+  </g>
+  <g id="LWPOLYLINE-1347" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2111.99" y1="782.05" x2="2202.14" y2="792.34"/>
+  </g>
+  <g id="LWPOLYLINE-1348" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.5" y1="767.23" x2="2116.83" y2="767.53"/>
+  </g>
+  <g id="LWPOLYLINE-1349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2119.86" y1="767.83" x2="2125.9" y2="768.44"/>
+  </g>
+  <g id="LWPOLYLINE-1350" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2128.93" y1="768.74" x2="2134.98" y2="769.64"/>
+  </g>
+  <g id="LWPOLYLINE-1351" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.01" y1="769.95" x2="2143.76" y2="770.56"/>
+  </g>
+  <g id="LWPOLYLINE-1352" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2146.78" y1="770.86" x2="2152.83" y2="771.46"/>
+  </g>
+  <g id="LWPOLYLINE-1353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2155.86" y1="771.77" x2="2161.61" y2="772.67"/>
+  </g>
+  <g id="LWPOLYLINE-1354" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2164.63" y1="772.98" x2="2170.68" y2="773.58"/>
+  </g>
+  <g id="LWPOLYLINE-1355" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2173.71" y1="773.88" x2="2179.75" y2="774.49"/>
+  </g>
+  <g id="LWPOLYLINE-1356" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2182.78" y1="775.09" x2="2188.53" y2="775.7"/>
+  </g>
+  <g id="LWPOLYLINE-1357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2191.56" y1="776" x2="2197.6" y2="776.61"/>
+  </g>
+  <g id="LWPOLYLINE-1358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2200.63" y1="776.91" x2="2203.96" y2="777.51"/>
+  </g>
+  <g id="LWPOLYLINE-1359" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.02" y1="755.13" x2="2205.47" y2="765.41"/>
+  </g>
+  <g id="LWPOLYLINE-1360" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2111.38" y1="785.68" x2="2201.84" y2="795.97"/>
+  </g>
+  <g id="LWPOLYLINE-1361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.83" y1="683.73" x2="2201.84" y2="697.35"/>
+  </g>
+  <g id="LWPOLYLINE-1362" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2199.42" y1="717.61" x2="2210.61" y2="718.82"/>
+  </g>
+  <g id="LWPOLYLINE-1363" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2074.47 679.5 2071.75 703.7 2078.71 704.3"/>
+  </g>
+  <g id="LWPOLYLINE-1364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2101.7" y1="844.98" x2="2107.45" y2="792.64"/>
+  </g>
+  <g id="LWPOLYLINE-1365" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2056.63 835.6 2057.23 830.45 2064.19 831.36"/>
+  </g>
+  <g id="LWPOLYLINE-1366" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2067.52 739.4 2060.56 800.51 2067.52 801.41"/>
+  </g>
+  <g id="LWPOLYLINE-1367" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2064.19 831.36 2063.89 833.18 2097.16 837.11"/>
+  </g>
+  <g id="LWPOLYLINE-1368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2073.57" y1="749.68" x2="2106.84" y2="753.31"/>
+  </g>
+  <g id="LWPOLYLINE-1369" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2064.19" y1="831.36" x2="2063.89" y2="833.18"/>
+  </g>
+  <g id="LWPOLYLINE-1370" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2097.17" y1="837.11" x2="2106.84" y2="753.31"/>
+  </g>
+  <g id="LWPOLYLINE-1371" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2067.52" y1="801.41" x2="2074.48" y2="740.3"/>
+  </g>
+  <g id="LWPOLYLINE-1372" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2110.48" y1="792.94" x2="2115.92" y2="746.96"/>
+  </g>
+  <g id="LWPOLYLINE-1373" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2078.71" y1="704.3" x2="2080.83" y2="683.73"/>
+  </g>
+  <g id="LWPOLYLINE-1374" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="734.9 787.8 734.9 773.58 739.43 773.58 741.55 774.18 742.76 775.7 743.37 776.9 744.27 779.03 744.27 782.35 743.37 784.47 742.76 785.68 741.55 786.9 739.43 787.8 734.9 787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1375" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="748.81 787.8 754.26 773.58 759.4 787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="750.93" y1="782.96" x2="757.58" y2="782.96"/>
+  </g>
+  <g id="LWPOLYLINE-1377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="768.17" y1="773.58" x2="768.17" y2="787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1378" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="763.64" y1="773.58" x2="772.71" y2="773.58"/>
+  </g>
+  <g id="LWPOLYLINE-1379" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="775.43 787.8 780.88 773.58 786.33 787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="777.55" y1="782.96" x2="784.21" y2="782.96"/>
+  </g>
+  <g id="LWPOLYLINE-1381" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="812.95 776.91 812.34 775.7 810.83 774.19 809.62 773.58 806.9 773.58 805.69 774.19 804.17 775.7 803.57 776.91 802.97 779.03 802.97 782.35 803.57 784.47 804.17 785.68 805.69 786.89 806.9 787.8 809.62 787.8 810.83 786.89 812.34 785.68 812.95 784.47"/>
+  </g>
+  <g id="LWPOLYLINE-1382" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="825.65 787.8 816.88 787.8 816.88 773.58 825.65 773.58"/>
+  </g>
+  <g id="LWPOLYLINE-1383" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="816.88" y1="780.24" x2="822.33" y2="780.24"/>
+  </g>
+  <g id="LWPOLYLINE-1384" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="829.59 787.8 829.59 773.58 838.96 787.8 838.96 773.58"/>
+  </g>
+  <g id="LWPOLYLINE-1385" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="848.95" y1="773.58" x2="848.95" y2="787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1386" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="844.41" y1="773.58" x2="853.79" y2="773.58"/>
+  </g>
+  <g id="LWPOLYLINE-1387" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="864.98 787.8 856.21 787.8 856.21 773.58 864.98 773.58"/>
+  </g>
+  <g id="LWPOLYLINE-1388" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="856.21" y1="780.24" x2="861.66" y2="780.24"/>
+  </g>
+  <g id="LWPOLYLINE-1389" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="868.92 787.8 868.92 773.58 874.96 773.58 877.08 774.18 877.69 775.1 878.29 776.3 878.29 777.52 877.69 779.03 877.08 779.63 874.96 780.23 868.92 780.23"/>
+  </g>
+  <g id="LWPOLYLINE-1390" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="873.76" y1="780.24" x2="878.29" y2="787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1391" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="895.23" y1="770.86" x2="883.13" y2="792.33"/>
+  </g>
+  <g id="LWPOLYLINE-1392" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="734.9" y1="814.12" x2="734.9" y2="799.9"/>
+  </g>
+  <g id="LWPOLYLINE-1393" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="744.88" y1="799.9" x2="744.88" y2="814.12"/>
+  </g>
+  <g id="LWPOLYLINE-1394" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="740.04" y1="799.9" x2="749.41" y2="799.9"/>
+  </g>
+  <g id="LWPOLYLINE-1395" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="774.22 802.02 772.71 800.81 770.9 799.9 768.18 799.9 766.06 800.81 764.85 802.02 764.85 803.53 765.45 804.74 766.06 805.35 767.57 805.95 771.5 807.47 772.71 808.07 773.62 808.67 774.22 810.19 774.22 812 772.71 813.51 770.9 814.12 768.18 814.12 766.06 813.51 764.85 812"/>
+  </g>
+  <g id="LWPOLYLINE-1396" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="783" y1="799.9" x2="783" y2="814.12"/>
+  </g>
+  <g id="LWPOLYLINE-1397" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="778.16" y1="799.9" x2="787.53" y2="799.9"/>
+  </g>
+  <g id="LWPOLYLINE-1398" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="794.19 799.9 792.98 800.8 791.47 802.02 790.86 803.53 790.26 805.35 790.26 808.67 790.86 810.79 791.47 812 792.98 813.52 794.19 814.12 796.91 814.12 798.12 813.52 799.64 812 800.24 810.79 800.84 808.67 800.84 805.35 800.24 803.53 799.64 802.02 798.12 800.8 796.91 799.9 794.19 799.9"/>
+  </g>
+  <g id="LWPOLYLINE-1399" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="804.78 814.12 804.78 799.9 810.83 799.9 812.95 800.81 813.55 801.42 814.16 802.62 814.16 804.14 813.55 805.35 812.95 805.95 810.83 806.86 804.78 806.86"/>
+  </g>
+  <g id="LWPOLYLINE-1400" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="809.62" y1="806.86" x2="814.16" y2="814.12"/>
+  </g>
+  <g id="LWPOLYLINE-1401" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="819 814.12 824.44 799.9 829.59 814.12"/>
+  </g>
+  <g id="LWPOLYLINE-1402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="820.81" y1="809.28" x2="827.77" y2="809.28"/>
+  </g>
+  <g id="LWPOLYLINE-1403" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="843.81 803.53 842.9 802.02 841.69 800.81 840.48 799.9 837.76 799.9 836.24 800.81 835.03 802.02 834.43 803.53 833.52 805.35 833.52 808.67 834.43 810.79 835.03 812 836.24 813.51 837.76 814.12 840.48 814.12 841.69 813.51 842.9 812 843.81 810.79 843.81 808.67 840.48 808.67"/>
+  </g>
+  <g id="LWPOLYLINE-1404" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="856.21 814.12 847.74 814.12 847.74 799.9 856.21 799.9"/>
+  </g>
+  <g id="LWPOLYLINE-1405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="847.74" y1="806.86" x2="852.88" y2="806.86"/>
+  </g>
+  <g id="LWPOLYLINE-1406" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="739.43" y1="933.31" x2="739.43" y2="947.23"/>
+  </g>
+  <g id="LWPOLYLINE-1407" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="734.9" y1="933.31" x2="744.27" y2="933.31"/>
+  </g>
+  <g id="LWPOLYLINE-1408" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="755.47 947.23 746.69 947.23 746.69 933.31 755.47 933.31"/>
+  </g>
+  <g id="LWPOLYLINE-1409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="746.69" y1="939.97" x2="752.14" y2="939.97"/>
+  </g>
+  <g id="LWPOLYLINE-1410" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="759.4 933.31 759.4 947.23 767.57 947.23"/>
+  </g>
+  <g id="LWPOLYLINE-1411" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="771.5 946.02 770.9 946.63 771.5 947.23 772.11 946.63"/>
+  </g>
+  <g id="LWPOLYLINE-1412" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="789.65" y1="930.59" x2="777.55" y2="952.07"/>
+  </g>
+  <g id="LWPOLYLINE-1413" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="801.45 935.13 800.24 933.92 798.12 933.31 795.7 933.31 793.59 933.92 792.37 935.13 792.37 936.64 792.98 937.85 793.59 938.46 794.8 939.36 799.03 940.58 800.24 941.18 800.85 941.78 801.45 943.3 801.45 945.11 800.24 946.62 798.12 947.23 795.7 947.23 793.59 946.62 792.37 945.11"/>
+  </g>
+  <g id="LWPOLYLINE-1414" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="814.16 947.23 805.69 947.23 805.69 933.31 814.16 933.31"/>
+  </g>
+  <g id="LWPOLYLINE-1415" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="805.69" y1="939.97" x2="810.83" y2="939.97"/>
+  </g>
+  <g id="LWPOLYLINE-1416" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="818.39 947.23 818.39 933.31 824.44 933.31 826.26 933.92 826.86 934.53 827.77 936.04 827.77 937.25 826.86 938.46 826.26 939.36 824.44 939.97 818.39 939.97"/>
+  </g>
+  <g id="LWPOLYLINE-1417" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="822.93" y1="939.97" x2="827.77" y2="947.23"/>
+  </g>
+  <g id="LWPOLYLINE-1418" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="832.31 933.31 837.76 947.23 842.9 933.31"/>
+  </g>
+  <g id="LWPOLYLINE-1419" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="854.39 947.23 845.62 947.23 845.62 933.31 854.39 933.31"/>
+  </g>
+  <g id="LWPOLYLINE-1420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="845.62" y1="939.97" x2="851.07" y2="939.97"/>
+  </g>
+  <g id="LWPOLYLINE-1421" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="858.33 947.23 858.33 933.31 864.37 933.31 866.49 933.92 867.1 934.53 867.7 936.04 867.7 937.25 867.1 938.46 866.49 939.36 864.37 939.97 858.33 939.97"/>
+  </g>
+  <g id="LWPOLYLINE-1422" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="863.17" y1="939.97" x2="867.7" y2="947.23"/>
+  </g>
+  <g id="LWPOLYLINE-1423" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="510.12 1016.21 510.12 1002.29 515.57 1016.21 521.01 1002.29 521.01 1016.21"/>
+  </g>
+  <g id="LWPOLYLINE-1424" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="534.93 1016.21 526.15 1016.21 526.15 1002.29 534.93 1002.29"/>
+  </g>
+  <g id="LWPOLYLINE-1425" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.15" y1="1008.94" x2="531.6" y2="1008.94"/>
+  </g>
+  <g id="LWPOLYLINE-1426" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="538.86 1016.21 538.86 1002.29 548.23 1016.21 548.23 1002.29"/>
+  </g>
+  <g id="LWPOLYLINE-1427" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="603" y1="868.57" x2="629.01" y2="947.53"/>
+  </g>
+  <g id="LWPOLYLINE-1428" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="606.02" y1="935.73" x2="605.72" y2="934.22"/>
+  </g>
+  <g id="ARC-64" data-name="ARC">
+    <path class="cls-3" d="M609.16,941.29c4.5-.99,7.34-5.45,6.35-9.94-.03-.13-.06-.27-.1-.4"/>
+  </g>
+  <g id="LWPOLYLINE-1429" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="604.21" y1="936.34" x2="602.69" y2="931.8"/>
+  </g>
+  <g id="LWPOLYLINE-1430" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="600.57 926.66 603 934.22 605.72 941.79"/>
+  </g>
+  <g id="ARC-65" data-name="ARC">
+    <path class="cls-3" d="M613.11,940.47c1.26-.9,2.35-2.01,3.23-3.29"/>
+  </g>
+  <g id="ARC-66" data-name="ARC">
+    <path class="cls-3" d="M608.2,942.74c1.65-.54,3.2-1.33,4.61-2.35"/>
+  </g>
+  <g id="SPLINE-37" data-name="SPLINE">
+    <path class="cls-3" d="M605.92,935.73c.08-.02.12-.11.09-.19"/>
+  </g>
+  <g id="SPLINE-38" data-name="SPLINE">
+    <path class="cls-3" d="M604.21,936.24c.02.08.11.12.19.09"/>
+  </g>
+  <g id="LWPOLYLINE-1431" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="606.02" y1="936.04" x2="604.51" y2="936.64"/>
+  </g>
+  <g id="ARC-67" data-name="ARC">
+    <path class="cls-3" d="M605.37,941.78c.57,1.09,1.91,1.52,3.01.98"/>
+  </g>
+  <g id="LWPOLYLINE-1432" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M608.44,933.01l-3.63,1.51c-.18.04-.36.04-.53,0-.14-.01-.27-.05-.4-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1433" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="605.11" y1="932.71" x2="604.51" y2="931.19"/>
+  </g>
+  <g id="ARC-68" data-name="ARC">
+    <path class="cls-3" d="M615.26,930.73c-.85-4.52-5.2-7.5-9.72-6.65-.63.12-1.25.31-1.84.57"/>
+  </g>
+  <g id="ARC-69" data-name="ARC">
+    <path class="cls-3" d="M603.72,924.9c-.55.19-.86.78-.67,1.34"/>
+  </g>
+  <g id="ARC-70" data-name="ARC">
+    <path class="cls-3" d="M605.34,932.37c-.72-2.11-1.55-4.19-2.47-6.22"/>
+  </g>
+  <g id="SPLINE-39" data-name="SPLINE">
+    <path class="cls-3" d="M602.8,931.2c-.08.02-.12.11-.09.19"/>
+  </g>
+  <g id="SPLINE-40" data-name="SPLINE">
+    <path class="cls-3" d="M604.5,931c-.02-.08-.11-.13-.19-.09"/>
+  </g>
+  <g id="LWPOLYLINE-1434" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="604.21" y1="930.89" x2="603" y2="931.5"/>
+  </g>
+  <g id="SPLINE-41" data-name="SPLINE">
+    <path class="cls-3" d="M604.59,934.18c.06-.02.11-.04.16-.08"/>
+  </g>
+  <g id="SPLINE-42" data-name="SPLINE">
+    <path class="cls-3" d="M604.3,934.22c.1,0,.2,0,.29-.04"/>
+  </g>
+  <g id="SPLINE-43" data-name="SPLINE">
+    <path class="cls-3" d="M604.02,934.14c.09.04.19.07.28.08"/>
+  </g>
+  <g id="SPLINE-44" data-name="SPLINE">
+    <path class="cls-3" d="M603.78,933.96c.06.08.15.14.23.18"/>
+  </g>
+  <g id="SPLINE-45" data-name="SPLINE">
+    <path class="cls-3" d="M603.64,933.7c.03.09.08.18.15.26"/>
+  </g>
+  <g id="SPLINE-46" data-name="SPLINE">
+    <path class="cls-3" d="M603.6,933.41c0,.1,0,.2.04.29"/>
+  </g>
+  <g id="SPLINE-47" data-name="SPLINE">
+    <path class="cls-3" d="M603.68,933.12c-.04.09-.07.18-.08.28"/>
+  </g>
+  <g id="SPLINE-48" data-name="SPLINE">
+    <path class="cls-3" d="M603.86,932.89c-.08.06-.14.15-.18.23"/>
+  </g>
+  <g id="SPLINE-49" data-name="SPLINE">
+    <path class="cls-3" d="M604.12,932.75c-.09.03-.18.08-.26.15"/>
+  </g>
+  <g id="SPLINE-50" data-name="SPLINE">
+    <path class="cls-3" d="M604.69,934.47c.19-.06.36-.18.49-.34"/>
+  </g>
+  <g id="SPLINE-51" data-name="SPLINE">
+    <path class="cls-3" d="M603.56,934.16c.09.11.2.19.33.25"/>
+  </g>
+  <g id="SPLINE-52" data-name="SPLINE">
+    <path class="cls-3" d="M603.35,933.8c.04.13.11.25.21.36"/>
+  </g>
+  <g id="SPLINE-53" data-name="SPLINE">
+    <path class="cls-3" d="M603.67,932.66c-.11.09-.19.2-.25.33"/>
+  </g>
+  <g id="ARC-71" data-name="ARC">
+    <path class="cls-3" d="M604.61,932.44c-.33-.08-.68,0-.94.23"/>
+  </g>
+  <g id="SPLINE-54" data-name="SPLINE">
+    <path class="cls-3" d="M608.42,932.11c-.08-.24-.34-.37-.57-.29"/>
+  </g>
+  <g id="ARC-72" data-name="ARC">
+    <path class="cls-3" d="M608.13,932.69c.24-.08.37-.33.29-.57,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="607.84" y1="932.1" x2="604.21" y2="933.01"/>
+  </g>
+  <g id="LWPOLYLINE-1436" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="591.8" y1="892.47" x2="592.41" y2="893.99"/>
+  </g>
+  <g id="ARC-73" data-name="ARC">
+    <path class="cls-3" d="M602.13,890.53c-1.66-4.28-6.48-6.41-10.76-4.75-.14.05-.27.11-.41.17"/>
+  </g>
+  <g id="ARC-74" data-name="ARC">
+    <path class="cls-3" d="M592.64,893.95c-.72-2.11-1.55-4.19-2.47-6.22"/>
+  </g>
+  <g id="LWPOLYLINE-1437" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="589.99" y1="893.08" x2="591.5" y2="897.92"/>
+  </g>
+  <g id="LWPOLYLINE-1438" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="593.01 903.06 590.29 895.5 587.87 887.93"/>
+  </g>
+  <g id="ARC-75" data-name="ARC">
+    <path class="cls-3" d="M594.42,884.61c-1.73.02-3.45.31-5.1.86"/>
+  </g>
+  <g id="ARC-76" data-name="ARC">
+    <path class="cls-3" d="M591.02,886.17c-.55.18-.85.78-.67,1.33h0"/>
+  </g>
+  <g id="SPLINE-55" data-name="SPLINE">
+    <path class="cls-3" d="M591.49,892.27c-.02-.08-.11-.12-.19-.09"/>
+  </g>
+  <g id="SPLINE-56" data-name="SPLINE">
+    <path class="cls-3" d="M590.09,892.78c-.08.02-.12.11-.09.19"/>
+  </g>
+  <g id="LWPOLYLINE-1439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="591.5" y1="892.47" x2="589.99" y2="892.78"/>
+  </g>
+  <g id="ARC-77" data-name="ARC">
+    <path class="cls-3" d="M589.43,885.25c-1.21.22-2.02,1.36-1.84,2.58"/>
+  </g>
+  <g id="LWPOLYLINE-1440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="595.13" y1="893.38" x2="591.5" y2="894.28"/>
+  </g>
+  <g id="LWPOLYLINE-1441" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="592.71" y1="895.5" x2="593.31" y2="897.31"/>
+  </g>
+  <g id="ARC-78" data-name="ARC">
+    <path class="cls-3" d="M596.5,902.56c4.48-1.01,7.3-5.45,6.29-9.93-.14-.63-.36-1.24-.64-1.82"/>
+  </g>
+  <g id="SPLINE-57" data-name="SPLINE">
+    <path class="cls-3" d="M591.51,897.51c.02.08.11.13.19.1"/>
+  </g>
+  <g id="SPLINE-58" data-name="SPLINE">
+    <path class="cls-3" d="M593.21,897.31c.08-.02.12-.11.09-.19"/>
+  </g>
+  <g id="LWPOLYLINE-1442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="593.31" y1="897.31" x2="591.8" y2="897.92"/>
+  </g>
+  <g id="SPLINE-59" data-name="SPLINE">
+    <path class="cls-3" d="M591.58,894.29c-.06,0-.11.02-.17.04"/>
+  </g>
+  <g id="SPLINE-60" data-name="SPLINE">
+    <path class="cls-3" d="M591.41,894.33c-.09.03-.18.08-.26.15"/>
+  </g>
+  <g id="SPLINE-61" data-name="SPLINE">
+    <path class="cls-3" d="M591.16,894.47c-.08.06-.14.15-.18.23"/>
+  </g>
+  <g id="SPLINE-62" data-name="SPLINE">
+    <path class="cls-3" d="M590.98,894.7c-.04.09-.07.19-.08.28"/>
+  </g>
+  <g id="SPLINE-63" data-name="SPLINE">
+    <path class="cls-3" d="M590.9,894.99c0,.1,0,.2.04.29"/>
+  </g>
+  <g id="SPLINE-64" data-name="SPLINE">
+    <path class="cls-3" d="M590.93,895.28c.03.09.08.18.15.26"/>
+  </g>
+  <g id="SPLINE-65" data-name="SPLINE">
+    <path class="cls-3" d="M591.08,895.54c.06.08.15.14.23.18"/>
+  </g>
+  <g id="SPLINE-66" data-name="SPLINE">
+    <path class="cls-3" d="M591.31,895.72c.09.04.19.08.28.08"/>
+  </g>
+  <g id="SPLINE-67" data-name="SPLINE">
+    <path class="cls-3" d="M591.59,895.8c.1,0,.2,0,.29-.04"/>
+  </g>
+  <g id="ARC-79" data-name="ARC">
+    <path class="cls-3" d="M591.91,894.02c-.2-.05-.4-.04-.6.02"/>
+  </g>
+  <g id="SPLINE-68" data-name="SPLINE">
+    <path class="cls-3" d="M591.32,894.04c-.13.04-.25.11-.36.2"/>
+  </g>
+  <g id="SPLINE-69" data-name="SPLINE">
+    <path class="cls-3" d="M590.96,894.24c-.11.09-.19.2-.25.33"/>
+  </g>
+  <g id="SPLINE-70" data-name="SPLINE">
+    <path class="cls-3" d="M590.65,895.38c.04.13.11.25.2.36"/>
+  </g>
+  <g id="SPLINE-71" data-name="SPLINE">
+    <path class="cls-3" d="M590.85,895.74c.09.11.2.19.33.25"/>
+  </g>
+  <g id="SPLINE-72" data-name="SPLINE">
+    <path class="cls-3" d="M595.71,893.69c-.08-.24-.33-.37-.57-.29"/>
+  </g>
+  <g id="LWPOLYLINE-1443" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M595.71,893.69s0,0,0,0c.09.24-.04.5-.28.59l-3.63,1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1444" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M588.78,857.68l-14.22,4.54-1.21-3.64-.91-3.02-.9-2.72-1.51-3.93,14.22-4.54c1.4-.48,2.85-.77,4.32-.88"/>
+  </g>
+  <g id="LWPOLYLINE-1445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="596.04" y1="851.63" x2="596.04" y2="851.63"/>
+  </g>
+  <g id="LWPOLYLINE-1446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="593.31" y1="851.33" x2="593.31" y2="851.33"/>
+  </g>
+  <g id="SPLINE-73" data-name="SPLINE">
+    <path class="cls-3" d="M593.43,845.19c.13-.09.19-.25.18-.41"/>
+  </g>
+  <g id="SPLINE-74" data-name="SPLINE">
+    <path class="cls-3" d="M593.62,844.78c-.02-.16-.11-.3-.26-.36"/>
+  </g>
+  <g id="LWPOLYLINE-1447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="593.62" y1="845.28" x2="591.8" y2="846.79"/>
+  </g>
+  <g id="ARC-80" data-name="ARC">
+    <path class="cls-3" d="M591.21,846.47c.14.04.29.02.41-.07"/>
+  </g>
+  <g id="ARC-81" data-name="ARC">
+    <path class="cls-3" d="M591.16,846.78c-.67-.21-1.36-.31-2.06-.29"/>
+  </g>
+  <g id="ARC-82" data-name="ARC">
+    <path class="cls-3" d="M582.87,853.62c.33.21.68.39,1.05.51"/>
+  </g>
+  <g id="ARC-83" data-name="ARC">
+    <path class="cls-3" d="M591.18,852.85c.57-.4,1.07-.89,1.48-1.46"/>
+  </g>
+  <g id="SPLINE-75" data-name="SPLINE">
+    <path class="cls-3" d="M593.16,851.33c-.15,0-.27.07-.36.19"/>
+  </g>
+  <g id="LWPOLYLINE-1448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="593.31" y1="851.33" x2="595.74" y2="851.33"/>
+  </g>
+  <g id="SPLINE-76" data-name="SPLINE">
+    <path class="cls-3" d="M595.99,851.98c.06-.14.06-.3-.02-.44"/>
+  </g>
+  <g id="SPLINE-77" data-name="SPLINE">
+    <path class="cls-3" d="M595.97,851.54c-.09-.13-.23-.21-.38-.21"/>
+  </g>
+  <g id="ARC-84" data-name="ARC">
+    <path class="cls-3" d="M581.19,856.14c.55.36,1.14.65,1.76.86"/>
+  </g>
+  <g id="LWPOLYLINE-1449" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="581.21 856.47 579.7 857.08 577.58 850.42 579.09 849.82"/>
+  </g>
+  <g id="ARC-85" data-name="ARC">
+    <path class="cls-3" d="M587.05,843.35c-1.84.32-3.58,1.05-5.09,2.13"/>
+  </g>
+  <g id="ARC-86" data-name="ARC">
+    <path class="cls-3" d="M594.42,846.49c-.42-.34-.87-.62-1.36-.86"/>
+  </g>
+  <g id="LWPOLYLINE-1450" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="663.8" y1="804.14" x2="631.43" y2="788.11"/>
+  </g>
+  <g id="ARC-87" data-name="ARC">
+    <path class="cls-3" d="M631.3,787.84c-4.28,8.58-4.98,18.51-1.95,27.6"/>
+  </g>
+  <g id="LWPOLYLINE-1451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="603" y1="822.59" x2="573.95" y2="832.27"/>
+  </g>
+  <g id="LWPOLYLINE-1452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="573.35" y1="830.76" x2="602.39" y2="821.08"/>
+  </g>
+  <g id="LWPOLYLINE-1453" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="569.11 820.17 567.91 820.47 565.48 813.82 566.99 813.52"/>
+  </g>
+  <g id="SPLINE-78" data-name="SPLINE">
+    <path class="cls-3" d="M581.63,808.58c.13-.09.19-.25.18-.41"/>
+  </g>
+  <g id="SPLINE-79" data-name="SPLINE">
+    <path class="cls-3" d="M581.82,808.18c-.02-.16-.11-.3-.26-.36"/>
+  </g>
+  <g id="LWPOLYLINE-1454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="581.52" y1="808.98" x2="579.7" y2="810.18"/>
+  </g>
+  <g id="SPLINE-80" data-name="SPLINE">
+    <path class="cls-3" d="M581.06,814.72c-.15,0-.27.07-.36.18"/>
+  </g>
+  <g id="LWPOLYLINE-1455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="581.21" y1="815.03" x2="583.64" y2="815.03"/>
+  </g>
+  <g id="SPLINE-81" data-name="SPLINE">
+    <path class="cls-3" d="M583.89,815.37c.06-.14.06-.31-.02-.44"/>
+  </g>
+  <g id="SPLINE-82" data-name="SPLINE">
+    <path class="cls-3" d="M583.87,814.94c-.09-.13-.23-.21-.38-.21"/>
+  </g>
+  <g id="LWPOLYLINE-1456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="581.21" y1="815.03" x2="581.21" y2="815.03"/>
+  </g>
+  <g id="ARC-88" data-name="ARC">
+    <path class="cls-3" d="M583.2,816.71c.24-.35.46-.72.64-1.11"/>
+  </g>
+  <g id="LWPOLYLINE-1457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="583.94" y1="815.33" x2="583.94" y2="815.33"/>
+  </g>
+  <g id="ARC-89" data-name="ARC">
+    <path class="cls-3" d="M582.32,809.89c-.42-.34-.87-.62-1.36-.86"/>
+  </g>
+  <g id="LWPOLYLINE-1458" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="605.11" y1="822.59" x2="603.6" y2="823.19"/>
+  </g>
+  <g id="LWPOLYLINE-1459" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="605.11 822.59 605.42 822.59 605.72 822.59 606.02 823.19 603.3 824.1 602.99 823.8 603.3 823.49 603.6 823.19 603.6 822.89"/>
+  </g>
+  <g id="ARC-90" data-name="ARC">
+    <path class="cls-3" d="M603.27,822.9c-.07-.24-.32-.37-.56-.29,0,0,0,0-.01,0"/>
+  </g>
+  <g id="ARC-91" data-name="ARC">
+    <path class="cls-3" d="M604.71,822.43c-.34-1.03-1.45-1.59-2.48-1.25,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1460" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M563.67,829.85l-.9-2.72.6-.3.3.3v.6l.29-.33c.25-.07.39-.33.31-.58,0,0,0,0,0,0l-9.37-29.04"/>
+  </g>
+  <g id="LWPOLYLINE-1461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="556.1" y1="797.48" x2="565.78" y2="826.52"/>
+  </g>
+  <g id="LWPOLYLINE-1462" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="554.29 797.48 553.99 797.78 553.99 798.09 553.99 798.38 553.38 798.69 552.47 795.66 553.08 795.66 553.38 795.66 553.38 796.27 553.68 796.27"/>
+  </g>
+  <g id="ARC-92" data-name="ARC">
+    <path class="cls-3" d="M554.57,797.79c-.08-.24-.33-.37-.57-.29,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="553.99" y1="797.78" x2="553.38" y2="796.27"/>
+  </g>
+  <g id="ARC-93" data-name="ARC">
+    <path class="cls-3" d="M556,797.32c-.34-1.03-1.45-1.59-2.48-1.25,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-94" data-name="ARC">
+    <path class="cls-3" d="M576.34,821.14c.48-.16.96-.34,1.42-.54"/>
+  </g>
+  <g id="LWPOLYLINE-1464" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="576.67" y1="821.38" x2="565.18" y2="825.01"/>
+  </g>
+  <g id="LWPOLYLINE-1465" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="560.94" y1="811.7" x2="572.14" y2="808.07"/>
+  </g>
+  <g id="LWPOLYLINE-1466" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="563.97 825.31 562.46 825.92 561.25 821.99 560.34 819.26 559.43 816.24 558.22 812.61 559.43 812"/>
+  </g>
+  <g id="LWPOLYLINE-1467" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="564.27" y1="828.94" x2="563.67" y2="827.74"/>
+  </g>
+  <g id="LWPOLYLINE-1468" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="564.57 829.55 564.27 829.85 563.67 829.85"/>
+  </g>
+  <g id="LWPOLYLINE-1469" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M565.68,826.36s0,0,0,0c.41,1.02-.09,2.17-1.11,2.58h-.3l.3.61"/>
+  </g>
+  <g id="LWPOLYLINE-1470" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="573.65 832.88 573.65 833.18 574.26 832.88 574.55 833.18 574.55 833.48 571.83 834.39 571.53 834.08 571.83 833.78 572.14 833.48 572.14 833.18"/>
+  </g>
+  <g id="ARC-95" data-name="ARC">
+    <path class="cls-3" d="M573.66,831.99c-.24.07-.37.32-.29.56,0,0,0,0,0,.01"/>
+  </g>
+  <g id="LWPOLYLINE-1471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="573.65" y1="833.18" x2="572.14" y2="833.48"/>
+  </g>
+  <g id="ARC-96" data-name="ARC">
+    <path class="cls-3" d="M573.19,830.55c-1.03.34-1.59,1.45-1.25,2.48,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1472" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="631.43 908.2 634.76 922.42 638.09 908.2 641.41 922.42 644.75 908.2"/>
+  </g>
+  <g id="LWPOLYLINE-1473" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="651.4 908.2 650.19 908.81 648.98 910.32 648.07 911.53 647.47 913.65 647.47 916.98 648.07 919.1 648.98 920.3 650.19 921.52 651.4 922.42 654.12 922.42 655.63 921.52 656.85 920.3 657.45 919.1 658.36 916.98 658.36 913.65 657.45 911.53 656.85 910.32 655.63 908.81 654.12 908.2 651.4 908.2"/>
+  </g>
+  <g id="LWPOLYLINE-1474" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="662.29 922.42 662.29 908.2 667.43 922.42 672.88 908.2 672.88 922.42"/>
+  </g>
+  <g id="LWPOLYLINE-1475" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="686.8 922.42 678.32 922.42 678.32 908.2 686.8 908.2"/>
+  </g>
+  <g id="LWPOLYLINE-1476" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="678.32" y1="914.86" x2="683.47" y2="914.86"/>
+  </g>
+  <g id="LWPOLYLINE-1477" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="691.03 922.42 691.03 908.2 700.41 922.42 700.41 908.2"/>
+  </g>
+  <g id="LWPOLYLINE-1478" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="527.97 1207.4 527.97 1193.18 533.42 1207.4 538.56 1193.18 538.56 1207.4"/>
+  </g>
+  <g id="LWPOLYLINE-1479" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="544 1207.4 549.45 1193.18 554.59 1207.4"/>
+  </g>
+  <g id="LWPOLYLINE-1480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="546.12" y1="1202.56" x2="552.77" y2="1202.56"/>
+  </g>
+  <g id="LWPOLYLINE-1481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="558.83" y1="1207.4" x2="558.83" y2="1193.18"/>
+  </g>
+  <g id="LWPOLYLINE-1482" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="563.97 1207.4 563.97 1193.18 573.35 1207.4 573.35 1193.18"/>
+  </g>
+  <g id="LWPOLYLINE-1483" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="591.5 1193.18 591.5 1207.4 599.36 1207.4"/>
+  </g>
+  <g id="LWPOLYLINE-1484" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="606.93 1193.18 605.41 1194.09 604.21 1195.3 603.6 1196.81 602.7 1198.63 602.7 1201.96 603.6 1204.08 604.21 1205.28 605.41 1206.8 606.93 1207.4 609.35 1207.4 610.86 1206.8 612.07 1205.28 612.68 1204.08 613.58 1201.96 613.58 1198.63 612.68 1196.81 612.07 1195.3 610.86 1194.09 609.35 1193.18 606.93 1193.18"/>
+  </g>
+  <g id="LWPOLYLINE-1485" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="623.57 1200.14 625.38 1200.75 626.29 1201.35 626.89 1202.56 626.89 1204.68 626.29 1205.89 625.38 1206.8 623.57 1207.4 617.52 1207.4 617.52 1193.18 623.57 1193.18 625.38 1194.09 626.29 1194.69 626.89 1195.91 626.89 1197.42 626.29 1198.63 625.38 1199.24 623.57 1200.14 617.52 1200.14"/>
+  </g>
+  <g id="LWPOLYLINE-1486" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="637.48 1200.14 639.6 1200.75 640.2 1201.35 640.81 1202.56 640.81 1204.68 640.2 1205.89 639.6 1206.8 637.48 1207.4 631.43 1207.4 631.43 1193.18 637.48 1193.18 639.6 1194.09 640.2 1194.69 640.81 1195.91 640.81 1197.42 640.2 1198.63 639.6 1199.24 637.48 1200.14 631.43 1200.14"/>
+  </g>
+  <g id="LWPOLYLINE-1487" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="645.65 1193.18 650.8 1200.14 656.24 1193.18"/>
+  </g>
+  <g id="LWPOLYLINE-1488" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="650.79" y1="1200.14" x2="650.79" y2="1207.4"/>
+  </g>
+  <g id="LWPOLYLINE-1489" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="534.02 1086.39 532.5 1085.18 530.69 1084.57 527.97 1084.57 525.85 1085.18 524.64 1086.39 524.64 1087.91 525.25 1089.11 525.85 1089.72 527.37 1090.32 531.3 1091.84 532.5 1092.44 533.41 1093.04 534.02 1094.56 534.02 1096.37 532.5 1097.89 530.69 1098.49 527.97 1098.49 525.85 1097.89 524.64 1096.37"/>
+  </g>
+  <g id="LWPOLYLINE-1490" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="546.73 1098.49 537.95 1098.49 537.95 1084.57 546.73 1084.57"/>
+  </g>
+  <g id="LWPOLYLINE-1491" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="537.95" y1="1091.23" x2="543.4" y2="1091.23"/>
+  </g>
+  <g id="LWPOLYLINE-1492" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="560.64 1087.9 560.04 1086.39 558.82 1085.18 557.31 1084.58 554.59 1084.58 553.38 1085.18 552.17 1086.39 551.27 1087.9 550.66 1089.72 550.66 1093.05 551.27 1095.16 552.17 1096.38 553.38 1097.89 554.59 1098.5 557.31 1098.5 558.82 1097.89 560.04 1096.38 560.64 1095.16"/>
+  </g>
+  <g id="LWPOLYLINE-1493" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="564.57 1084.58 564.57 1094.56 565.48 1096.37 566.69 1097.89 568.81 1098.49 570.02 1098.49 572.14 1097.89 573.35 1096.37 573.95 1094.56 573.95 1084.58"/>
+  </g>
+  <g id="LWPOLYLINE-1494" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="579.4 1098.49 579.4 1084.57 585.45 1084.57 587.57 1085.18 588.17 1085.79 588.77 1087 588.77 1088.51 588.17 1089.72 587.57 1090.32 585.45 1091.23 579.4 1091.23"/>
+  </g>
+  <g id="LWPOLYLINE-1495" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="583.94" y1="1091.23" x2="588.78" y2="1098.5"/>
+  </g>
+  <g id="LWPOLYLINE-1496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="593.31" y1="1098.49" x2="593.31" y2="1084.57"/>
+  </g>
+  <g id="LWPOLYLINE-1497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="603.6" y1="1084.58" x2="603.6" y2="1098.49"/>
+  </g>
+  <g id="LWPOLYLINE-1498" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="598.76" y1="1084.58" x2="608.13" y2="1084.58"/>
+  </g>
+  <g id="LWPOLYLINE-1499" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="610.86 1084.58 616 1091.23 621.45 1084.58"/>
+  </g>
+  <g id="LWPOLYLINE-1500" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="616" y1="1091.23" x2="616" y2="1098.5"/>
+  </g>
+  <g id="LWPOLYLINE-1501" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="464.14 1147.2 462.93 1145.99 460.81 1145.38 458.09 1145.38 456.27 1145.99 454.76 1147.2 454.76 1148.71 455.36 1149.92 456.27 1150.53 457.48 1151.43 461.42 1152.65 462.93 1153.25 463.53 1153.85 464.14 1155.37 464.14 1157.18 462.93 1158.69 460.81 1159.3 458.09 1159.3 456.27 1158.69 454.76 1157.18"/>
+  </g>
+  <g id="LWPOLYLINE-1502" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="472.91" y1="1145.38" x2="472.91" y2="1159.3"/>
+  </g>
+  <g id="LWPOLYLINE-1503" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="468.07" y1="1145.38" x2="477.44" y2="1145.38"/>
+  </g>
+  <g id="LWPOLYLINE-1504" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="480.17 1159.3 485.62 1145.38 490.76 1159.3"/>
+  </g>
+  <g id="LWPOLYLINE-1505" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="482.29" y1="1154.76" x2="488.94" y2="1154.76"/>
+  </g>
+  <g id="LWPOLYLINE-1506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="494.99" y1="1159.3" x2="494.99" y2="1145.38"/>
+  </g>
+  <g id="LWPOLYLINE-1507" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="500.14 1159.3 500.14 1145.38 506.18 1145.38 508.3 1145.99 508.91 1146.6 509.51 1148.11 509.51 1149.32 508.91 1150.53 508.3 1151.44 506.18 1152.04 500.14 1152.04"/>
+  </g>
+  <g id="LWPOLYLINE-1508" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="504.98" y1="1152.04" x2="509.51" y2="1159.3"/>
+  </g>
+  <g id="LWPOLYLINE-1509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="514.36" y1="1153.25" x2="526.15" y2="1153.25"/>
+  </g>
+  <g id="LWPOLYLINE-1510" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="531.6 1148.11 532.81 1147.2 534.93 1145.39 534.93 1159.3"/>
+  </g>
+  <g id="LWPOLYLINE-1511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2046.34" y1="379.99" x2="2042.41" y2="367.59"/>
+  </g>
+  <g id="LWPOLYLINE-1512" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2048.46 379.99 2047.85 378.48 2046.64 377.87 2045.13 378.48 2044.53 379.99 2045.13 381.2 2046.64 381.81 2047.85 381.2 2048.46 379.99"/>
+  </g>
+  <g id="LWPOLYLINE-1513" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2038.18 376.06 2042.41 367.59 2050.88 371.82"/>
+  </g>
+  <g id="LWPOLYLINE-1514" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.46 461.37 2155.26 459.86 2153.44 458.95 2150.71 458.65 2148.6 459.25 2147.08 460.47 2147.08 461.68 2147.39 463.19 2147.99 463.8 2149.2 464.7 2153.14 466.52 2154.34 467.12 2154.95 468.03 2155.56 469.24 2155.26 471.36 2153.74 472.56 2151.62 472.87 2149.2 472.56 2147.08 471.66 2145.87 470.15"/>
+  </g>
+  <g id="LWPOLYLINE-1515" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2165.23" y1="460.47" x2="2163.72" y2="474.38"/>
+  </g>
+  <g id="LWPOLYLINE-1516" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2160.7" y1="459.86" x2="2169.77" y2="460.77"/>
+  </g>
+  <g id="LWPOLYLINE-1517" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2170.98 474.99 2177.94 461.68 2181.57 476.19"/>
+  </g>
+  <g id="LWPOLYLINE-1518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2173.4" y1="470.75" x2="2180.06" y2="471.36"/>
+  </g>
+  <g id="LWPOLYLINE-1519" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2185.5" y1="476.8" x2="2187.02" y2="462.89"/>
+  </g>
+  <g id="LWPOLYLINE-1520" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2190.95 477.41 2192.46 463.49 2198.52 464.1 2200.32 465 2200.93 465.91 2201.54 467.12 2201.24 468.64 2200.32 469.84 2199.72 470.45 2197.6 470.75 2191.56 470.15"/>
+  </g>
+  <g id="LWPOLYLINE-1521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2196.4" y1="470.75" x2="2200.02" y2="478.32"/>
+  </g>
+  <g id="LWPOLYLINE-1522" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2205.47" y1="472.87" x2="2217.57" y2="474.38"/>
+  </g>
+  <g id="LWPOLYLINE-1523" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2223.92 470.45 2223.92 469.84 2224.83 468.63 2225.44 468.03 2226.95 467.43 2229.67 467.73 2230.88 468.63 2231.49 469.24 2232.09 470.75 2231.79 471.96 2230.88 473.17 2229.37 474.99 2222.11 481.04 2231.49 481.94"/>
+  </g>
+  <g id="LWPOLYLINE-1524" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2038.47 389.07 2041.2 397.24 2042.41 398.45 2043.62 399.36 2045.44 399.36 2046.64 399.05 2048.16 397.85 2048.76 396.34 2048.76 394.52 2046.04 386.35"/>
+  </g>
+  <g id="LWPOLYLINE-1525" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2054.21 396.33 2050.58 385.14 2055.41 383.33 2057.23 383.33 2057.84 383.93 2058.75 384.84 2059.35 386.35 2059.05 387.56 2058.75 388.47 2057.23 389.37 2052.39 390.89"/>
+  </g>
+  <g id="LWPOLYLINE-1526" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2095.35" y1="735.16" x2="2096.87" y2="721.24"/>
+  </g>
+  <g id="LWPOLYLINE-1527" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2106.24" y1="722.15" x2="2095.96" y2="730.32"/>
+  </g>
+  <g id="LWPOLYLINE-1528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.59" y1="727.6" x2="2104.73" y2="736.07"/>
+  </g>
+  <g id="LWPOLYLINE-1529" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2109.27" y1="736.67" x2="2110.78" y2="722.75"/>
+  </g>
+  <g id="LWPOLYLINE-1530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2120.76" y1="723.97" x2="2119.25" y2="737.88"/>
+  </g>
+  <g id="LWPOLYLINE-1531" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2116.23" y1="723.36" x2="2125.3" y2="724.27"/>
+  </g>
+  <g id="LWPOLYLINE-1532" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2137.7 729.11 2137.1 727.59 2135.89 726.08 2134.68 725.48 2131.96 725.18 2130.75 725.48 2129.23 726.69 2128.33 728.2 2127.42 730.01 2127.11 733.34 2127.42 735.46 2128.03 736.68 2129.23 738.19 2130.44 739.09 2133.16 739.4 2134.68 738.79 2135.89 737.58 2136.8 736.37"/>
+  </g>
+  <g id="LWPOLYLINE-1533" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.43" y1="740.3" x2="2141.94" y2="726.38"/>
+  </g>
+  <g id="LWPOLYLINE-1534" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.32" y1="727.29" x2="2149.8" y2="741.21"/>
+  </g>
+  <g id="LWPOLYLINE-1535" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2141.34" y1="732.74" x2="2150.71" y2="733.95"/>
+  </g>
+  <g id="LWPOLYLINE-1536" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2163.72 742.72 2154.95 741.81 2156.77 727.9 2165.24 728.81"/>
+  </g>
+  <g id="LWPOLYLINE-1537" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2155.86" y1="734.55" x2="2161.3" y2="735.16"/>
+  </g>
+  <g id="LWPOLYLINE-1538" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.65 743.33 2169.17 729.41 2177.03 744.23 2178.55 730.32"/>
+  </g>
+  <g id="LWPOLYLINE-1539" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2174.32 413.27 2166.75 412.36 2168.26 400.57 2175.52 401.18"/>
+  </g>
+  <g id="LWPOLYLINE-1540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2167.65" y1="406.32" x2="2172.19" y2="406.62"/>
+  </g>
+  <g id="LWPOLYLINE-1541" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2177.64 413.58 2178.84 401.78 2184 402.08 2185.81 402.98 2186.11 403.6 2186.72 404.8 2186.41 406.32 2185.81 407.53 2185.2 408.13 2183.39 408.43 2178.24 407.83"/>
+  </g>
+  <g id="LWPOLYLINE-1542" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2196.09 346.11 2194.89 356.7 2193.97 358.82 2193.07 359.42 2191.86 359.72 2190.34 359.72 2189.14 358.82 2188.52 358.21 2188.23 356.09 2188.23 354.58"/>
+  </g>
+  <g id="LWPOLYLINE-1543" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2198.51 360.63 2205.17 347.32 2209.1 361.84"/>
+  </g>
+  <g id="LWPOLYLINE-1544" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2200.93" y1="356.1" x2="2207.59" y2="357"/>
+  </g>
+  <g id="LWPOLYLINE-1545" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2213.03 362.15 2214.55 348.23 2222.41 363.35 2223.93 349.44"/>
+  </g>
+  <g id="LWPOLYLINE-1546" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2228.46 362.75 2227.56 363.36 2228.16 363.96 2229.07 363.36"/>
+  </g>
+  <g id="LWPOLYLINE-1547" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1666.07 1178.36 1664.55 1177.15 1662.74 1176.54 1660.02 1176.54 1657.9 1177.15 1656.69 1178.36 1656.69 1179.87 1657.29 1181.08 1657.9 1181.69 1659.11 1182.59 1663.35 1183.81 1664.55 1184.41 1665.16 1185.01 1666.07 1186.53 1666.07 1188.34 1664.55 1189.85 1662.74 1190.46 1660.02 1190.46 1657.9 1189.85 1656.69 1188.34"/>
+  </g>
+  <g id="LWPOLYLINE-1548" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1674.54" y1="1176.54" x2="1674.54" y2="1190.46"/>
+  </g>
+  <g id="LWPOLYLINE-1549" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1670" y1="1176.54" x2="1679.38" y2="1176.54"/>
+  </g>
+  <g id="LWPOLYLINE-1550" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1686.03 1176.54 1684.52 1177.15 1683.31 1178.36 1682.71 1179.87 1682.1 1181.69 1682.1 1185.01 1682.71 1187.13 1683.31 1188.34 1684.52 1189.86 1686.03 1190.46 1688.76 1190.46 1689.97 1189.86 1691.18 1188.34 1692.08 1187.13 1692.69 1185.01 1692.69 1181.69 1692.08 1179.87 1691.18 1178.36 1689.97 1177.15 1688.76 1176.54 1686.03 1176.54"/>
+  </g>
+  <g id="LWPOLYLINE-1551" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1696.62 1190.46 1696.62 1176.54 1702.67 1176.54 1704.79 1177.15 1705.4 1177.76 1706 1178.96 1706 1180.48 1705.4 1181.69 1704.79 1182.59 1702.67 1183.2 1696.62 1183.2"/>
+  </g>
+  <g id="LWPOLYLINE-1552" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1701.46" y1="1183.2" x2="1706" y2="1190.46"/>
+  </g>
+  <g id="LWPOLYLINE-1553" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1711.45 1189.25 1710.54 1189.85 1711.45 1190.46 1712.05 1189.85"/>
+  </g>
+  <g id="LWPOLYLINE-1554" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1970.11 1179.27 1968.9 1178.06 1966.78 1177.45 1964.06 1177.45 1962.24 1178.06 1960.72 1179.27 1960.72 1180.78 1961.64 1181.99 1962.24 1182.59 1963.45 1183.2 1967.39 1184.71 1968.9 1185.31 1969.5 1185.92 1970.11 1187.43 1970.11 1189.25 1968.9 1190.76 1966.78 1191.37 1964.06 1191.37 1962.24 1190.76 1960.72 1189.25"/>
+  </g>
+  <g id="LWPOLYLINE-1555" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1978.88" y1="1177.45" x2="1978.88" y2="1191.37"/>
+  </g>
+  <g id="LWPOLYLINE-1556" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1974.34" y1="1177.45" x2="1983.42" y2="1177.45"/>
+  </g>
+  <g id="LWPOLYLINE-1557" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1990.37 1177.45 1988.86 1178.06 1987.66 1179.27 1986.74 1180.78 1986.14 1182.6 1986.14 1185.92 1986.74 1188.04 1987.66 1189.25 1988.86 1190.76 1990.37 1191.37 1992.8 1191.37 1994.31 1190.76 1995.52 1189.25 1996.12 1188.04 1997.03 1185.92 1997.03 1182.6 1996.12 1180.78 1995.52 1179.27 1994.31 1178.06 1992.8 1177.45 1990.37 1177.45"/>
+  </g>
+  <g id="LWPOLYLINE-1558" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2000.96 1191.37 2000.96 1177.45 2007.01 1177.45 2008.83 1178.06 2009.74 1178.67 2010.35 1179.87 2010.35 1181.39 2009.74 1182.59 2008.83 1183.2 2007.01 1184.11 2000.96 1184.11"/>
+  </g>
+  <g id="LWPOLYLINE-1559" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2005.5" y1="1184.11" x2="2010.34" y2="1191.37"/>
+  </g>
+  <g id="LWPOLYLINE-1560" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2015.49 1190.16 2014.88 1190.76 2015.49 1191.36 2016.39 1190.76"/>
+  </g>
+  <g id="LWPOLYLINE-1561" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2103.52 1005.92 2102.31 1004.41 2100.19 1003.8 2097.47 1003.8 2095.66 1004.41 2094.14 1005.92 2094.14 1007.13 2094.75 1008.64 2095.66 1009.25 2096.86 1009.85 2100.8 1011.06 2102.31 1011.97 2102.91 1012.57 2103.52 1013.78 2103.52 1015.9 2102.31 1017.12 2100.19 1017.72 2097.47 1017.72 2095.66 1017.12 2094.14 1015.9"/>
+  </g>
+  <g id="LWPOLYLINE-1562" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.29" y1="1003.8" x2="2112.29" y2="1017.72"/>
+  </g>
+  <g id="LWPOLYLINE-1563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2107.45" y1="1003.8" x2="2116.83" y2="1003.8"/>
+  </g>
+  <g id="LWPOLYLINE-1564" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2123.49 1003.8 2122.28 1004.41 2121.06 1005.92 2120.16 1007.13 2119.55 1009.25 2119.55 1012.58 2120.16 1014.39 2121.06 1015.9 2122.28 1017.11 2123.49 1017.72 2126.21 1017.72 2127.72 1017.11 2128.93 1015.9 2129.53 1014.39 2130.44 1012.58 2130.44 1009.25 2129.53 1007.13 2128.93 1005.92 2127.72 1004.41 2126.21 1003.8 2123.49 1003.8"/>
+  </g>
+  <g id="LWPOLYLINE-1565" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2134.38 1017.72 2134.38 1003.8 2140.42 1003.8 2142.24 1004.41 2142.85 1005.31 2143.76 1006.53 2143.76 1007.74 2142.85 1009.25 2142.24 1009.85 2140.42 1010.46 2134.38 1010.46"/>
+  </g>
+  <g id="LWPOLYLINE-1566" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.92" y1="1010.46" x2="2143.76" y2="1017.72"/>
+  </g>
+  <g id="LWPOLYLINE-1567" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2148.9 1016.51 2148.29 1017.11 2148.9 1017.71 2149.8 1017.11"/>
+  </g>
+  <g id="LWPOLYLINE-1568" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1967.38 530.95 1965.87 529.75 1964.06 528.83 1961.34 528.83 1959.22 529.75 1958 530.95 1958 532.16 1958.61 533.68 1959.22 534.28 1960.42 534.89 1964.66 536.4 1965.87 537 1966.48 537.61 1967.38 539.12 1967.38 540.94 1965.87 542.45 1964.06 543.06 1961.34 543.06 1959.22 542.45 1958 540.94"/>
+  </g>
+  <g id="LWPOLYLINE-1569" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1975.85" y1="528.84" x2="1975.85" y2="543.06"/>
+  </g>
+  <g id="LWPOLYLINE-1570" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1971.32" y1="528.84" x2="1980.69" y2="528.84"/>
+  </g>
+  <g id="LWPOLYLINE-1571" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1987.35 528.84 1985.84 529.74 1984.63 530.96 1984.02 532.16 1983.41 534.28 1983.41 537.61 1984.02 539.73 1984.63 540.94 1985.84 542.45 1987.35 543.06 1990.07 543.06 1991.28 542.45 1992.49 540.94 1993.4 539.73 1994 537.61 1994 534.28 1993.4 532.16 1992.49 530.96 1991.28 529.74 1990.07 528.84 1987.35 528.84"/>
+  </g>
+  <g id="LWPOLYLINE-1572" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1997.94 543.06 1997.94 528.83 2003.99 528.83 2006.11 529.75 2006.71 530.35 2007.32 531.56 2007.32 533.07 2006.71 534.28 2006.11 534.89 2003.99 535.8 1997.94 535.8"/>
+  </g>
+  <g id="LWPOLYLINE-1573" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2002.78" y1="535.79" x2="2007.32" y2="543.05"/>
+  </g>
+  <g id="LWPOLYLINE-1574" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2012.76 541.54 2012.16 542.45 2012.76 543.06 2013.37 542.45"/>
+  </g>
+  <g id="LWPOLYLINE-1575" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2112.29 304.06 2108.06 290.75 2117.44 302.55 2118.04 287.42 2122.58 300.73"/>
+  </g>
+  <g id="LWPOLYLINE-1576" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2135.89 296.5 2127.72 299.22 2123.18 285.91 2131.35 283.19"/>
+  </g>
+  <g id="LWPOLYLINE-1577" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2125.3" y1="292.26" x2="2130.45" y2="290.45"/>
+  </g>
+  <g id="LWPOLYLINE-1578" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2145.87 281.98 2144.67 280.77 2143.15 279.86 2141.63 279.86 2139.21 280.46 2138.01 281.67 2137.1 283.49 2137.1 284.7 2137.1 286.82 2138.01 290.15 2139.21 291.96 2140.43 292.87 2141.94 293.78 2143.45 294.08 2146.18 293.17 2147.08 291.96 2147.99 290.45 2148.3 288.93"/>
+  </g>
+  <g id="LWPOLYLINE-1579" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2153.13" y1="290.75" x2="2148.6" y2="277.44"/>
+  </g>
+  <g id="LWPOLYLINE-1580" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2157.37" y1="274.41" x2="2161.91" y2="287.73"/>
+  </g>
+  <g id="LWPOLYLINE-1581" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2150.71" y1="283.79" x2="2159.49" y2="280.77"/>
+  </g>
+  <g id="LWPOLYLINE-1582" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.05 286.21 2167.65 271.09 2177.03 282.89"/>
+  </g>
+  <g id="LWPOLYLINE-1583" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2167.35" y1="281.07" x2="2173.71" y2="278.95"/>
+  </g>
+  <g id="LWPOLYLINE-1584" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2180.97 281.67 2176.42 268.36 2189.74 278.65 2185.5 265.34"/>
+  </g>
+  <g id="LWPOLYLINE-1585" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2194.88" y1="276.83" x2="2190.34" y2="263.52"/>
+  </g>
+  <g id="LWPOLYLINE-1586" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2206.08 262.01 2205.17 261.11 2203.35 260.19 2201.85 259.89 2199.42 260.8 2198.21 261.71 2197.6 263.52 2197.3 265.03 2197.3 267.15 2198.21 270.18 2199.42 271.99 2200.63 272.9 2202.14 273.81 2203.65 274.11 2206.38 273.2 2207.28 272.3 2208.2 270.48 2208.5 268.97"/>
+  </g>
+  <g id="LWPOLYLINE-1587" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2213.34 270.78 2213.94 255.96 2223.32 267.46"/>
+  </g>
+  <g id="LWPOLYLINE-1588" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2213.64" y1="265.94" x2="2219.99" y2="263.82"/>
+  </g>
+  <g id="LWPOLYLINE-1589" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2222.71 252.94 2227.25 266.24 2234.82 263.82"/>
+  </g>
+  <g id="LWPOLYLINE-1590" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1020.48 1244.92 1020.48 1250.96 1014.43 1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1591" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1011.4" y1="1250.96" x2="1005.65" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1592" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1002.63" y1="1250.96" x2="996.58" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1593" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="993.55" y1="1250.96" x2="987.51" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1594" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="984.48" y1="1250.96" x2="978.43" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1595" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="975.4" y1="1250.96" x2="969.36" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1596" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="966.33" y1="1250.96" x2="960.28" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="957.55" y1="1250.96" x2="951.51" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1598" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="948.48" y1="1250.96" x2="942.43" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1599" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="939.4" y1="1250.96" x2="933.36" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1600" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="930.33" y1="1250.96" x2="924.28" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1601" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="921.25" y1="1250.96" x2="915.5" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1602" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1020.48" y1="1244.91" x2="1014.43" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1603" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1011.4" y1="1244.91" x2="1005.65" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1604" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1002.63" y1="1244.91" x2="996.58" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1605" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="993.55" y1="1244.91" x2="987.51" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1606" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="984.48" y1="1244.91" x2="978.43" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1607" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="975.4" y1="1244.91" x2="969.36" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1608" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="966.33" y1="1244.91" x2="960.28" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1609" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="957.55" y1="1244.91" x2="951.51" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1610" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="948.48" y1="1244.91" x2="942.43" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1611" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="939.4" y1="1244.91" x2="933.36" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1612" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="930.33" y1="1244.91" x2="924.28" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1613" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="921.25" y1="1244.91" x2="915.5" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1614" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1178.1 1244.92 1178.1 1250.96 1185.35 1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1615" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1188.38" y1="1250.96" x2="1194.43" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1616" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1197.46" y1="1250.96" x2="1203.5" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1617" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1206.53" y1="1250.96" x2="1212.58" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1618" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1215.61" y1="1250.96" x2="1221.36" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1224.38" y1="1250.96" x2="1230.43" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1620" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1233.46" y1="1250.96" x2="1239.51" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1621" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1242.53" y1="1250.96" x2="1248.58" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1622" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1251.61" y1="1250.96" x2="1257.66" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1623" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1260.68" y1="1250.96" x2="1266.73" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1624" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1269.46" y1="1250.96" x2="1275.51" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1625" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1278.53" y1="1250.96" x2="1284.58" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1626" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1287.61" y1="1250.96" x2="1295.18" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1627" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1178.1" y1="1244.91" x2="1185.35" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1628" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1188.38" y1="1244.91" x2="1194.43" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1629" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1197.46" y1="1244.91" x2="1203.5" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1630" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1206.53" y1="1244.91" x2="1212.58" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1631" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1215.61" y1="1244.91" x2="1221.36" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1632" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1224.38" y1="1244.91" x2="1230.43" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1633" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1233.46" y1="1244.91" x2="1239.51" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1634" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1242.53" y1="1244.91" x2="1248.58" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1251.61" y1="1244.91" x2="1257.66" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1636" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1260.68" y1="1244.91" x2="1266.73" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1637" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1269.46" y1="1244.91" x2="1275.51" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1638" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1278.53" y1="1244.91" x2="1284.58" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1639" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1287.61" y1="1244.91" x2="1295.18" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1640" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1412.25 1244.92 1412.25 1250.96 1404.68 1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1641" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1401.66" y1="1250.96" x2="1395.91" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1642" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1392.89" y1="1250.96" x2="1386.84" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1643" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1383.81" y1="1250.96" x2="1377.76" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1644" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1374.74" y1="1250.96" x2="1368.69" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1645" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1365.66" y1="1250.96" x2="1359.61" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1646" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1356.59" y1="1250.96" x2="1350.84" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1647" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1347.81" y1="1250.96" x2="1341.76" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1648" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1338.74" y1="1250.96" x2="1332.69" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1649" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1329.66" y1="1250.96" x2="1323.61" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1650" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1320.58" y1="1250.96" x2="1314.54" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1651" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.51" y1="1250.96" x2="1305.46" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1652" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.74" y1="1250.96" x2="1295.17" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1653" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1412.25" y1="1244.91" x2="1404.68" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1654" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1401.66" y1="1244.91" x2="1395.91" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1655" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1392.89" y1="1244.91" x2="1386.84" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1656" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1383.81" y1="1244.91" x2="1377.76" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1657" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1374.74" y1="1244.91" x2="1368.69" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1658" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1365.66" y1="1244.91" x2="1359.61" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1659" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1356.59" y1="1244.91" x2="1350.84" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1660" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1347.81" y1="1244.91" x2="1341.76" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1661" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1338.74" y1="1244.91" x2="1332.69" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1662" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1329.66" y1="1244.91" x2="1323.61" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1663" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1320.58" y1="1244.91" x2="1314.54" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1664" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.51" y1="1244.91" x2="1305.46" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1665" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1302.74" y1="1244.91" x2="1295.17" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1666" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1569.56 1244.92 1569.56 1250.96 1575.31 1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1667" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1578.34" y1="1250.96" x2="1584.38" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1668" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1587.41" y1="1250.96" x2="1593.46" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1669" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1596.49" y1="1250.96" x2="1602.54" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1670" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1605.56" y1="1250.96" x2="1611.61" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1671" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1614.64" y1="1250.96" x2="1620.39" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1672" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.41" y1="1250.96" x2="1629.46" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1673" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1632.49" y1="1250.96" x2="1638.53" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1674" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1641.56" y1="1250.96" x2="1647.61" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1675" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1650.64" y1="1250.96" x2="1656.69" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1676" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.72" y1="1250.96" x2="1665.47" y2="1250.96"/>
+  </g>
+  <g id="LWPOLYLINE-1677" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1569.56" y1="1244.91" x2="1575.31" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1678" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1578.34" y1="1244.91" x2="1584.38" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1679" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1587.41" y1="1244.91" x2="1593.46" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1680" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1596.49" y1="1244.91" x2="1602.54" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1681" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1605.56" y1="1244.91" x2="1611.61" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1682" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1614.64" y1="1244.91" x2="1620.39" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1683" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.41" y1="1244.91" x2="1629.46" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1684" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1632.49" y1="1244.91" x2="1638.53" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1685" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1641.56" y1="1244.91" x2="1647.61" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1686" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1650.64" y1="1244.91" x2="1656.69" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1687" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.72" y1="1244.91" x2="1665.47" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1688" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1547.78 542.45 1547.18 541.25 1545.96 539.73 1544.45 539.12 1542.03 539.12 1540.52 539.73 1539.31 541.25 1538.7 542.45 1537.8 544.57 1537.8 547.9 1538.7 549.72 1539.31 551.23 1540.52 552.43 1542.03 553.04 1544.45 553.04 1545.96 552.43 1547.18 551.23 1547.78 549.72"/>
+  </g>
+  <g id="LWPOLYLINE-1689" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1555.95 539.12 1554.74 539.73 1553.23 541.24 1552.62 542.45 1552.01 544.57 1552.01 547.9 1552.62 549.71 1553.23 551.22 1554.74 552.44 1555.95 553.04 1558.67 553.04 1559.88 552.44 1561.4 551.22 1562 549.71 1562.6 547.9 1562.6 544.57 1562 542.45 1561.4 541.24 1559.88 539.73 1558.67 539.12 1555.95 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1690" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1566.54 553.04 1566.54 539.12 1575.91 553.04 1575.91 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1691" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1581.36 553.04 1581.36 539.12 1590.14 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1692" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1581.36" y1="545.78" x2="1586.81" y2="545.78"/>
+  </g>
+  <g id="LWPOLYLINE-1693" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1601.93 553.04 1593.46 553.04 1593.46 539.12 1601.93 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1694" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1593.46" y1="545.78" x2="1598.61" y2="545.78"/>
+  </g>
+  <g id="LWPOLYLINE-1695" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1606.17 553.04 1606.17 539.12 1611.92 539.12 1614.03 539.73 1614.64 540.34 1615.25 541.85 1615.25 543.06 1614.64 544.57 1614.03 545.18 1611.92 545.78 1606.17 545.78"/>
+  </g>
+  <g id="LWPOLYLINE-1696" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1610.71" y1="545.78" x2="1615.24" y2="553.04"/>
+  </g>
+  <g id="LWPOLYLINE-1697" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1628.86 553.04 1620.08 553.04 1620.08 539.12 1628.86 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1698" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1620.08" y1="545.78" x2="1625.53" y2="545.78"/>
+  </g>
+  <g id="LWPOLYLINE-1699" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1632.79 553.04 1632.79 539.12 1642.17 553.04 1642.17 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1700" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1657.6 542.45 1656.69 541.25 1655.48 539.73 1654.27 539.12 1651.55 539.12 1650.03 539.73 1648.82 541.25 1648.22 542.45 1647.31 544.57 1647.31 547.9 1648.22 549.72 1648.82 551.23 1650.03 552.43 1651.55 553.04 1654.27 553.04 1655.48 552.43 1656.69 551.23 1657.6 549.72"/>
+  </g>
+  <g id="LWPOLYLINE-1701" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1670.3 553.04 1661.53 553.04 1661.53 539.12 1670.3 539.12"/>
+  </g>
+  <g id="LWPOLYLINE-1702" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1661.53" y1="545.78" x2="1666.67" y2="545.78"/>
+  </g>
+  <g id="CIRCLE-20" data-name="CIRCLE">
+    <circle class="cls-3" cx="699.04" cy="985.5" r="8.92"/>
+  </g>
+  <g id="LWPOLYLINE-1703" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="678.63 1232.21 678.63 1217.99 687.1 1217.99"/>
+  </g>
+  <g id="LWPOLYLINE-1704" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="678.63" y1="1224.64" x2="683.77" y2="1224.64"/>
+  </g>
+  <g id="LWPOLYLINE-1705" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="700.41 1221.32 699.8 1220.11 698.59 1218.6 697.08 1217.99 694.66 1217.99 693.15 1218.6 691.94 1220.11 691.03 1221.32 690.43 1223.44 690.43 1226.76 691.03 1228.58 691.94 1230.09 693.15 1231.3 694.66 1232.21 697.08 1232.21 698.59 1231.3 699.8 1230.09 700.41 1228.58"/>
+  </g>
+  <g id="LWPOLYLINE-1706" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="714.63 1221.32 714.02 1220.11 712.51 1218.6 711.3 1217.99 708.58 1217.99 707.06 1218.6 705.85 1220.11 705.25 1221.32 704.65 1223.44 704.65 1226.76 705.25 1228.58 705.85 1230.09 707.06 1231.3 708.58 1232.21 711.3 1232.21 712.51 1231.3 714.02 1230.09 714.63 1228.58"/>
+  </g>
+  <g id="LWPOLYLINE-1707" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2188.53" y1="975.97" x2="2172.5" y2="974.15"/>
+  </g>
+  <g id="LWPOLYLINE-1708" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2201.84" y1="715.5" x2="2217.87" y2="717.31"/>
+  </g>
+  <g id="LWPOLYLINE-1709" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2154.94 434.45 2146.48 433.24 2147.99 419.32 2156.76 420.54"/>
+  </g>
+  <g id="LWPOLYLINE-1710" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.38" y1="425.98" x2="2152.53" y2="426.59"/>
+  </g>
+  <g id="LWPOLYLINE-1711" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2160.7 420.84 2159.18 434.75 2167.05 435.66"/>
+  </g>
+  <g id="LWPOLYLINE-1712" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2178.85 437.17 2170.38 435.96 2171.89 422.04 2180.67 423.26"/>
+  </g>
+  <g id="LWPOLYLINE-1713" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2171.29" y1="428.7" x2="2176.43" y2="429.31"/>
+  </g>
+  <g id="LWPOLYLINE-1714" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2193.97 428.1 2193.67 426.59 2192.46 425.07 2191.25 424.47 2188.53 424.16 2187.01 424.47 2185.5 425.67 2184.9 426.89 2183.99 429 2183.38 432.33 2183.99 434.14 2184.59 435.66 2185.81 437.17 2187.01 438.08 2189.43 438.39 2190.95 437.77 2192.46 436.57 2193.37 435.36"/>
+  </g>
+  <g id="LWPOLYLINE-1715" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2197.6 437.78 2197 438.38 2197.6 439.29 2198.21 438.68"/>
+  </g>
+  <g id="LWPOLYLINE-1716" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.53" y1="900.04" x2="285.04" y2="898.83"/>
+  </g>
+  <g id="LWPOLYLINE-1717" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.23" y1="903.67" x2="285.04" y2="901.85"/>
+  </g>
+  <g id="LWPOLYLINE-1718" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.92" y1="906.99" x2="284.74" y2="905.48"/>
+  </g>
+  <g id="LWPOLYLINE-1719" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.32" y1="910.62" x2="284.44" y2="909.11"/>
+  </g>
+  <g id="LWPOLYLINE-1720" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.02" y1="913.95" x2="283.83" y2="912.44"/>
+  </g>
+  <g id="LWPOLYLINE-1721" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="281.71" y1="917.58" x2="283.53" y2="916.07"/>
+  </g>
+  <g id="LWPOLYLINE-1722" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="281.11" y1="921.21" x2="283.23" y2="919.7"/>
+  </g>
+  <g id="LWPOLYLINE-1723" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="280.81" y1="924.54" x2="282.62" y2="923.03"/>
+  </g>
+  <g id="LWPOLYLINE-1724" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="280.5" y1="928.17" x2="282.32" y2="926.66"/>
+  </g>
+  <g id="LWPOLYLINE-1725" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.9" y1="931.8" x2="282.02" y2="930.29"/>
+  </g>
+  <g id="LWPOLYLINE-1726" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.6" y1="935.13" x2="281.41" y2="933.61"/>
+  </g>
+  <g id="LWPOLYLINE-1727" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.29" y1="938.76" x2="281.11" y2="937.24"/>
+  </g>
+  <g id="LWPOLYLINE-1728" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.69" y1="942.39" x2="280.81" y2="940.57"/>
+  </g>
+  <g id="LWPOLYLINE-1729" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.39" y1="945.72" x2="280.2" y2="944.2"/>
+  </g>
+  <g id="LWPOLYLINE-1730" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.08" y1="949.35" x2="279.9" y2="947.83"/>
+  </g>
+  <g id="LWPOLYLINE-1731" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.48" y1="952.68" x2="279.6" y2="951.16"/>
+  </g>
+  <g id="LWPOLYLINE-1732" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.18" y1="956.31" x2="279.3" y2="954.79"/>
+  </g>
+  <g id="LWPOLYLINE-1733" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="276.87" y1="959.94" x2="278.69" y2="958.42"/>
+  </g>
+  <g id="LWPOLYLINE-1734" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="276.27" y1="963.26" x2="278.39" y2="961.75"/>
+  </g>
+  <g id="LWPOLYLINE-1735" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.78" y1="965.38" x2="278.08" y2="965.38"/>
+  </g>
+  <g id="LWPOLYLINE-1736" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="275.66" y1="970.52" x2="277.48" y2="968.71"/>
+  </g>
+  <g id="LWPOLYLINE-1737" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="275.06" y1="973.85" x2="277.18" y2="972.34"/>
+  </g>
+  <g id="LWPOLYLINE-1738" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.76" y1="977.48" x2="276.88" y2="975.97"/>
+  </g>
+  <g id="LWPOLYLINE-1739" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.45" y1="981.11" x2="276.27" y2="979.29"/>
+  </g>
+  <g id="LWPOLYLINE-1740" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.85" y1="984.44" x2="275.97" y2="982.93"/>
+  </g>
+  <g id="LWPOLYLINE-1741" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.55" y1="988.07" x2="275.67" y2="986.56"/>
+  </g>
+  <g id="LWPOLYLINE-1742" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.24" y1="991.4" x2="275.06" y2="989.88"/>
+  </g>
+  <g id="LWPOLYLINE-1743" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.64" y1="995.03" x2="274.76" y2="993.51"/>
+  </g>
+  <g id="LWPOLYLINE-1744" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.34" y1="998.66" x2="274.46" y2="997.15"/>
+  </g>
+  <g id="LWPOLYLINE-1745" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.03" y1="1001.99" x2="273.85" y2="1000.47"/>
+  </g>
+  <g id="LWPOLYLINE-1746" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="271.43" y1="1005.62" x2="273.55" y2="1004.1"/>
+  </g>
+  <g id="LWPOLYLINE-1747" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="271.13" y1="1009.25" x2="273.25" y2="1007.43"/>
+  </g>
+  <g id="LWPOLYLINE-1748" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="270.82" y1="1012.57" x2="272.64" y2="1011.06"/>
+  </g>
+  <g id="LWPOLYLINE-1749" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="270.52" y1="1016.21" x2="272.34" y2="1014.69"/>
+  </g>
+  <g id="LWPOLYLINE-1750" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="269.92" y1="1019.84" x2="272.04" y2="1018.02"/>
+  </g>
+  <g id="LWPOLYLINE-1751" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="269.61" y1="1023.16" x2="271.43" y2="1021.65"/>
+  </g>
+  <g id="LWPOLYLINE-1752" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="269.31" y1="1026.79" x2="271.13" y2="1025.28"/>
+  </g>
+  <g id="LWPOLYLINE-1753" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="268.4 1033.75 270.22 1032.24 268.71 1030.12 270.83 1028.61 269.31 1026.8"/>
+  </g>
+  <g id="LWPOLYLINE-1754" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="271.13" y1="1025.28" x2="269.61" y2="1023.16"/>
+  </g>
+  <g id="LWPOLYLINE-1755" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="271.43" y1="1021.65" x2="269.91" y2="1019.83"/>
+  </g>
+  <g id="LWPOLYLINE-1756" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.03" y1="1018.02" x2="270.52" y2="1016.2"/>
+  </g>
+  <g id="LWPOLYLINE-1757" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.34" y1="1014.69" x2="270.82" y2="1012.57"/>
+  </g>
+  <g id="LWPOLYLINE-1758" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.64" y1="1011.06" x2="271.12" y2="1009.25"/>
+  </g>
+  <g id="LWPOLYLINE-1759" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.24" y1="1007.43" x2="271.43" y2="1005.62"/>
+  </g>
+  <g id="LWPOLYLINE-1760" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.55" y1="1004.1" x2="272.03" y2="1001.98"/>
+  </g>
+  <g id="LWPOLYLINE-1761" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.85" y1="1000.47" x2="272.33" y2="998.66"/>
+  </g>
+  <g id="LWPOLYLINE-1762" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.45" y1="997.15" x2="272.64" y2="995.03"/>
+  </g>
+  <g id="LWPOLYLINE-1763" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.76" y1="993.52" x2="273.24" y2="991.4"/>
+  </g>
+  <g id="LWPOLYLINE-1764" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="275.06" y1="989.89" x2="273.54" y2="988.07"/>
+  </g>
+  <g id="LWPOLYLINE-1765" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="275.66" y1="986.56" x2="273.85" y2="984.44"/>
+  </g>
+  <g id="LWPOLYLINE-1766" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="275.97" y1="982.93" x2="274.45" y2="981.11"/>
+  </g>
+  <g id="LWPOLYLINE-1767" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="276.27" y1="979.3" x2="274.75" y2="977.48"/>
+  </g>
+  <g id="LWPOLYLINE-1768" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="276.87" y1="975.97" x2="275.06" y2="973.85"/>
+  </g>
+  <g id="LWPOLYLINE-1769" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.18" y1="972.34" x2="275.66" y2="970.52"/>
+  </g>
+  <g id="LWPOLYLINE-1770" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.48" y1="968.71" x2="276.27" y2="967.19"/>
+  </g>
+  <g id="LWPOLYLINE-1771" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.08" y1="965.38" x2="276.27" y2="963.26"/>
+  </g>
+  <g id="LWPOLYLINE-1772" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.39" y1="961.75" x2="276.87" y2="959.93"/>
+  </g>
+  <g id="LWPOLYLINE-1773" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.69" y1="958.42" x2="277.17" y2="956.3"/>
+  </g>
+  <g id="LWPOLYLINE-1774" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.29" y1="954.79" x2="277.48" y2="952.67"/>
+  </g>
+  <g id="LWPOLYLINE-1775" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.6" y1="951.16" x2="278.08" y2="949.34"/>
+  </g>
+  <g id="LWPOLYLINE-1776" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.9" y1="947.84" x2="278.38" y2="945.71"/>
+  </g>
+  <g id="LWPOLYLINE-1777" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="280.2" y1="944.2" x2="278.69" y2="942.39"/>
+  </g>
+  <g id="LWPOLYLINE-1778" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="280.81" y1="940.57" x2="279.29" y2="938.76"/>
+  </g>
+  <g id="LWPOLYLINE-1779" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="281.11" y1="937.25" x2="279.59" y2="935.13"/>
+  </g>
+  <g id="LWPOLYLINE-1780" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="281.41" y1="933.62" x2="279.9" y2="931.8"/>
+  </g>
+  <g id="LWPOLYLINE-1781" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.02" y1="930.29" x2="280.5" y2="928.17"/>
+  </g>
+  <g id="LWPOLYLINE-1782" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.32" y1="926.66" x2="280.8" y2="924.54"/>
+  </g>
+  <g id="LWPOLYLINE-1783" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.62" y1="923.03" x2="281.11" y2="921.21"/>
+  </g>
+  <g id="LWPOLYLINE-1784" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.23" y1="919.7" x2="281.71" y2="917.58"/>
+  </g>
+  <g id="LWPOLYLINE-1785" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.53" y1="916.07" x2="282.01" y2="913.95"/>
+  </g>
+  <g id="LWPOLYLINE-1786" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.83" y1="912.44" x2="282.32" y2="910.62"/>
+  </g>
+  <g id="LWPOLYLINE-1787" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="284.44" y1="909.11" x2="282.92" y2="906.99"/>
+  </g>
+  <g id="LWPOLYLINE-1788" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="284.74" y1="905.48" x2="283.22" y2="903.66"/>
+  </g>
+  <g id="LWPOLYLINE-1789" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="285.04" y1="901.85" x2="283.53" y2="900.03"/>
+  </g>
+  <g id="LWPOLYLINE-1790" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.32" y1="896.41" x2="266.59" y2="1035.27"/>
+  </g>
+  <g id="LWPOLYLINE-1791" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="287.16 897.01 287.16 899.13 282.01 898.52 282.32 896.4 287.16 897.01"/>
+  </g>
+  <g id="LWPOLYLINE-1792" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="271.73 1034.05 271.43 1035.87 266.59 1035.26 266.59 1033.45 271.73 1034.05"/>
+  </g>
+  <g id="LWPOLYLINE-1793" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="287.16" y1="899.13" x2="271.43" y2="1034.96"/>
+  </g>
+  <g id="LWPOLYLINE-1794" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.75" y1="1090.02" x2="263.26" y2="1088.82"/>
+  </g>
+  <g id="LWPOLYLINE-1795" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.44" y1="1093.35" x2="263.26" y2="1091.83"/>
+  </g>
+  <g id="LWPOLYLINE-1796" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.84" y1="1096.98" x2="262.96" y2="1095.47"/>
+  </g>
+  <g id="LWPOLYLINE-1797" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.54" y1="1100.31" x2="262.66" y2="1098.79"/>
+  </g>
+  <g id="LWPOLYLINE-1798" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.23" y1="1103.94" x2="262.05" y2="1102.42"/>
+  </g>
+  <g id="LWPOLYLINE-1799" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="259.63" y1="1107.57" x2="261.75" y2="1106.05"/>
+  </g>
+  <g id="LWPOLYLINE-1800" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="259.33" y1="1110.9" x2="261.45" y2="1109.38"/>
+  </g>
+  <g id="LWPOLYLINE-1801" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="259.02" y1="1114.53" x2="260.84" y2="1113.01"/>
+  </g>
+  <g id="LWPOLYLINE-1802" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.42" y1="1118.16" x2="260.54" y2="1116.34"/>
+  </g>
+  <g id="LWPOLYLINE-1803" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.12" y1="1121.48" x2="260.24" y2="1119.97"/>
+  </g>
+  <g id="LWPOLYLINE-1804" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="258.72 1127.53 259.33 1126.93 257.82 1125.11 259.63 1123.6 258.12 1121.49"/>
+  </g>
+  <g id="LWPOLYLINE-1805" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.23" y1="1119.97" x2="258.42" y2="1118.15"/>
+  </g>
+  <g id="LWPOLYLINE-1806" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.54" y1="1116.34" x2="259.02" y2="1114.52"/>
+  </g>
+  <g id="LWPOLYLINE-1807" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.84" y1="1113.01" x2="259.32" y2="1110.89"/>
+  </g>
+  <g id="LWPOLYLINE-1808" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.44" y1="1109.38" x2="259.63" y2="1107.57"/>
+  </g>
+  <g id="LWPOLYLINE-1809" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.75" y1="1106.05" x2="260.23" y2="1103.93"/>
+  </g>
+  <g id="LWPOLYLINE-1810" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.05" y1="1102.43" x2="260.54" y2="1100.3"/>
+  </g>
+  <g id="LWPOLYLINE-1811" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.65" y1="1098.79" x2="260.84" y2="1096.98"/>
+  </g>
+  <g id="LWPOLYLINE-1812" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.96" y1="1095.47" x2="261.44" y2="1093.35"/>
+  </g>
+  <g id="LWPOLYLINE-1813" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="263.26" y1="1091.84" x2="261.75" y2="1090.02"/>
+  </g>
+  <g id="LWPOLYLINE-1814" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.54" y1="1086.39" x2="255.7" y2="1129.35"/>
+  </g>
+  <g id="LWPOLYLINE-1815" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="265.68 1087 265.38 1089.12 260.54 1088.51 260.54 1086.39 265.68 1087"/>
+  </g>
+  <g id="LWPOLYLINE-1816" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="261.14 1127.84 260.84 1129.66 255.7 1129.35 256 1127.23 261.14 1127.84"/>
+  </g>
+  <g id="LWPOLYLINE-1817" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="265.38" y1="1089.11" x2="260.84" y2="1129.65"/>
+  </g>
+  <g id="LWPOLYLINE-1818" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="255.7" y1="1129.35" x2="272.64" y2="1131.17"/>
+  </g>
+  <g id="LWPOLYLINE-1819" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="279.6 965.68 279.29 967.5 274.15 966.89 274.45 965.08 279.6 965.68"/>
+  </g>
+  <g id="LWPOLYLINE-1820" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="229.07" y="1244.91" width="3.02" height="3.02"/>
+  </g>
+  <g id="LWPOLYLINE-1821" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="152.67" y="939.2" width="1.54" height="1.54" transform="translate(-798.37 906.09) rotate(-78.69)"/>
+  </g>
+  <g id="LWPOLYLINE-1822" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="229.07" y1="1246.12" x2="162.21" y2="1246.12"/>
+  </g>
+  <g id="LWPOLYLINE-1823" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="229.07" y1="1247.03" x2="162.21" y2="1247.03"/>
+  </g>
+  <g id="LWPOLYLINE-1824" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="159.19" y="1244.91" width="3.02" height="3.02"/>
+  </g>
+  <g id="LWPOLYLINE-1825" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="93.85" y1="1236.44" x2="108.67" y2="1227.97"/>
+  </g>
+  <g id="LWPOLYLINE-1826" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="93.85" y1="1235.23" x2="108.07" y2="1227.07"/>
+  </g>
+  <g id="LWPOLYLINE-1827" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="107.76 1226.76 109.28 1226.16 109.88 1227.37 108.66 1228.28 107.76 1226.76"/>
+  </g>
+  <g id="LWPOLYLINE-1828" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="158.89 1245.82 157.68 1245.22 157.07 1246.43 158.28 1247.34 158.89 1245.82"/>
+  </g>
+  <g id="LWPOLYLINE-1829" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="157.07" y1="1246.12" x2="125.31" y2="1227.98"/>
+  </g>
+  <g id="LWPOLYLINE-1830" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="157.68" y1="1245.52" x2="125.91" y2="1227.07"/>
+  </g>
+  <g id="LWPOLYLINE-1831" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="125.91 1226.76 124.71 1226.16 124.1 1227.37 125.31 1228.28 125.91 1226.76"/>
+  </g>
+  <g id="LWPOLYLINE-1832" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="270.6" y="878.94" width="2.87" height="2.87" transform="translate(-263.66 130.64) rotate(-18.38)"/>
+  </g>
+  <g id="LWPOLYLINE-1833" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="195.28" y="903.45" width="3.16" height="3.16" transform="translate(-250.94 94.28) rotate(-16.64)"/>
+  </g>
+  <g id="LWPOLYLINE-1834" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="111.48" y="930.98" width="3.16" height="3.16" transform="translate(-262.33 71.44) rotate(-16.64)"/>
+  </g>
+  <g id="LWPOLYLINE-1835" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="195.19 906.39 194.29 907.6 193.07 906.39 193.98 905.49 195.19 906.39"/>
+  </g>
+  <g id="LWPOLYLINE-1836" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="193.07" y1="906.69" x2="168.87" y2="933.92"/>
+  </g>
+  <g id="LWPOLYLINE-1837" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="193.98" y1="907.3" x2="169.48" y2="934.52"/>
+  </g>
+  <g id="LWPOLYLINE-1838" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="169.78 934.83 168.87 936.03 167.66 934.83 168.57 933.92 169.78 934.83"/>
+  </g>
+  <g id="LWPOLYLINE-1839" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="115.46" y="931.33" width="1.54" height="1.54" transform="translate(-820.57 863.28) rotate(-78.69)"/>
+  </g>
+  <g id="LWPOLYLINE-1840" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="116.84" y1="931.8" x2="152.84" y2="939.37"/>
+  </g>
+  <g id="LWPOLYLINE-1841" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="116.84" y1="932.71" x2="152.53" y2="940.28"/>
+  </g>
+  <g id="LWPOLYLINE-1842" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="232.1" y1="1244.91" x2="238.45" y2="1244.91"/>
+  </g>
+  <g id="LWPOLYLINE-1843" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1571.08 670.72 1571.08 658.62 1578.64 658.62"/>
+  </g>
+  <g id="LWPOLYLINE-1844" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1571.08" y1="664.37" x2="1575.61" y2="664.37"/>
+  </g>
+  <g id="LWPOLYLINE-1845" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1581.36" y1="670.72" x2="1581.36" y2="658.62"/>
+  </g>
+  <g id="LWPOLYLINE-1846" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1589.53" y1="658.62" x2="1589.53" y2="670.72"/>
+  </g>
+  <g id="LWPOLYLINE-1847" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1581.36" y1="664.37" x2="1589.53" y2="664.37"/>
+  </g>
+  <g id="LWPOLYLINE-1848" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1602.54 661.34 1602.23 660.44 1601.03 659.22 1599.82 658.62 1597.39 658.62 1596.49 659.22 1595.28 660.44 1594.67 661.34 1594.07 663.16 1594.07 666.18 1594.67 667.69 1595.28 668.91 1596.49 670.12 1597.39 670.72 1599.82 670.72 1601.03 670.12 1602.23 668.91 1602.54 667.69"/>
+  </g>
+  <g id="LWPOLYLINE-1849" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="197.91 994.73 153.14 989.58 150.72 1011.67 195.49 1016.81 197.91 994.73"/>
+  </g>
+  <g id="LWPOLYLINE-1850" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="197.01 995.63 154.05 990.79 151.94 1010.76 194.58 1015.6 197.01 995.63"/>
+  </g>
+  <g id="LWPOLYLINE-1851" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="208.8 975.97 143.15 968.4 140.74 988.37 206.38 995.94 208.8 975.97"/>
+  </g>
+  <g id="LWPOLYLINE-1852" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="207.59 976.88 143.76 969.62 141.95 987.47 205.47 994.72 207.59 976.88"/>
+  </g>
+  <g id="LWPOLYLINE-1853" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.97" y1="972.64" x2="143.77" y2="984.74"/>
+  </g>
+  <g id="LWPOLYLINE-1854" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="141.04" y1="972.34" x2="149.21" y2="973.24"/>
+  </g>
+  <g id="LWPOLYLINE-1855" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="150.72" y1="980.2" x2="161.01" y2="981.41"/>
+  </g>
+  <g id="LWPOLYLINE-1856" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="167.36 975.06 173.71 975.67 169.78 979.9 171.29 980.21 172.5 980.81 173.11 981.41 173.41 983.23 173.11 984.44 172.5 985.96 171.29 987.16 169.48 987.47 167.66 987.16 166.15 986.56 165.54 985.96 165.24 984.74"/>
+  </g>
+  <g id="LWPOLYLINE-1857" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="177.64 976.27 185.51 976.88 178.55 988.37"/>
+  </g>
+  <g id="LWPOLYLINE-1858" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="189.14 980.2 189.14 979.6 190.04 978.69 190.66 978.08 191.86 977.78 193.98 977.78 195.19 978.69 195.79 979.3 196.1 980.51 196.1 981.72 195.19 982.63 193.98 984.14 187.63 989.28 195.79 990.19"/>
+  </g>
+  <g id="LWPOLYLINE-1859" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="200.33 978.69 208.2 979.3 201.24 990.79"/>
+  </g>
+  <g id="LWPOLYLINE-1860" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="219.7 1208.91 218.49 1209.22 217.27 1210.43 216.67 1211.34 216.37 1213.76 216.67 1214.96 217.58 1216.18 218.79 1216.78 220.3 1217.69 223.33 1217.99 225.14 1217.69 226.35 1217.08 227.56 1216.18 228.17 1214.96 228.47 1212.85 228.17 1211.64 226.96 1210.43 226.05 1209.52 224.23 1209.52 223.93 1212.24"/>
+  </g>
+  <g id="LWPOLYLINE-1861" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="229.07 1206.49 217.88 1200.74 230.28 1197.42"/>
+  </g>
+  <g id="LWPOLYLINE-1862" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="225.44" y1="1204.38" x2="226.05" y2="1198.63"/>
+  </g>
+  <g id="LWPOLYLINE-1863" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="221.21 1185.02 220 1185.92 219.39 1187.44 219.09 1189.86 219.39 1191.67 220.3 1192.89 221.51 1192.89 222.72 1192.58 223.33 1191.97 223.93 1191.06 225.44 1187.74 226.35 1186.53 226.96 1186.22 228.16 1185.62 229.68 1185.92 230.89 1187.14 231.19 1188.95 230.89 1191.06 230.29 1192.89 228.78 1193.79"/>
+  </g>
+  <g id="LWPOLYLINE-1864" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="233.01 1171.7 221.21 1170.5 233.61 1167.16 222.11 1161.41 234.21 1162.63"/>
+  </g>
+  <g id="LWPOLYLINE-1865" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="235.43 1150.83 234.82 1158.09 222.72 1156.88 223.63 1149.32"/>
+  </g>
+  <g id="LWPOLYLINE-1866" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="228.47" y1="1157.49" x2="229.08" y2="1152.95"/>
+  </g>
+  <g id="LWPOLYLINE-1867" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="224.54" y1="1142.06" x2="236.33" y2="1143.26"/>
+  </g>
+  <g id="LWPOLYLINE-1868" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="223.93" y1="1145.99" x2="224.83" y2="1138.12"/>
+  </g>
+  <g id="LWPOLYLINE-1869" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="237.85 1129.65 237.24 1137.22 225.14 1135.7 226.05 1128.44"/>
+  </g>
+  <g id="LWPOLYLINE-1870" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="230.89" y1="1136.31" x2="231.5" y2="1131.77"/>
+  </g>
+  <g id="LWPOLYLINE-1871" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="238.45 1126.32 226.35 1125.12 226.96 1119.97 227.86 1118.16 228.47 1117.85 229.68 1117.25 230.59 1117.55 231.8 1118.16 232.4 1118.76 232.7 1120.57 232.1 1125.72"/>
+  </g>
+  <g id="LWPOLYLINE-1872" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="232.4" y1="1121.79" x2="239.36" y2="1118.46"/>
+  </g>
+  <g id="CIRCLE-21" data-name="CIRCLE">
+    <circle class="cls-3" cx="195.95" cy="1196.66" r="1.97"/>
+  </g>
+  <g id="CIRCLE-22" data-name="CIRCLE">
+    <circle class="cls-3" cx="206.23" cy="1107.12" r="1.97"/>
+  </g>
+  <g id="CIRCLE-23" data-name="CIRCLE">
+    <circle class="cls-3" cx="202.9" cy="1136.76" r="1.97"/>
+  </g>
+  <g id="CIRCLE-24" data-name="CIRCLE">
+    <circle class="cls-3" cx="199.27" cy="1166.71" r="1.97"/>
+  </g>
+  <g id="LWPOLYLINE-1873" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="322.55" y1="931.8" x2="321.35" y2="943.6"/>
+  </g>
+  <g id="LWPOLYLINE-1874" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="318.62" y1="931.2" x2="326.49" y2="932.1"/>
+  </g>
+  <g id="LWPOLYLINE-1875" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="327.39 944.51 328.91 932.41 333.74 933.01 335.56 933.61 336.17 934.22 336.47 935.43 336.47 936.64 335.56 937.85 334.96 938.16 333.44 938.76 328.3 938.16"/>
+  </g>
+  <g id="LWPOLYLINE-1876" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="332.23" y1="938.46" x2="335.56" y2="945.11"/>
+  </g>
+  <g id="LWPOLYLINE-1877" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="339.49 945.72 345.24 934.22 348.58 946.62"/>
+  </g>
+  <g id="LWPOLYLINE-1878" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="341.61" y1="941.79" x2="347.36" y2="942.39"/>
+  </g>
+  <g id="LWPOLYLINE-1879" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="351.9 946.93 353.11 934.83 360.07 947.83 361.27 935.74"/>
+  </g>
+  <g id="LWPOLYLINE-1880" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="373.68 938.76 372.48 937.55 370.96 936.94 368.54 936.64 366.73 936.94 365.51 937.85 365.51 939.06 365.82 940.27 366.42 940.88 367.63 941.78 370.96 943.3 371.86 943.9 372.48 944.51 372.78 945.72 372.78 947.23 371.56 948.44 369.74 948.74 367.32 948.44 365.82 947.84 364.61 946.62"/>
+  </g>
+  <g id="LWPOLYLINE-1881" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="375.8 949.35 377.31 937.55 384.57 938.16"/>
+  </g>
+  <g id="LWPOLYLINE-1882" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="376.71" y1="943.3" x2="381.24" y2="943.6"/>
+  </g>
+  <g id="LWPOLYLINE-1883" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="393.65 951.16 386.09 950.56 387.29 938.46 394.86 939.37"/>
+  </g>
+  <g id="LWPOLYLINE-1884" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="386.69" y1="944.2" x2="391.53" y2="944.81"/>
+  </g>
+  <g id="LWPOLYLINE-1885" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="396.98 951.77 398.18 939.67 403.33 940.27 405.14 940.87 405.45 941.48 406.05 942.69 405.75 943.9 405.14 945.11 404.54 945.42 402.73 946.02 397.58 945.42"/>
+  </g>
+  <g id="LWPOLYLINE-1886" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="401.51" y1="945.72" x2="404.84" y2="952.37"/>
+  </g>
+  <g id="LWPOLYLINE-1887" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="326.18 954.49 325.28 953.28 323.76 952.37 321.34 952.07 319.53 952.67 318.32 953.59 318.32 954.79 318.62 956.01 319.23 956.61 320.14 957.21 323.46 958.72 324.67 959.33 325.28 959.94 325.58 961.14 325.28 962.96 324.06 963.87 322.25 964.47 320.14 964.17 318.32 963.26 317.41 962.06"/>
+  </g>
+  <g id="LWPOLYLINE-1888" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="329.81 952.98 331.63 965.38 335.56 953.58 337.08 965.98 341.31 954.18"/>
+  </g>
+  <g id="LWPOLYLINE-1889" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="342.22" y1="966.29" x2="343.42" y2="954.49"/>
+  </g>
+  <g id="LWPOLYLINE-1890" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="352.2" y1="955.4" x2="350.99" y2="967.2"/>
+  </g>
+  <g id="LWPOLYLINE-1891" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="348.27" y1="955.1" x2="356.13" y2="955.7"/>
+  </g>
+  <g id="LWPOLYLINE-1892" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="366.72 959.63 366.12 958.43 365.21 957.21 364 956.61 361.88 956.31 360.67 956.91 359.46 957.82 358.55 959.03 357.95 960.54 357.65 963.57 357.95 965.08 358.55 966.29 359.46 967.5 360.67 968.41 362.79 968.71 364 968.1 365.21 967.2 366.12 965.98"/>
+  </g>
+  <g id="LWPOLYLINE-1893" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="369.14" y1="969.31" x2="370.35" y2="957.21"/>
+  </g>
+  <g id="LWPOLYLINE-1894" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="378.22" y1="958.12" x2="377.01" y2="969.92"/>
+  </g>
+  <g id="LWPOLYLINE-1895" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="369.75" y1="962.96" x2="377.61" y2="963.87"/>
+  </g>
+  <g id="LWPOLYLINE-1896" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="288.67 792.64 292.6 804.13 298.96 801.72"/>
+  </g>
+  <g id="LWPOLYLINE-1897" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="301.68 800.81 302.29 788.11 310.45 798.09"/>
+  </g>
+  <g id="LWPOLYLINE-1898" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="301.98" y1="796.57" x2="307.43" y2="794.76"/>
+  </g>
+  <g id="LWPOLYLINE-1899" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="313.78 796.88 314.39 784.17 322.25 794.15"/>
+  </g>
+  <g id="LWPOLYLINE-1900" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="314.08" y1="792.64" x2="319.53" y2="790.82"/>
+  </g>
+  <g id="LWPOLYLINE-1901" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="325.58 792.94 321.95 781.75 326.79 779.94 328.6 779.94 329.21 780.54 330.12 781.45 330.72 782.35 330.42 783.57 330.12 784.47 328.6 785.38 323.76 787.19"/>
+  </g>
+  <g id="LWPOLYLINE-1902" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="327.39" y1="785.68" x2="333.14" y2="790.52"/>
+  </g>
+  <g id="LWPOLYLINE-1903" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="341.31 776.91 340.1 776.3 338.29 776.3 336.17 776.91 334.66 778.11 333.74 779.63 334.05 780.54 334.96 781.45 335.86 781.75 337.08 782.05 340.7 782.05 341.92 782.35 342.83 782.66 343.73 783.56 344.03 785.08 343.43 786.59 341.92 787.8 339.8 788.4 337.98 788.4 336.47 787.8"/>
+  </g>
+  <g id="LWPOLYLINE-1904" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="361.28 774.79 363.1 774.79 363.7 775.09 364.61 776 365.21 777.51 364.91 778.72 364.61 779.63 363.1 780.54 358.25 782.36 354.62 770.86 359.46 769.34 361.28 769.34 361.88 769.65 362.79 770.56 363.1 771.77 363.1 772.97 362.79 773.58 361.28 774.79 356.44 776.3"/>
+  </g>
+  <g id="LWPOLYLINE-1905" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="369.14 766.02 368.24 766.92 367.63 768.44 367.33 769.65 367.33 771.46 368.24 774.19 369.45 775.69 370.35 776.61 371.57 777.21 373.08 777.51 375.19 776.61 376.1 775.69 376.71 774.49 377.01 772.97 377.01 771.16 376.1 768.44 374.89 767.22 373.98 766.32 372.77 765.41 371.26 765.41 369.14 766.02"/>
+  </g>
+  <g id="LWPOLYLINE-1906" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="381.55" y1="774.49" x2="377.92" y2="763.3"/>
+  </g>
+  <g id="LWPOLYLINE-1907" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="382.15 761.78 386.09 773.28 392.44 770.86"/>
+  </g>
+  <g id="LWPOLYLINE-1908" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="402.42 767.83 395.16 769.95 391.53 758.76 398.49 756.33"/>
+  </g>
+  <g id="LWPOLYLINE-1909" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="393.35" y1="764.2" x2="397.58" y2="762.69"/>
+  </g>
+  <g id="LWPOLYLINE-1910" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="405.45 766.62 401.82 755.13 406.65 753.62 408.47 753.62 409.38 753.92 410.29 754.82 410.59 756.03 410.29 757.25 409.98 758.15 408.47 759.06 403.63 760.57"/>
+  </g>
+  <g id="LWPOLYLINE-1911" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="407.26" y1="759.36" x2="413.31" y2="764.2"/>
+  </g>
+  <g id="LWPOLYLINE-1912" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="298.65 811.4 297.14 812.6 297.14 813.82 297.45 814.72 298.35 815.63 299.56 815.94 301.98 815.63 303.8 815.63 305.31 816.54 306.22 817.44 306.52 818.96 306.52 820.17 306.22 821.07 304.7 821.99 302.59 822.89 300.78 822.89 299.86 822.29 298.96 821.38 298.65 819.87 298.65 818.66 299.56 817.15 300.78 816.24 302.89 814.72 303.8 813.82 304.1 812.6 303.5 811.7 302.59 810.79 300.78 810.79 298.65 811.4"/>
+  </g>
+  <g id="LWPOLYLINE-1913" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="313.48 806.56 308.03 808.37 308.94 813.51 309.24 812.6 310.76 811.7 312.58 811.1 314.38 811.1 315.6 811.7 316.81 813.21 317.11 814.42 317.11 816.23 316.5 817.45 314.99 818.66 313.48 819.26 311.66 819.26 310.76 818.96 309.85 818.05"/>
+  </g>
+  <g id="LWPOLYLINE-1914" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="321.04 804.14 319.53 805.04 318.92 807.16 319.23 809.89 319.84 811.7 321.35 814.12 322.86 815.33 324.67 815.33 325.88 815.03 327.39 814.12 328 812 327.39 808.98 327.09 807.46 325.58 805.04 323.76 803.53 321.95 803.53 321.04 804.14"/>
+  </g>
+  <g id="LWPOLYLINE-1915" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="332.54" y1="812.91" x2="328.61" y2="801.41"/>
+  </g>
+  <g id="LWPOLYLINE-1916" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="336.17" y1="798.99" x2="331.02" y2="809.28"/>
+  </g>
+  <g id="LWPOLYLINE-1917" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="332.84" y1="805.65" x2="340.1" y2="810.49"/>
+  </g>
+  <g id="LWPOLYLINE-1918" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="357.04 798.09 358.86 798.09 359.47 798.39 360.37 799.29 360.97 801.11 360.97 802.32 360.37 802.93 359.16 804.13 354.02 805.65 350.39 794.46 355.23 792.64 357.04 792.64 357.65 793.24 358.56 794.15 359.16 795.06 358.86 796.27 358.56 797.18 357.04 798.09 352.2 799.9"/>
+  </g>
+  <g id="LWPOLYLINE-1919" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="365.51" y1="789.31" x2="369.45" y2="800.81"/>
+  </g>
+  <g id="LWPOLYLINE-1920" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="361.88" y1="790.52" x2="369.45" y2="788.1"/>
+  </g>
+  <g id="LWPOLYLINE-1921" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="371.56 787.19 374.28 795.36 375.5 796.87 376.71 797.79 378.52 797.79 379.73 797.17 381.24 796.27 381.85 794.76 381.85 792.94 379.13 784.77"/>
+  </g>
+  <g id="LWPOLYLINE-1922" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="387.3" y1="794.76" x2="383.67" y2="783.26"/>
+  </g>
+  <g id="LWPOLYLINE-1923" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="391.23" y1="780.84" x2="394.86" y2="792.34"/>
+  </g>
+  <g id="LWPOLYLINE-1924" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="385.48" y1="788.71" x2="393.05" y2="786.28"/>
+  </g>
+  <g id="ARC-97" data-name="ARC">
+    <path class="cls-3" d="M377.29,876.67c6.61-23.36,8.55-47.8,5.71-71.92"/>
+  </g>
+  <g id="MTEXT">
+    <text class="cls-1" transform="translate(1075.88 1339.03)"><tspan x="0" y="0">Mission Street</tspan></text>
+  </g>
+  <g id="MTEXT-2" data-name="MTEXT">
+    <text class="cls-2" transform="translate(1127.36 486.21) rotate(-18.5)"><tspan x="0" y="0">Otis Street</tspan></text>
+  </g>
+  <g id="LWPOLYLINE-1925" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M534.42,877.65c1.21-.07,2.41-.32,3.55-.74.49-.11.98-.25,1.47-.41"/>
+  </g>
+  <g id="LWPOLYLINE-1926" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M528.31,867.73c-.69.94-1.16,2.01-1.4,3.15-.23.87-.2,1.79.09,2.64.28.86.8,1.61,1.5,2.18"/>
+  </g>
+  <g id="LWPOLYLINE-1927" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M537.62,866.15c-.95.02-1.9.18-2.8.48-.93.31-1.8.76-2.6,1.33-.57.4-1.07.89-1.48,1.46"/>
+  </g>
+  <g id="LWPOLYLINE-1928" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M540.83,867.19c-.31-.17-.64-.31-.98-.4-.7-.23-1.44-.34-2.18-.33"/>
+  </g>
+  <g id="LWPOLYLINE-1929" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M534.36,874.62c.95-.02,1.9-.18,2.8-.48.93-.31,1.8-.76,2.6-1.33.63-.42,1.19-.95,1.64-1.57.26-.31.48-.65.65-1.01.4-1.2-.04-2.53-1.07-3.26"/>
+  </g>
+  <g id="LWPOLYLINE-1930" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M532.08,874.41c.13-.1.3-.13.46-.08.67.21,1.36.31,2.06.29"/>
+  </g>
+  <g id="LWPOLYLINE-1931" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M528.37,871.26c-.15.59-.13,1.21.06,1.79.19.58.54,1.09,1.02,1.47"/>
+  </g>
+  <g id="LWPOLYLINE-1932" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M529.01,827.92c-1.03-.35-2.11-.51-3.19-.48-1.88.03-3.74.48-5.43,1.32"/>
+  </g>
+  <g id="LWPOLYLINE-1933" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M528.06,830.79c-.72-.24-1.48-.35-2.24-.33-.95.02-1.9.18-2.8.48-.93.31-1.8.76-2.6,1.33-.57.4-1.07.89-1.48,1.46"/>
+  </g>
+  <g id="LWPOLYLINE-1934" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M522.56,838.92c.95-.02,1.9-.18,2.8-.48.93-.31,1.8-.76,2.6-1.33.63-.42,1.19-.95,1.64-1.57.26-.31.48-.65.65-1.01.4-1.2-.04-2.52-1.07-3.25"/>
+  </g>
+  <g id="LWPOLYLINE-1935" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M518.17,839.92c-.2.15-.25.43-.1.63.04.06.09.1.16.13-.6-.23-1.17-.53-1.69-.89"/>
+  </g>
+  <g id="LWPOLYLINE-1936" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M519.16,829.38c-1,.64-1.9,1.43-2.65,2.35-.69.94-1.17,2.01-1.4,3.15-.23.87-.19,1.79.09,2.64.28.86.8,1.61,1.5,2.18"/>
+  </g>
+  <g id="LWPOLYLINE-1937" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M516.57,835.26c-.15.59-.13,1.21.06,1.79.19.58.54,1.09,1.02,1.47"/>
+  </g>
+  <g id="LWPOLYLINE-1938" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M564.23,1053.82c.47-4.59-2.87-8.69-7.45-9.16-.14-.01-.29-.03-.43-.03-4.55-.56-8.69,2.67-9.25,7.22-.08.64-.08,1.29-.01,1.93-.04.6.41,1.11,1.01,1.15,0,0,0,0,0,0,2.27-.21,4.54-.31,6.82-.3"/>
+  </g>
+  <g id="LWPOLYLINE-1939" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M562.46,1046.06c-.87-1.19-1.97-2.19-3.25-2.93-1.09-.6-2.31-.91-3.56-.91-1.24,0-2.47.32-3.56.92-1.28.73-2.39,1.73-3.25,2.92"/>
+  </g>
+  <g id="LWPOLYLINE-1940" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M563.58,1057.62c1.22-.19,2.06-1.32,1.9-2.54,0-1.73-.26-3.46-.78-5.11"/>
+  </g>
+  <g id="LWPOLYLINE-1941" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M554.75,1055.73c-.18.29-.21.65-.08.97.05.13.13.24.23.34.1.1.21.18.34.23.13.05.27.08.41.08.14,0,.28-.03.41-.08.13-.05.24-.13.34-.23.1-.1.18-.21.23-.34.05-.13.08-.27.08-.41"/>
+  </g>
+  <g id="LWPOLYLINE-1942" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M400.42,1082.72c.22.35.69.45,1.04.23,0,0,0,0,0,0,.35-.23.45-.69.23-1.05s-.69-.45-1.05-.23c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1943" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M403.75,1080.6c.22.35.69.45,1.04.23,0,0,0,0,0,0,.35-.23.45-.69.23-1.05s-.69-.45-1.05-.23c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1944" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M515.54,1054.63c2.28,0,4.56.09,6.83.3.6-.04,1.05-.55,1.02-1.15,0,0,0,0,0,0,.49-4.56-2.82-8.66-7.38-9.14-.64-.07-1.29-.06-1.93.02-4.58.23-8.11,4.13-7.88,8.72,0,.14.02.28.03.42"/>
+  </g>
+  <g id="LWPOLYLINE-1945" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M518.37,1043.13c-1.09-.6-2.32-.91-3.56-.91-1.24,0-2.47.31-3.56.91-1.28.73-2.38,1.73-3.25,2.92"/>
+  </g>
+  <g id="LWPOLYLINE-1946" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M508.01,1045.75c-.93,1.23-1.65,2.62-2.12,4.09-.57,1.69-.88,3.46-.92,5.24-.16,1.22.68,2.35,1.9,2.55"/>
+  </g>
+  <g id="LWPOLYLINE-1947" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M514.05,1056.29c0,.1.02.2.06.29.04.09.1.18.17.25"/>
+  </g>
+  <g id="LWPOLYLINE-1948" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M514.52,1056.99c.09.04.19.06.29.06.1,0,.2-.02.29-.06.09-.04.18-.1.25-.17"/>
+  </g>
+  <g id="LWPOLYLINE-1949" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M513.83,1056.7c.05.13.13.25.23.35.1.1.22.18.35.23.13.05.27.08.41.08.14,0,.28-.03.41-.08.13-.05.24-.13.34-.23.1-.1.17-.22.22-.35"/>
+  </g>
+  <g id="LWPOLYLINE-1950" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2185.21,775.07c-.1.75.43,1.43,1.18,1.52,0,0,0,0,0,0,.75.09,1.43-.44,1.52-1.18s-.44-1.43-1.18-1.52c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1951" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2187.57,782.36c-.41-.05-.79.24-.85.65s.24.79.65.85c0,0,0,0,0,0,.41.05.79-.23.84-.64,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1952" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M608.93,940.82c-.54.23-1.17-.03-1.4-.57-.46-2.18-1.04-4.34-1.72-6.47"/>
+  </g>
+  <g id="LWPOLYLINE-1953" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M615.97,936.98c.85-1.19,1.44-2.55,1.73-3.98.23-1.22.14-2.49-.25-3.67-.39-1.18-1.07-2.25-1.98-3.09-1.09-1.04-2.38-1.84-3.8-2.35-1.44-.54-2.95-.83-4.49-.86-1.75.02-3.49.31-5.16.87-1.2.27-1.96,1.45-1.72,2.66"/>
+  </g>
+  <g id="LWPOLYLINE-1954" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M603.41,932.99c-.06.12-.1.26-.11.4-.01.14,0,.28.05.41"/>
+  </g>
+  <g id="LWPOLYLINE-1955" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M603.26,898.25c.85-1.19,1.44-2.55,1.73-3.98.23-1.22.14-2.48-.25-3.67-.39-1.18-1.07-2.25-1.98-3.1-1.09-1.04-2.38-1.84-3.8-2.34-1.44-.54-2.95-.83-4.49-.86"/>
+  </g>
+  <g id="LWPOLYLINE-1956" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M593.1,895.36c.7,2.09,1.29,4.22,1.78,6.37.19.55.78.86,1.34.67"/>
+  </g>
+  <g id="LWPOLYLINE-1957" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M590.71,894.57c-.06.12-.1.26-.11.4-.01.14,0,.28.05.41"/>
+  </g>
+  <g id="LWPOLYLINE-1958" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M591.17,895.99c.12.06.26.1.4.11.34.03.68-.12.89-.39"/>
+  </g>
+  <g id="LWPOLYLINE-1959" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M592.67,903.06c.57,1.09,1.91,1.52,3.01.98,1.59-.56,3.08-1.36,4.42-2.37,1.26-.87,2.35-1.96,3.23-3.21"/>
+  </g>
+  <g id="LWPOLYLINE-1960" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M588.44,857.44c.48-.16.96-.34,1.42-.54,1.18-.35,2.29-.87,3.32-1.54"/>
+  </g>
+  <g id="LWPOLYLINE-1961" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M592.94,855.32c.91-.63,1.71-1.4,2.36-2.3.24-.35.46-.72.64-1.11"/>
+  </g>
+  <g id="LWPOLYLINE-1962" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M596.24,851.81c.26-.6.45-1.23.55-1.88.23-.87.2-1.79-.09-2.64-.28-.85-.81-1.61-1.5-2.18"/>
+  </g>
+  <g id="LWPOLYLINE-1963" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M595.37,845.32c-.93-.75-2-1.29-3.15-1.59-1.19-.38-2.43-.56-3.68-.55"/>
+  </g>
+  <g id="LWPOLYLINE-1964" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M589.04,846.19c-.95.02-1.89.18-2.8.48-.9.3-1.76.73-2.54,1.28"/>
+  </g>
+  <g id="LWPOLYLINE-1965" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M583.95,847.99c-.61.43-1.13.96-1.55,1.57-.25.32-.46.66-.62,1.04-.43,1.17-.04,2.49.96,3.24"/>
+  </g>
+  <g id="LWPOLYLINE-1966" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M583.85,854.32c.7.23,1.44.34,2.18.33.97-.01,1.93-.18,2.86-.48.91-.3,1.76-.73,2.54-1.28"/>
+  </g>
+  <g id="LWPOLYLINE-1967" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M582.89,857.19c1.05.35,2.15.51,3.25.49,1.25-.03,2.5-.24,3.69-.63"/>
+  </g>
+  <g id="LWPOLYLINE-1968" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M582.2,845.53c-.91.62-1.71,1.4-2.36,2.3-.38.54-.68,1.12-.9,1.74"/>
+  </g>
+  <g id="LWPOLYLINE-1969" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M594.88,851.15c.28-.5.49-1.04.63-1.59.09-.61,0-1.23-.24-1.8-.19-.58-.55-1.09-1.02-1.47"/>
+  </g>
+  <g id="LWPOLYLINE-1970" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M574.05,821.38c1.25-.03,2.5-.24,3.69-.63,1.19-.39,2.32-.96,3.34-1.69.91-.64,1.7-1.43,2.34-2.34"/>
+  </g>
+  <g id="LWPOLYLINE-1971" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M569.09,819.84c.53.32,1.1.58,1.7.75,1.03.35,2.11.51,3.19.48"/>
+  </g>
+  <g id="LWPOLYLINE-1972" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M575.25,807.05c-1.86.33-3.62,1.08-5.16,2.18-.91.62-1.71,1.4-2.36,2.3-.38.54-.68,1.12-.9,1.74"/>
+  </g>
+  <g id="LWPOLYLINE-1973" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M577,809.88c.71-.02,1.43.08,2.11.28.14.04.29.02.41-.07"/>
+  </g>
+  <g id="LWPOLYLINE-1974" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M577.25,809.89c-.95.02-1.89.18-2.8.48-.91.3-1.76.73-2.54,1.28-.63.44-1.17.98-1.61,1.61-.25.32-.46.67-.62,1.04-.43,1.17-.04,2.48.95,3.24"/>
+  </g>
+  <g id="LWPOLYLINE-1975" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M570.77,817.32c.33.21.68.39,1.05.51.69.19,1.4.27,2.11.22"/>
+  </g>
+  <g id="LWPOLYLINE-1976" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M573.99,818.35c.95-.02,1.89-.18,2.8-.48.91-.3,1.76-.73,2.54-1.28.59-.41,1.11-.92,1.54-1.5"/>
+  </g>
+  <g id="LWPOLYLINE-1977" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M584.14,815.51c.26-.6.45-1.23.55-1.88.23-.87.2-1.79-.09-2.64-.28-.85-.81-1.61-1.5-2.18"/>
+  </g>
+  <g id="LWPOLYLINE-1978" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M583.27,808.71c-.92-.75-2-1.29-3.15-1.59-1.21-.28-2.45-.36-3.68-.25-1.45.09-2.88.37-4.26.83"/>
+  </g>
+  <g id="LWPOLYLINE-1979" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M582.78,814.84c.28-.5.49-1.04.63-1.59.09-.61,0-1.23-.24-1.8-.19-.58-.55-1.09-1.02-1.47"/>
+  </g>
+</svg>

--- a/public/floorplans/Floor 2.svg
+++ b/public/floorplans/Floor 2.svg
@@ -1,0 +1,5876 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="LAYER_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2507.39 1410.79">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 54.09px;
+      }
+
+      .cls-1, .cls-2 {
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-2 {
+        font-size: 54.09px;
+      }
+
+      .cls-3 {
+        fill: none;
+        stroke: #000;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: .71px;
+      }
+    </style>
+  </defs>
+  <g id="LWPOLYLINE">
+    <polygon class="cls-3" points="1019.66 970.24 1019.66 974.08 1020.3 974.08 1020.3 965.76 1019.66 965.76 1019.66 969.6 1012.29 969.6 1012.29 965.76 1011.66 965.76 1011.66 974.08 1012.29 974.08 1012.29 970.24 1019.66 970.24"/>
+  </g>
+  <g id="CIRCLE">
+    <circle class="cls-3" cx="1015.66" cy="969.77" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-2" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="785.94" y="1254.55" width="45.46" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-3" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1851.12" y="1259.03" width="54.1" height="17.93"/>
+  </g>
+  <g id="LWPOLYLINE-4" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2134.78 1259.03 2083.24 1259.03 2083.24 1276.96 2141.19 1276.96"/>
+  </g>
+  <g id="LWPOLYLINE-5" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1905.23" y1="1272.8" x2="2083.24" y2="1272.8"/>
+  </g>
+  <g id="LWPOLYLINE-6" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2028.49 1127.12 2028.49 1107.91 2032.65 1107.91"/>
+  </g>
+  <g id="LWPOLYLINE-7" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="155.86 1276.96 155.86 1253.91 126.41 1253.91"/>
+  </g>
+  <g id="LWPOLYLINE-8" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.97" y1="1207.8" x2="277.52" y2="1207.8"/>
+  </g>
+  <g id="LWPOLYLINE-9" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.97" y1="1159.14" x2="277.52" y2="1159.14"/>
+  </g>
+  <g id="LWPOLYLINE-10" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="334.19" y="1259.03" width="54.43" height="17.93"/>
+  </g>
+  <g id="LWPOLYLINE-11" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="155.86" y1="1272.48" x2="334.2" y2="1272.48"/>
+  </g>
+  <g id="LWPOLYLINE-12" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="155.86" y1="1272.8" x2="334.2" y2="1272.8"/>
+  </g>
+  <g id="LWPOLYLINE-13" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="155.86" y1="1262.23" x2="334.2" y2="1262.23"/>
+  </g>
+  <g id="LWPOLYLINE-14" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="155.86" y1="1276.96" x2="101.43" y2="1276.96"/>
+  </g>
+  <g id="LWPOLYLINE-15" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="616.58 669.61 565.35 686.58 570.79 703.55 622.02 686.58 616.58 669.61"/>
+  </g>
+  <g id="LWPOLYLINE-16" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M362.69,757.66l-152.72,50.27,152.72-50.27Z"/>
+  </g>
+  <g id="CIRCLE-2" data-name="CIRCLE">
+    <circle class="cls-3" cx="1223.12" cy="675.86" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-17" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1227.12 970.24 1227.12 974.08 1227.76 974.08 1227.76 965.76 1227.12 965.76 1227.12 969.6 1219.76 969.6 1219.76 965.76 1219.12 965.76 1219.12 974.08 1219.76 974.08 1219.76 970.24 1227.12 970.24"/>
+  </g>
+  <g id="CIRCLE-3" data-name="CIRCLE">
+    <circle class="cls-3" cx="1223.12" cy="969.77" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-18" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1434.27 970.24 1434.27 974.08 1434.91 974.08 1434.91 965.76 1434.27 965.76 1434.27 969.6 1426.91 969.6 1426.91 965.76 1426.27 965.76 1426.27 974.08 1426.91 974.08 1426.91 970.24 1434.27 970.24"/>
+  </g>
+  <g id="LWPOLYLINE-19" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1643.33 970.24 1643.33 974.08 1643.97 974.08 1643.97 965.76 1643.33 965.76 1643.33 969.6 1635.97 969.6 1635.97 965.76 1635.33 965.76 1635.33 974.08 1635.97 974.08 1635.97 970.24 1643.33 970.24"/>
+  </g>
+  <g id="LWPOLYLINE-20" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1886.66 970.24 1886.66 974.08 1887.3 974.08 1887.3 965.76 1886.66 965.76 1886.66 969.6 1879.29 969.6 1879.29 965.76 1878.65 965.76 1878.65 974.08 1879.29 974.08 1879.29 970.24 1886.66 970.24"/>
+  </g>
+  <g id="CIRCLE-4" data-name="CIRCLE">
+    <circle class="cls-3" cx="1882.98" cy="969.77" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-21" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1886.66 676.34 1886.66 680.5 1887.3 680.5 1887.3 671.85 1886.66 671.85 1886.66 676.01 1879.29 676.01 1879.29 671.85 1878.65 671.85 1878.65 680.5 1879.29 680.5 1879.29 676.34 1886.66 676.34"/>
+  </g>
+  <g id="CIRCLE-5" data-name="CIRCLE">
+    <circle class="cls-3" cx="1882.65" cy="675.85" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-22" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1643.33 676.34 1643.33 680.5 1643.66 680.5 1643.66 671.85 1643.33 671.85 1643.33 676.01 1635.65 676.01 1635.65 671.85 1635.33 671.85 1635.33 680.5 1635.65 680.5 1635.65 676.34 1643.33 676.34"/>
+  </g>
+  <g id="LWPOLYLINE-23" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="812.52 970.24 812.52 974.08 812.84 974.08 812.84 965.76 812.52 965.76 812.52 969.6 804.83 969.6 804.83 965.76 804.51 965.76 804.51 974.08 804.83 974.08 804.83 970.24 812.52 970.24"/>
+  </g>
+  <g id="CIRCLE-6" data-name="CIRCLE">
+    <circle class="cls-3" cx="808.2" cy="969.77" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-24" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="604.41 970.24 604.41 974.08 605.05 974.08 605.05 965.76 604.41 965.76 604.41 969.6 597.05 969.6 597.05 965.76 596.73 965.76 596.73 974.08 597.05 974.08 597.05 970.24 604.41 970.24"/>
+  </g>
+  <g id="LWPOLYLINE-25" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="381.26 969.28 381.26 973.12 381.58 973.12 381.58 964.8 381.26 964.8 381.26 968.64 373.57 968.64 373.57 964.8 373.25 964.8 373.25 973.12 373.57 973.12 373.57 969.28 381.26 969.28"/>
+  </g>
+  <g id="CIRCLE-7" data-name="CIRCLE">
+    <circle class="cls-3" cx="377.25" cy="968.8" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-26" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1434.27 676.34 1434.27 680.5 1434.91 680.5 1434.91 671.85 1434.27 671.85 1434.27 676.01 1426.91 676.01 1426.91 671.85 1426.27 671.85 1426.27 680.5 1426.91 680.5 1426.91 676.34 1434.27 676.34"/>
+  </g>
+  <g id="CIRCLE-8" data-name="CIRCLE">
+    <circle class="cls-3" cx="1430.27" cy="675.86" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-27" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1227.12 676.34 1227.12 680.5 1227.45 680.5 1227.45 671.85 1227.12 671.85 1227.12 676.01 1219.44 676.01 1219.44 671.85 1219.12 671.85 1219.12 680.5 1219.44 680.5 1219.44 676.34 1227.12 676.34"/>
+  </g>
+  <g id="LWPOLYLINE-28" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1019.66 676.34 1019.66 680.5 1020.3 680.5 1020.3 671.85 1019.66 671.85 1019.66 676.01 1012.29 676.01 1012.29 671.85 1011.66 671.85 1011.66 680.5 1012.29 680.5 1012.29 676.34 1019.66 676.34"/>
+  </g>
+  <g id="CIRCLE-9" data-name="CIRCLE">
+    <circle class="cls-3" cx="1015.66" cy="675.86" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-29" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="812.52 676.34 812.52 680.5 812.84 680.5 812.84 671.85 812.52 671.85 812.52 676.01 804.83 676.01 804.83 671.85 804.51 671.85 804.51 680.5 804.83 680.5 804.83 676.34 812.52 676.34"/>
+  </g>
+  <g id="CIRCLE-10" data-name="CIRCLE">
+    <circle class="cls-3" cx="808.2" cy="675.86" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-30" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2111.73 676.34 2111.73 680.5 2112.37 680.5 2112.37 671.85 2111.73 671.85 2111.73 676.01 2104.37 676.01 2104.37 671.85 2103.73 671.85 2103.73 680.5 2104.37 680.5 2104.37 676.34 2111.73 676.34"/>
+  </g>
+  <g id="CIRCLE-11" data-name="CIRCLE">
+    <circle class="cls-3" cx="2107.41" cy="675.85" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-31" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1868.73 475.91 1870.01 479.44 1870.33 479.44 1867.77 471.43 1867.45 471.43 1868.73 475.28 1861.36 477.51 1860.09 473.99 1859.76 473.99 1862.32 482 1862.97 482 1861.68 478.16 1868.73 475.91"/>
+  </g>
+  <g id="CIRCLE-12" data-name="CIRCLE">
+    <circle class="cls-3" cx="1865.05" cy="476.39" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-32" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2043.54 444.22 2044.82 448.06 2044.17 448.38 2041.62 440.38 2041.94 440.05 2043.22 443.89 2050.26 441.66 2048.98 437.81 2049.62 437.49 2052.18 445.49 2051.86 445.82 2050.59 441.97 2043.54 444.22"/>
+  </g>
+  <g id="CIRCLE-13" data-name="CIRCLE">
+    <circle class="cls-3" cx="2046.58" cy="442.78" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-33" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1012.62 549.55 1013.9 553.39 1014.21 553.39 1011.65 545.39 1011.02 545.39 1012.29 549.23 1005.25 551.47 1003.98 547.63 1003.65 547.95 1006.21 555.96 1006.53 555.96 1005.25 552.11 1012.62 549.55"/>
+  </g>
+  <g id="LWPOLYLINE-34" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="597.37 686.26 598.65 690.1 599.29 689.78 596.73 681.78 596.09 681.78 597.37 685.62 590.32 688.18 589.04 684.34 588.4 684.34 591.28 692.34 591.61 692.34 590.32 688.5 597.37 686.26"/>
+  </g>
+  <g id="LWPOLYLINE-35" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="393.74 753.17 395.03 757.01 395.34 757.01 392.78 749.01 392.14 749.01 393.42 752.85 386.38 755.09 385.1 751.25 384.78 751.57 387.34 759.58 387.98 759.58 386.7 755.73 393.74 753.17"/>
+  </g>
+  <g id="LWPOLYLINE-36" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1643.33 1267.67 1643.33 1271.84 1643.66 1271.84 1643.66 1263.19 1643.33 1263.19 1643.33 1267.35 1635.65 1267.35 1635.65 1263.19 1635.33 1263.19 1635.33 1271.84 1635.65 1271.84 1635.65 1267.67 1643.33 1267.67"/>
+  </g>
+  <g id="LWPOLYLINE-37" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1227.12 1263.51 1227.12 1267.67 1227.45 1267.67 1227.45 1259.03 1227.12 1259.03 1227.12 1263.19 1219.44 1263.19 1219.44 1259.03 1219.12 1259.03 1219.12 1267.67 1219.44 1267.67 1219.44 1263.51 1227.12 1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-38" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1019.66 1263.51 1019.66 1267.67 1020.3 1267.67 1020.3 1259.03 1019.66 1259.03 1019.66 1263.19 1012.29 1263.19 1012.29 1259.03 1011.66 1259.03 1011.66 1267.67 1012.29 1267.67 1012.29 1263.51 1019.66 1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-39" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="812.52 1263.83 812.52 1267.67 812.84 1267.67 812.84 1259.35 812.52 1259.35 812.52 1263.19 804.83 1263.19 804.83 1259.35 804.51 1259.35 804.51 1267.67 804.83 1267.67 804.83 1263.83 812.52 1263.83"/>
+  </g>
+  <g id="LWPOLYLINE-40" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="596.73 1265.75 596.73 1269.92 597.05 1269.92 597.05 1261.27 596.73 1261.27 596.73 1265.43 589.04 1265.43 589.04 1261.27 588.72 1261.27 588.72 1269.92 589.04 1269.92 589.04 1265.75 596.73 1265.75"/>
+  </g>
+  <g id="LWPOLYLINE-41" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="365.25 1265.75 365.25 1269.92 365.57 1269.92 365.57 1261.27 365.25 1261.27 365.25 1265.43 357.57 1265.43 357.57 1261.27 357.25 1261.27 357.25 1269.92 357.57 1269.92 357.57 1265.75 365.25 1265.75"/>
+  </g>
+  <g id="LWPOLYLINE-42" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1886.66 1267.67 1886.66 1271.84 1887.3 1271.84 1887.3 1263.19 1886.66 1263.19 1886.66 1267.35 1879.29 1267.35 1879.29 1263.19 1878.65 1263.19 1878.65 1271.84 1879.29 1271.84 1879.29 1267.67 1886.66 1267.67"/>
+  </g>
+  <g id="LWPOLYLINE-43" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="142.1 1054.45 137.93 1054.12 137.93 1054.77 146.26 1055.73 146.58 1055.08 142.42 1054.77 143.38 1047.08 147.22 1047.72 147.22 1047.08 138.9 1046.12 138.9 1046.76 142.73 1047.08 142.1 1054.45"/>
+  </g>
+  <g id="LWPOLYLINE-44" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="167.39 830.65 163.55 830.33 163.55 830.65 171.87 831.61 171.87 831.29 168.03 830.65 168.67 823.29 172.84 823.93 172.84 823.29 164.51 822.33 164.51 822.97 168.35 823.29 167.39 830.65"/>
+  </g>
+  <g id="LWPOLYLINE-45" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2138.63 1264.15 2142.47 1264.48 2142.47 1263.83 2134.14 1262.87 2134.14 1263.51 2137.99 1263.83 2137.34 1271.52 2133.18 1270.87 2133.18 1271.52 2141.51 1272.48 2141.83 1271.84 2137.66 1271.52 2138.63 1264.15"/>
+  </g>
+  <g id="LWPOLYLINE-46" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2163.28 973.76 2159.44 973.13 2159.12 973.76 2167.76 974.73 2167.76 974.09 2163.92 973.76 2164.56 966.08 2168.4 966.72 2168.72 966.08 2160.08 965.12 2160.08 965.76 2163.92 966.08 2163.28 973.76"/>
+  </g>
+  <g id="LWPOLYLINE-47" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2194.01 678.9 2190.17 678.26 2189.85 678.9 2198.5 679.86 2198.5 679.22 2194.65 678.9 2195.29 671.53 2199.13 671.85 2199.13 671.21 2190.81 670.57 2190.81 670.89 2194.65 671.21 2194.01 678.9"/>
+  </g>
+  <g id="LWPOLYLINE-48" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2221.87 410.6 2218.03 410.28 2218.03 410.6 2226.35 411.56 2226.35 410.92 2222.51 410.6 2223.14 403.23 2227.31 403.55 2227.31 402.92 2218.67 402.27 2218.67 402.6 2222.83 403.23 2221.87 410.6"/>
+  </g>
+  <g id="LWPOLYLINE-49" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2266.05 137.5 2267.33 141.34 2267.65 141.34 2265.09 133.02 2264.77 133.34 2266.05 137.18 2258.69 139.42 2257.41 135.58 2257.08 135.9 2259.64 143.9 2260.29 143.59 2259 140.06 2266.05 137.5"/>
+  </g>
+  <g id="LWPOLYLINE-50" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="158.1" y1="1271.2" x2="160.35" y2="1268.95"/>
+  </g>
+  <g id="LWPOLYLINE-51" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="160.34 1268.96 163.23 1271.52 166.11 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-52" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="166.11 1268.96 168.67 1271.52 171.55 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-53" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="171.55 1268.96 174.43 1271.52 177.32 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-54" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="177.32 1268.96 179.88 1271.52 182.76 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-55" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="182.76 1268.96 185.64 1271.52 188.52 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-56" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="188.52 1268.96 191.4 1271.52 193.96 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-57" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="193.96 1268.96 196.85 1271.52 199.73 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-58" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="199.72 1268.96 202.61 1271.52 205.49 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-59" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="205.49 1268.96 208.05 1271.52 210.93 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-60" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="210.93 1268.96 213.81 1271.52 216.69 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-61" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="216.7 1268.96 219.25 1271.52 222.14 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-62" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="222.14 1268.96 225.02 1271.52 227.9 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-63" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="227.9 1268.96 230.78 1271.52 233.34 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-64" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="233.34 1268.96 236.22 1271.52 239.11 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-65" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="239.11 1268.96 241.99 1271.52 243.91 1269.6"/>
+  </g>
+  <g id="LWPOLYLINE-66" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="155.86" y="1267.03" width="2.24" height="5.44"/>
+  </g>
+  <g id="LWPOLYLINE-67" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="243.91" y="1267.03" width="2.24" height="5.44"/>
+  </g>
+  <g id="LWPOLYLINE-68" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="331.95" y="1267.03" width="2.24" height="5.44"/>
+  </g>
+  <g id="LWPOLYLINE-69" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="331.95" y1="1267.03" x2="158.1" y2="1267.03"/>
+  </g>
+  <g id="LWPOLYLINE-70" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="246.15 1270.23 247.43 1271.52 250.31 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-71" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="250.31 1268.96 253.19 1271.52 256.07 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-72" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="256.08 1268.96 258.63 1271.52 261.52 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-73" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="261.52 1268.96 264.4 1271.52 267.28 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-74" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="267.28 1268.96 270.16 1271.52 272.72 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-75" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="272.72 1268.96 275.6 1271.52 278.49 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-76" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="278.49 1268.96 281.37 1271.52 283.93 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-77" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="283.93 1268.96 286.81 1271.52 289.69 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-78" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="289.69 1268.96 292.57 1271.52 295.45 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-79" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="295.46 1268.96 298.02 1271.52 300.9 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-80" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="300.9 1268.96 303.78 1271.52 306.66 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-81" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="306.66 1268.96 309.22 1271.52 312.1 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-82" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="312.1 1268.96 314.98 1271.52 317.87 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-83" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="317.86 1268.96 320.75 1271.52 323.3 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-84" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="323.31 1268.96 326.19 1271.52 329.07 1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-85" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="331.95" y1="1271.52" x2="331.95" y2="1271.52"/>
+  </g>
+  <g id="LWPOLYLINE-86" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="331.95" y1="1271.52" x2="329.07" y2="1268.96"/>
+  </g>
+  <g id="LWPOLYLINE-87" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="619.78 1272.8 624.26 1272.8 624.26 1254.55 602.81 1254.55 602.81 1259.03 565.99 1259.03 565.99 1276.96 619.78 1276.96 619.78 1272.8"/>
+  </g>
+  <g id="LWPOLYLINE-88" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="624.26" y1="1268.63" x2="785.94" y2="1268.63"/>
+  </g>
+  <g id="LWPOLYLINE-89" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="624.26" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-90" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="627.46" y1="1260.31" x2="703.02" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-91" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="627.46" y1="1259.35" x2="703.02" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-92" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="625.22" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-93" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="784.66" y="1259.03" width="1.28" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-94" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="782.74" y="1259.03" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-95" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="706.86" y1="1260.31" x2="782.74" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-96" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="706.86" y1="1259.35" x2="782.74" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-97" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="993.09" y="1254.55" width="45.78" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-98" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="993.09" y1="1268.63" x2="831.41" y2="1268.63"/>
+  </g>
+  <g id="LWPOLYLINE-99" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1200.55,1268.63h-161.68,161.68Z"/>
+  </g>
+  <g id="LWPOLYLINE-100" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1407.7" y1="1268.63" x2="1246.02" y2="1268.63"/>
+  </g>
+  <g id="LWPOLYLINE-101" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1673.11 1259.03 1635.97 1259.03 1635.97 1254.55 1615.16 1254.55 1615.16 1272.8 1619.32 1272.8 1619.32 1276.96 1673.11 1276.96 1673.11 1259.03"/>
+  </g>
+  <g id="LWPOLYLINE-102" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1453.48" y1="1268.63" x2="1615.16" y2="1268.63"/>
+  </g>
+  <g id="LWPOLYLINE-103" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="147.22 875.15 153.3 822.01 208.69 803.76 215.42 823.93"/>
+  </g>
+  <g id="LWPOLYLINE-104" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.89" y1="814" x2="364.61" y2="763.74"/>
+  </g>
+  <g id="LWPOLYLINE-105" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.17" y1="810.48" x2="214.45" y2="807.92"/>
+  </g>
+  <g id="LWPOLYLINE-106" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="214.45 807.92 217.98 809.52 219.89 806"/>
+  </g>
+  <g id="LWPOLYLINE-107" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="219.89 806 223.42 807.92 225.34 804.4"/>
+  </g>
+  <g id="LWPOLYLINE-108" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="225.34 804.4 228.86 806 230.46 802.47"/>
+  </g>
+  <g id="LWPOLYLINE-109" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="230.46 802.48 233.98 804.4 235.9 800.88"/>
+  </g>
+  <g id="LWPOLYLINE-110" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="235.9 800.88 239.43 802.48 241.35 798.96"/>
+  </g>
+  <g id="LWPOLYLINE-111" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="241.35 798.96 244.87 800.88 246.47 797.35"/>
+  </g>
+  <g id="LWPOLYLINE-112" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="246.47 797.35 250.31 798.96 251.91 795.43"/>
+  </g>
+  <g id="LWPOLYLINE-113" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="251.91 795.44 255.43 797.35 257.35 793.83"/>
+  </g>
+  <g id="LWPOLYLINE-114" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="257.35 793.83 260.88 795.43 262.48 791.91"/>
+  </g>
+  <g id="LWPOLYLINE-115" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="262.48 791.91 266.32 793.83 267.92 790.31"/>
+  </g>
+  <g id="LWPOLYLINE-116" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="267.92 790.31 271.44 791.91 273.36 788.39"/>
+  </g>
+  <g id="LWPOLYLINE-117" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="273.36 788.39 276.88 790.31 278.8 786.79"/>
+  </g>
+  <g id="LWPOLYLINE-118" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="278.81 786.79 282.33 788.39 283.93 784.87"/>
+  </g>
+  <g id="LWPOLYLINE-119" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.17" y1="786.15" x2="283.92" y2="784.87"/>
+  </g>
+  <g id="LWPOLYLINE-120" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="210.72" y="807.47" width="2.03" height="5.07" transform="translate(-244.75 108.18) rotate(-18.39)"/>
+  </g>
+  <g id="LWPOLYLINE-121" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="286.81 788.07 289.05 787.43 287.45 782.31 285.21 782.95 286.81 788.07"/>
+  </g>
+  <g id="LWPOLYLINE-122" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="362.37 763.42 364.29 762.78 362.69 757.66 360.45 758.3 362.37 763.42"/>
+  </g>
+  <g id="LWPOLYLINE-123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.49" y1="812.08" x2="364.29" y2="762.78"/>
+  </g>
+  <g id="LWPOLYLINE-124" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.89" y1="807.28" x2="362.69" y2="757.66"/>
+  </g>
+  <g id="LWPOLYLINE-125" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="288.41" y1="785.51" x2="289.37" y2="783.27"/>
+  </g>
+  <g id="LWPOLYLINE-126" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="289.37 783.27 292.89 784.87 294.81 781.34"/>
+  </g>
+  <g id="LWPOLYLINE-127" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="294.81 781.35 298.34 783.27 299.94 779.74"/>
+  </g>
+  <g id="LWPOLYLINE-128" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="299.93 779.75 303.46 781.35 305.38 777.83"/>
+  </g>
+  <g id="LWPOLYLINE-129" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="305.38 777.83 308.9 779.75 310.82 776.22"/>
+  </g>
+  <g id="LWPOLYLINE-130" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="310.82 776.22 314.34 778.15 315.94 774.31"/>
+  </g>
+  <g id="LWPOLYLINE-131" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="315.94 774.3 319.47 776.22 321.39 772.7"/>
+  </g>
+  <g id="LWPOLYLINE-132" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="321.39 772.7 324.91 774.62 326.83 770.79"/>
+  </g>
+  <g id="LWPOLYLINE-133" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="326.83 770.78 330.35 772.7 331.95 769.18"/>
+  </g>
+  <g id="LWPOLYLINE-134" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="331.95 769.18 335.47 771.1 337.39 767.26"/>
+  </g>
+  <g id="LWPOLYLINE-135" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="337.4 767.26 340.92 769.18 342.84 765.66"/>
+  </g>
+  <g id="LWPOLYLINE-136" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="342.84 765.66 346.36 767.58 347.96 764.06"/>
+  </g>
+  <g id="LWPOLYLINE-137" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="347.96 764.06 351.8 765.66 353.4 762.14"/>
+  </g>
+  <g id="LWPOLYLINE-138" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="353.4 762.14 356.92 764.06 358.84 760.54"/>
+  </g>
+  <g id="LWPOLYLINE-139" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="361.73" y1="761.82" x2="358.85" y2="760.54"/>
+  </g>
+  <g id="LWPOLYLINE-140" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="824.04 601.42 772.82 618.39 778.26 635.35 829.8 618.39 824.04 601.42"/>
+  </g>
+  <g id="LWPOLYLINE-141" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1031.51 533.22 980.28 550.19 985.72 567.16 1037.27 550.19 1031.51 533.22"/>
+  </g>
+  <g id="LWPOLYLINE-142" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2270.53 125.98 2218.99 142.95 2224.43 159.91"/>
+  </g>
+  <g id="LWPOLYLINE-143" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2270.53" y1="125.98" x2="2271.49" y2="129.5"/>
+  </g>
+  <g id="LWPOLYLINE-144" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2067.55,197.05l152.72-49.95-152.72,49.95Z"/>
+  </g>
+  <g id="LWPOLYLINE-145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2224.43" y1="159.91" x2="2071.71" y2="210.18"/>
+  </g>
+  <g id="LWPOLYLINE-146" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2145.67" y1="173.68" x2="2145.99" y2="173.04"/>
+  </g>
+  <g id="LWPOLYLINE-147" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2145.99 173.04 2149.51 174.64 2151.43 171.12"/>
+  </g>
+  <g id="LWPOLYLINE-148" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2151.43 171.12 2154.96 173.04 2156.55 169.52"/>
+  </g>
+  <g id="LWPOLYLINE-149" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.55 169.52 2160.08 171.12 2162 167.6"/>
+  </g>
+  <g id="LWPOLYLINE-150" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2161.99 167.59 2165.52 169.52 2167.44 166"/>
+  </g>
+  <g id="LWPOLYLINE-151" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.44 166 2170.96 167.6 2172.56 164.08"/>
+  </g>
+  <g id="LWPOLYLINE-152" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2172.56 164.08 2176.09 166 2178 162.47"/>
+  </g>
+  <g id="LWPOLYLINE-153" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2178 162.47 2181.53 164.08 2183.45 160.56"/>
+  </g>
+  <g id="LWPOLYLINE-154" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2183.45 160.55 2186.97 162.47 2188.57 158.95"/>
+  </g>
+  <g id="LWPOLYLINE-155" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2188.57 158.95 2192.09 160.55 2194.01 157.03"/>
+  </g>
+  <g id="LWPOLYLINE-156" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2194.01 157.03 2197.54 158.95 2199.46 155.43"/>
+  </g>
+  <g id="LWPOLYLINE-157" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2199.45 155.43 2202.98 157.03 2204.57 153.51"/>
+  </g>
+  <g id="LWPOLYLINE-158" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2204.58 153.51 2208.42 155.43 2210.02 151.91"/>
+  </g>
+  <g id="LWPOLYLINE-159" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2210.02 151.91 2213.54 153.51 2215.46 149.99"/>
+  </g>
+  <g id="LWPOLYLINE-160" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2215.46 149.99 2218.99 151.91 2219.31 151.27"/>
+  </g>
+  <g id="LWPOLYLINE-161" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2221.87 151.91 2219.94 152.55 2218.03 147.75 2220.26 147.11 2221.87 151.91"/>
+  </g>
+  <g id="LWPOLYLINE-162" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2146.63 176.88 2144.39 177.52 2142.79 172.4 2145.02 171.76 2146.63 176.88"/>
+  </g>
+  <g id="LWPOLYLINE-163" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2071.07 201.54 2069.15 202.17 2067.55 197.05 2069.47 196.41 2071.07 201.54"/>
+  </g>
+  <g id="LWPOLYLINE-164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2219.95" y1="152.55" x2="2069.15" y2="202.18"/>
+  </g>
+  <g id="LWPOLYLINE-165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2218.03" y1="147.75" x2="2067.55" y2="197.05"/>
+  </g>
+  <g id="LWPOLYLINE-166" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2070.43" y1="198.97" x2="2071.07" y2="197.37"/>
+  </g>
+  <g id="LWPOLYLINE-167" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2071.07 197.37 2074.59 199.29 2076.51 195.77"/>
+  </g>
+  <g id="LWPOLYLINE-168" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2076.51 195.77 2080.04 197.37 2081.96 193.85"/>
+  </g>
+  <g id="LWPOLYLINE-169" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2081.96 193.85 2085.48 195.77 2087.08 192.25"/>
+  </g>
+  <g id="LWPOLYLINE-170" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2087.08 192.25 2090.6 193.85 2092.52 190.33"/>
+  </g>
+  <g id="LWPOLYLINE-171" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2092.52 190.33 2096.04 192.25 2097.96 188.72"/>
+  </g>
+  <g id="LWPOLYLINE-172" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2097.96 188.72 2101.49 190.65 2103.08 186.81"/>
+  </g>
+  <g id="LWPOLYLINE-173" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2103.09 186.81 2106.93 188.73 2108.53 185.21"/>
+  </g>
+  <g id="LWPOLYLINE-174" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2108.53 185.21 2112.05 187.13 2113.97 183.29"/>
+  </g>
+  <g id="LWPOLYLINE-175" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.97 183.29 2117.5 185.21 2119.1 181.69"/>
+  </g>
+  <g id="LWPOLYLINE-176" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2119.1 181.68 2122.94 183.6 2124.54 179.77"/>
+  </g>
+  <g id="LWPOLYLINE-177" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2124.54 179.76 2128.06 181.68 2129.98 178.16"/>
+  </g>
+  <g id="LWPOLYLINE-178" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2129.98 178.16 2133.5 180.08 2135.42 176.56"/>
+  </g>
+  <g id="LWPOLYLINE-179" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2135.42 176.56 2138.95 178.16 2140.55 174.64"/>
+  </g>
+  <g id="LWPOLYLINE-180" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2140.54 174.64 2144.07 176.56 2144.07 176.24"/>
+  </g>
+  <g id="LWPOLYLINE-181" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="624.26" y1="1254.55" x2="785.94" y2="1254.55"/>
+  </g>
+  <g id="LWPOLYLINE-182" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.35" y1="955.84" x2="800.35" y2="947.83"/>
+  </g>
+  <g id="LWPOLYLINE-183" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.35" y1="908.13" x2="800.35" y2="678.58"/>
+  </g>
+  <g id="LWPOLYLINE-184" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.35" y1="673.77" x2="800.35" y2="627.99"/>
+  </g>
+  <g id="LWPOLYLINE-185" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1029.91" y1="728.84" x2="1029.91" y2="552.43"/>
+  </g>
+  <g id="LWPOLYLINE-186" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1029.91 728.84 1003.33 728.84 1003.33 724.68"/>
+  </g>
+  <g id="LWPOLYLINE-187" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1025.74" y1="724.68" x2="1025.74" y2="554.03"/>
+  </g>
+  <g id="LWPOLYLINE-188" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="795.87" y1="951.35" x2="795.87" y2="947.83"/>
+  </g>
+  <g id="LWPOLYLINE-189" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="795.87" y1="908.13" x2="795.87" y2="629.27"/>
+  </g>
+  <g id="LWPOLYLINE-190" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="819.24" y1="724.68" x2="819.24" y2="621.58"/>
+  </g>
+  <g id="LWPOLYLINE-191" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="823.72" y1="724.68" x2="823.72" y2="620.31"/>
+  </g>
+  <g id="LWPOLYLINE-192" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="384.46" y1="1259.03" x2="384.46" y2="1143.77"/>
+  </g>
+  <g id="LWPOLYLINE-193" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="389.9" y1="1231.5" x2="389.9" y2="1165.22"/>
+  </g>
+  <g id="LWPOLYLINE-194" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="380.3" y1="1259.03" x2="380.3" y2="1143.77"/>
+  </g>
+  <g id="LWPOLYLINE-195" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="380.3 1231.5 374.85 1231.5 374.85 1165.22"/>
+  </g>
+  <g id="LWPOLYLINE-196" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.29" y1="1262.23" x2="283.29" y2="1207.8"/>
+  </g>
+  <g id="LWPOLYLINE-197" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.29" y1="1159.14" x2="283.29" y2="1143.45"/>
+  </g>
+  <g id="LWPOLYLINE-198" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="333.87" y1="1143.77" x2="333.87" y2="1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-199" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="443.05 1143.77 372.29 1143.77 372.29 1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-200" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.52" y1="1262.23" x2="277.52" y2="1207.8"/>
+  </g>
+  <g id="LWPOLYLINE-201" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="277.52" y1="1159.14" x2="277.52" y2="1149.85"/>
+  </g>
+  <g id="LWPOLYLINE-202" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="274" y="1204.6" width="10.88" height="3.2"/>
+  </g>
+  <g id="LWPOLYLINE-203" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="274 1204.6 274 1162.34 284.89 1162.34 284.89 1159.14 274 1159.14 274 1162.34"/>
+  </g>
+  <g id="LWPOLYLINE-204" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="258.96 1162.34 190.44 1162.34 190.44 1235.98 258.96 1235.98 258.96 1204.6 271.12 1204.6 271.12 1239.18 187.56 1239.18 187.56 1159.14 271.12 1159.14 271.12 1162.34 258.96 1162.34"/>
+  </g>
+  <g id="LWPOLYLINE-205" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="204.53 1193.08 195.24 1193.08 195.24 1178.35 204.53 1178.35"/>
+  </g>
+  <g id="LWPOLYLINE-206" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="195.24" y1="1185.39" x2="201" y2="1185.39"/>
+  </g>
+  <g id="LWPOLYLINE-207" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="208.69 1178.35 208.69 1193.07 217.02 1193.07"/>
+  </g>
+  <g id="LWPOLYLINE-208" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="229.82 1193.08 220.54 1193.08 220.54 1178.35 229.82 1178.35"/>
+  </g>
+  <g id="LWPOLYLINE-209" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="220.54" y1="1185.39" x2="226.3" y2="1185.39"/>
+  </g>
+  <g id="LWPOLYLINE-210" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="233.98 1178.35 239.74 1193.07 245.51 1178.35"/>
+  </g>
+  <g id="LWPOLYLINE-211" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="249.03 1191.8 248.39 1192.43 249.03 1193.08 249.67 1192.43"/>
+  </g>
+  <g id="LWPOLYLINE-212" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="255.43 1181.23 256.71 1180.27 258.96 1178.35 258.96 1193.07"/>
+  </g>
+  <g id="LWPOLYLINE-213" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="138.25" y1="1149.85" x2="277.52" y2="1149.85"/>
+  </g>
+  <g id="LWPOLYLINE-214" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.29" y1="1143.45" x2="138.89" y2="1143.45"/>
+  </g>
+  <g id="LWPOLYLINE-215" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="338.04 808.88 337.4 807.28 336.12 806.64 334.52 807.28 333.87 808.88 334.52 810.16 336.12 810.8 337.4 810.16 338.04 808.88"/>
+  </g>
+  <g id="LWPOLYLINE-216" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.81" y1="819.45" x2="366.21" y2="769.18"/>
+  </g>
+  <g id="LWPOLYLINE-217" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="419.35 899.17 395.34 826.17 592.24 761.18"/>
+  </g>
+  <g id="LWPOLYLINE-218" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="424.16 897.57 402.07 829.69 598.97 764.7"/>
+  </g>
+  <g id="LWPOLYLINE-219" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.25" y1="907.17" x2="184.36" y2="1143.45"/>
+  </g>
+  <g id="LWPOLYLINE-220" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="218.62" y1="909.09" x2="192.36" y2="1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-221" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="205.81 1020.19 269.2 1027.55 268.56 1032.03"/>
+  </g>
+  <g id="CIRCLE-14" data-name="CIRCLE">
+    <circle class="cls-3" cx="1639.33" cy="675.85" r="9.44"/>
+  </g>
+  <g id="CIRCLE-15" data-name="CIRCLE">
+    <circle class="cls-3" cx="1639.33" cy="969.44" r="9.44"/>
+  </g>
+  <g id="CIRCLE-16" data-name="CIRCLE">
+    <circle class="cls-3" cx="1430.27" cy="969.77" r="9.45"/>
+  </g>
+  <g id="LWPOLYLINE-222" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="473.46 982.73 446.57 955.84 447.85 954.23 475.06 981.45"/>
+  </g>
+  <g id="LWPOLYLINE-223" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="472.82 983.37 475.7 980.17 478.58 976.65 480.83 972.8 482.43 968.65 483.71 964.48 484.67 960 484.67 955.84"/>
+  </g>
+  <g id="LWPOLYLINE-224" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="647.63" y1="765.66" x2="621.38" y2="686.9"/>
+  </g>
+  <g id="LWPOLYLINE-225" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="643.47" y1="766.3" x2="617.54" y2="688.18"/>
+  </g>
+  <g id="LWPOLYLINE-226" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="598.97" y1="764.7" x2="577.84" y2="700.99"/>
+  </g>
+  <g id="LWPOLYLINE-227" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="592.24" y1="761.18" x2="573.03" y2="702.91"/>
+  </g>
+  <g id="LWPOLYLINE-228" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="805.15 618.07 806.11 621.59 806.75 621.59 804.19 613.58 803.55 613.58 804.83 617.43 797.79 619.67 796.51 615.82 796.19 616.14 798.74 624.15 799.07 624.15 797.79 620.31 805.15 618.07"/>
+  </g>
+  <g id="LWPOLYLINE-229" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.35" y1="728.84" x2="965.23" y2="728.84"/>
+  </g>
+  <g id="LWPOLYLINE-230" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1029.91" y1="689.14" x2="1170.14" y2="689.14"/>
+  </g>
+  <g id="LWPOLYLINE-231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1242.17" y1="605.26" x2="1383.05" y2="605.26"/>
+  </g>
+  <g id="LWPOLYLINE-232" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1422.74 601.09 1422.74 605.26 1449.32 605.26"/>
+  </g>
+  <g id="LWPOLYLINE-233" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1411.22" y1="659.05" x2="1414.1" y2="659.05"/>
+  </g>
+  <g id="LWPOLYLINE-234" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1445.8" y1="659.05" x2="1448.68" y2="659.05"/>
+  </g>
+  <g id="LWPOLYLINE-235" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1411.22 659.04 1411.22 687.86 1448.68 687.86"/>
+  </g>
+  <g id="LWPOLYLINE-236" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1415.06 667.37 1415.06 683.7 1426.9 683.7"/>
+  </g>
+  <g id="LWPOLYLINE-237" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1434.27" y1="683.7" x2="1444.52" y2="683.7"/>
+  </g>
+  <g id="LWPOLYLINE-238" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1449.32" y1="528.74" x2="1591.15" y2="528.74"/>
+  </g>
+  <g id="LWPOLYLINE-239" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1631.17 524.26 1631.17 528.74 1657.42 528.74"/>
+  </g>
+  <g id="LWPOLYLINE-240" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1449.32" y1="524.26" x2="1591.15" y2="524.26"/>
+  </g>
+  <g id="LWPOLYLINE-241" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1631.17" y1="524.26" x2="1653.26" y2="524.26"/>
+  </g>
+  <g id="LWPOLYLINE-242" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1242.17" y1="601.1" x2="1383.05" y2="601.1"/>
+  </g>
+  <g id="LWPOLYLINE-243" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1422.74" y1="601.1" x2="1444.83" y2="601.1"/>
+  </g>
+  <g id="LWPOLYLINE-244" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1029.91" y1="684.98" x2="1170.14" y2="684.98"/>
+  </g>
+  <g id="LWPOLYLINE-245" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="800.35" y1="724.68" x2="965.23" y2="724.68"/>
+  </g>
+  <g id="LWPOLYLINE-246" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1003.33" y1="724.68" x2="1025.74" y2="724.68"/>
+  </g>
+  <g id="LWPOLYLINE-247" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="992.12" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-248" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="989.89" y1="1260.31" x2="914.01" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-249" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="989.89" y1="1259.35" x2="914.01" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-250" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="989.88" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-251" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="831.41" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-252" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="832.37" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-253" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="834.61" y1="1260.31" x2="910.48" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-254" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="834.61" y1="1259.35" x2="910.48" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-255" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="993.09" y1="1254.55" x2="831.41" y2="1254.55"/>
+  </g>
+  <g id="LWPOLYLINE-256" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="825.32" y1="605.58" x2="981.56" y2="554.03"/>
+  </g>
+  <g id="LWPOLYLINE-257" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="829.8" y1="618.38" x2="985.73" y2="566.84"/>
+  </g>
+  <g id="LWPOLYLINE-258" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="976.44 697.47 1003.33 724.68 1002.05 725.96 975.16 699.07"/>
+  </g>
+  <g id="LWPOLYLINE-259" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="977.08 696.83 974.2 700.03 971.32 703.55 969.08 707.39 967.47 711.55 966.19 715.71 965.55 720.2 965.24 724.68"/>
+  </g>
+  <g id="LWPOLYLINE-260" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1242.17" y1="689.14" x2="1242.17" y2="482.64"/>
+  </g>
+  <g id="LWPOLYLINE-261" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1448.68" y1="687.86" x2="1448.68" y2="659.04"/>
+  </g>
+  <g id="LWPOLYLINE-262" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1444.51" y1="683.7" x2="1444.51" y2="667.37"/>
+  </g>
+  <g id="LWPOLYLINE-263" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1238.01" y1="684.98" x2="1238.01" y2="484.24"/>
+  </g>
+  <g id="LWPOLYLINE-264" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1182.94 658.09 1209.83 684.98 1208.56 686.26 1181.66 659.36"/>
+  </g>
+  <g id="LWPOLYLINE-265" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1183.58 657.13 1180.7 660.65 1177.82 664.17 1175.58 668.01 1173.98 671.85 1172.7 676.34 1172.05 680.5 1171.74 684.98"/>
+  </g>
+  <g id="LWPOLYLINE-266" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1187.74 482 1239.29 465.03 1244.74 482 1193.19 498.64 1187.74 482"/>
+  </g>
+  <g id="LWPOLYLINE-267" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1213.04 483.92 1214.32 487.76 1213.68 487.76 1211.12 479.75 1211.44 479.44 1212.71 483.28 1219.76 481.04 1218.48 477.19 1219.12 477.19 1221.68 485.19 1221.36 485.19 1220.08 481.36 1213.04 483.92"/>
+  </g>
+  <g id="LWPOLYLINE-268" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1189.03" y1="485.84" x2="1033.1" y2="537.38"/>
+  </g>
+  <g id="LWPOLYLINE-269" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1193.19" y1="498.64" x2="1037.27" y2="550.19"/>
+  </g>
+  <g id="LWPOLYLINE-270" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1395.85 573.88 1422.74 601.1 1421.46 602.38 1394.25 575.49"/>
+  </g>
+  <g id="LWPOLYLINE-271" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1396.49 573.24 1393.61 576.44 1390.73 579.97 1388.49 583.81 1386.89 587.97 1385.61 592.13 1384.65 596.61 1384.65 601.09"/>
+  </g>
+  <g id="LWPOLYLINE-272" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1449.32" y1="605.26" x2="1449.32" y2="414.77"/>
+  </g>
+  <g id="LWPOLYLINE-273" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1444.84" y1="601.1" x2="1444.84" y2="416.04"/>
+  </g>
+  <g id="LWPOLYLINE-274" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2015.68 536.1 1988.79 508.89 1987.19 510.49 2014.4 537.38"/>
+  </g>
+  <g id="LWPOLYLINE-275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2016.32 535.14 2013.12 538.34 2009.6 540.9 2005.76 543.15 2001.6 544.75 1997.44 546.03 1992.95 546.99 1988.79 547.31"/>
+  </g>
+  <g id="LWPOLYLINE-276" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1200.55" y="1254.55" width="45.46" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-277" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1426.91 1263.51 1426.91 1267.67 1426.27 1267.67 1426.27 1259.03 1426.91 1259.03 1426.91 1263.19 1434.27 1263.19 1434.27 1259.03 1434.91 1259.03 1434.91 1267.67 1434.27 1267.67 1434.27 1263.51 1426.91 1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-278" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1407.7" y="1254.55" width="45.78" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-279" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1246.01 1268.63 1407.7 1268.63 1246.01 1268.63"/>
+  </g>
+  <g id="LWPOLYLINE-280" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2059.54 1081.02 2032.65 1107.91 2031.37 1106.63 2058.27 1079.42"/>
+  </g>
+  <g id="LWPOLYLINE-281" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2060.51 1081.66 2057.3 1078.78 2053.78 1075.9 2049.94 1073.66 2045.78 1072.06 2041.62 1070.78 2037.14 1069.82 2032.65 1069.82"/>
+  </g>
+  <g id="LWPOLYLINE-282" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2014.72 210.18 2066.27 193.21 2071.71 210.18 2020.48 226.83 2014.72 210.18"/>
+  </g>
+  <g id="LWPOLYLINE-283" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2036.17 213.06 2037.45 216.9 2037.13 217.22 2034.25 208.9 2034.9 208.9 2036.17 212.74 2043.22 210.5 2041.93 206.66 2042.58 206.34 2045.14 214.34 2044.5 214.66 2043.54 210.82 2036.17 213.06"/>
+  </g>
+  <g id="LWPOLYLINE-284" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="128.65 1076.54 111.68 1223.49 107.52 1223.17 101.43 1276.96"/>
+  </g>
+  <g id="LWPOLYLINE-285" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="126.41" y1="1253.91" x2="170.91" y2="862.98"/>
+  </g>
+  <g id="LWPOLYLINE-286" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="124.17" y1="1076.22" x2="130.57" y2="1022.11"/>
+  </g>
+  <g id="LWPOLYLINE-287" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="134.73" y1="1022.75" x2="151.39" y2="875.79"/>
+  </g>
+  <g id="LWPOLYLINE-288" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M413.92,740.69l152.72-49.95-152.72,49.95Z"/>
+  </g>
+  <g id="LWPOLYLINE-289" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="568.55" y1="696.5" x2="415.84" y2="746.77"/>
+  </g>
+  <g id="LWPOLYLINE-290" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="492.03" y1="717.63" x2="492.36" y2="716.67"/>
+  </g>
+  <g id="LWPOLYLINE-291" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="492.35 716.68 495.87 718.6 497.79 715.07"/>
+  </g>
+  <g id="LWPOLYLINE-292" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="497.8 715.07 501.32 716.68 503.24 713.16"/>
+  </g>
+  <g id="LWPOLYLINE-293" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="503.24 713.15 506.76 715.07 508.36 711.55"/>
+  </g>
+  <g id="LWPOLYLINE-294" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="508.36 711.55 511.88 713.15 513.8 709.63"/>
+  </g>
+  <g id="LWPOLYLINE-295" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="513.8 709.63 517.33 711.55 519.25 708.03"/>
+  </g>
+  <g id="LWPOLYLINE-296" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="519.24 708.03 522.77 709.63 524.37 706.11"/>
+  </g>
+  <g id="LWPOLYLINE-297" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="524.37 706.11 527.89 708.03 529.81 704.51"/>
+  </g>
+  <g id="LWPOLYLINE-298" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="529.81 704.51 533.33 706.43 535.25 702.91"/>
+  </g>
+  <g id="LWPOLYLINE-299" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="535.26 702.91 538.78 704.51 540.38 700.98"/>
+  </g>
+  <g id="LWPOLYLINE-300" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="540.38 700.98 544.22 702.91 545.82 699.39"/>
+  </g>
+  <g id="LWPOLYLINE-301" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="545.82 699.38 549.34 700.99 551.26 697.47"/>
+  </g>
+  <g id="LWPOLYLINE-302" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="551.26 697.47 554.79 699.39 556.7 695.86"/>
+  </g>
+  <g id="LWPOLYLINE-303" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="556.71 695.86 560.23 697.47 561.83 693.95"/>
+  </g>
+  <g id="LWPOLYLINE-304" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="561.82 693.94 565.35 695.86 565.67 695.22"/>
+  </g>
+  <g id="LWPOLYLINE-305" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="565.46" y="690.93" width="2.03" height="5.06" transform="translate(-189.86 214.15) rotate(-18.39)"/>
+  </g>
+  <g id="LWPOLYLINE-306" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="492.99 720.52 491.07 721.15 489.15 716.03 491.39 715.4 492.99 720.52"/>
+  </g>
+  <g id="LWPOLYLINE-307" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="417.76 745.17 415.51 745.81 413.92 740.69 415.84 740.05 417.76 745.17"/>
+  </g>
+  <g id="LWPOLYLINE-308" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="566.31" y1="696.18" x2="415.51" y2="745.81"/>
+  </g>
+  <g id="LWPOLYLINE-309" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="564.71" y1="691.38" x2="413.91" y2="740.69"/>
+  </g>
+  <g id="LWPOLYLINE-310" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="416.79" y1="742.61" x2="417.43" y2="741"/>
+  </g>
+  <g id="LWPOLYLINE-311" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="417.44 741 421.28 742.93 422.88 739.41"/>
+  </g>
+  <g id="LWPOLYLINE-312" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="422.88 739.41 426.4 741.33 428.32 737.81"/>
+  </g>
+  <g id="LWPOLYLINE-313" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="428.32 737.81 431.84 739.41 433.76 735.88"/>
+  </g>
+  <g id="LWPOLYLINE-314" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="433.77 735.88 437.29 737.81 438.89 734.29"/>
+  </g>
+  <g id="LWPOLYLINE-315" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="438.88 734.28 442.41 735.88 444.33 732.36"/>
+  </g>
+  <g id="LWPOLYLINE-316" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="444.33 732.36 447.85 734.28 449.77 730.76"/>
+  </g>
+  <g id="LWPOLYLINE-317" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="449.77 730.76 453.29 732.36 454.89 728.84"/>
+  </g>
+  <g id="LWPOLYLINE-318" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="454.89 728.84 458.42 730.76 460.34 727.24"/>
+  </g>
+  <g id="LWPOLYLINE-319" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="460.34 727.24 463.86 728.84 465.78 725.32"/>
+  </g>
+  <g id="LWPOLYLINE-320" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="465.78 725.32 469.3 727.24 470.9 723.72"/>
+  </g>
+  <g id="LWPOLYLINE-321" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="470.9 723.72 474.42 725.64 476.34 721.8"/>
+  </g>
+  <g id="LWPOLYLINE-322" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="476.35 721.8 479.87 723.72 481.79 720.2"/>
+  </g>
+  <g id="LWPOLYLINE-323" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="481.79 720.19 485.31 722.12 486.91 718.59"/>
+  </g>
+  <g id="LWPOLYLINE-324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="490.75" y1="720.2" x2="490.75" y2="720.2"/>
+  </g>
+  <g id="LWPOLYLINE-325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="490.75" y1="720.2" x2="486.91" y2="718.6"/>
+  </g>
+  <g id="LWPOLYLINE-326" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1419.54 416.04 1420.82 419.57 1420.18 419.88 1417.62 411.88 1418.26 411.56 1419.22 415.4 1426.59 413.16 1425.3 409.32 1425.62 409 1428.18 417.32 1427.87 417.32 1426.59 413.48 1419.54 416.04"/>
+  </g>
+  <g id="LWPOLYLINE-327" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1395.21 413.8 1446.75 396.83 1452.2 413.8 1400.97 430.46 1395.21 413.8"/>
+  </g>
+  <g id="LWPOLYLINE-328" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1240.57" y1="469.19" x2="1396.49" y2="417.64"/>
+  </g>
+  <g id="LWPOLYLINE-329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1244.73" y1="482" x2="1400.97" y2="430.45"/>
+  </g>
+  <g id="LWPOLYLINE-330" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1654.22 328.64 1602.67 345.61 1608.44 362.26 1659.66 345.61 1654.22 328.64"/>
+  </g>
+  <g id="LWPOLYLINE-331" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1635.01 344.97 1636.29 348.81 1636.93 348.81 1634.05 340.48 1633.73 340.8 1635.01 344.64 1627.65 346.89 1626.69 343.05 1626.05 343.37 1628.61 351.37 1629.25 351.05 1627.97 347.52 1635.01 344.97"/>
+  </g>
+  <g id="LWPOLYLINE-332" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1604.28" y1="349.45" x2="1448.03" y2="401"/>
+  </g>
+  <g id="LWPOLYLINE-333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1608.44" y1="362.25" x2="1452.2" y2="413.8"/>
+  </g>
+  <g id="LWPOLYLINE-334" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1842.48 276.77 1843.75 280.61 1844.4 280.61 1841.51 272.29 1841.2 272.61 1842.48 276.46 1835.43 278.7 1834.15 274.85 1833.51 275.17 1836.39 283.18 1836.72 282.85 1835.43 279.01 1842.48 276.77"/>
+  </g>
+  <g id="LWPOLYLINE-335" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1861.69 260.45 1810.46 277.41 1815.9 294.06 1867.13 277.41 1861.69 260.45"/>
+  </g>
+  <g id="LWPOLYLINE-336" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1655.5" y1="332.48" x2="1811.74" y2="281.26"/>
+  </g>
+  <g id="LWPOLYLINE-337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.66" y1="345.61" x2="1815.9" y2="294.06"/>
+  </g>
+  <g id="LWPOLYLINE-338" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="117.44 1269.27 113.61 1268.95 113.61 1269.27 121.93 1270.24 121.93 1269.91 118.08 1269.27 118.73 1261.91 122.89 1262.23 122.89 1261.91 114.56 1260.95 114.24 1261.27 118.41 1261.91 117.44 1269.27"/>
+  </g>
+  <g id="LWPOLYLINE-339" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="185.64 864.59 193 849.55 188.84 832.89 215.42 823.93"/>
+  </g>
+  <g id="LWPOLYLINE-340" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="412.63 736.85 361.41 753.81 367.81 773.67 419.36 756.69 412.63 736.85"/>
+  </g>
+  <g id="LWPOLYLINE-341" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="809.63" y1="629.59" x2="815.08" y2="627.67"/>
+  </g>
+  <g id="LWPOLYLINE-342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="818.28" y1="626.71" x2="824.36" y2="624.46"/>
+  </g>
+  <g id="LWPOLYLINE-343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="827.24" y1="623.51" x2="833.33" y2="621.58"/>
+  </g>
+  <g id="LWPOLYLINE-344" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="836.21" y1="620.63" x2="842.29" y2="618.7"/>
+  </g>
+  <g id="LWPOLYLINE-345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="845.49" y1="617.75" x2="851.58" y2="615.5"/>
+  </g>
+  <g id="LWPOLYLINE-346" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="854.46" y1="614.54" x2="860.54" y2="612.62"/>
+  </g>
+  <g id="LWPOLYLINE-347" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="863.42" y1="611.66" x2="869.5" y2="609.74"/>
+  </g>
+  <g id="LWPOLYLINE-348" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="872.71" y1="608.78" x2="878.47" y2="606.86"/>
+  </g>
+  <g id="LWPOLYLINE-349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="881.67" y1="605.58" x2="887.75" y2="603.66"/>
+  </g>
+  <g id="LWPOLYLINE-350" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="890.63" y1="602.7" x2="896.72" y2="600.78"/>
+  </g>
+  <g id="LWPOLYLINE-351" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="899.92" y1="599.81" x2="905.68" y2="597.9"/>
+  </g>
+  <g id="LWPOLYLINE-352" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="908.88" y1="596.93" x2="914.97" y2="594.69"/>
+  </g>
+  <g id="LWPOLYLINE-353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="917.85" y1="593.73" x2="923.93" y2="591.81"/>
+  </g>
+  <g id="LWPOLYLINE-354" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="926.81" y1="590.85" x2="932.9" y2="588.93"/>
+  </g>
+  <g id="LWPOLYLINE-355" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="936.1" y1="587.97" x2="942.18" y2="585.73"/>
+  </g>
+  <g id="LWPOLYLINE-356" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="945.06" y1="584.77" x2="951.14" y2="582.85"/>
+  </g>
+  <g id="LWPOLYLINE-357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="954.03" y1="581.89" x2="960.11" y2="579.97"/>
+  </g>
+  <g id="LWPOLYLINE-358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="963.31" y1="579" x2="969.4" y2="576.76"/>
+  </g>
+  <g id="LWPOLYLINE-359" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="972.28" y1="575.8" x2="978.04" y2="574.2"/>
+  </g>
+  <g id="LWPOLYLINE-360" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="809.63 629.59 811.23 634.39 816.68 632.47"/>
+  </g>
+  <g id="LWPOLYLINE-361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="819.88" y1="631.51" x2="825.96" y2="629.59"/>
+  </g>
+  <g id="LWPOLYLINE-362" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="828.84" y1="628.63" x2="834.93" y2="626.71"/>
+  </g>
+  <g id="LWPOLYLINE-363" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="837.81" y1="625.75" x2="843.89" y2="623.83"/>
+  </g>
+  <g id="LWPOLYLINE-364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="847.09" y1="622.55" x2="853.18" y2="620.63"/>
+  </g>
+  <g id="LWPOLYLINE-365" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="856.06" y1="619.67" x2="862.14" y2="617.75"/>
+  </g>
+  <g id="LWPOLYLINE-366" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="865.02" y1="616.78" x2="871.1" y2="614.87"/>
+  </g>
+  <g id="LWPOLYLINE-367" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="874.31" y1="613.58" x2="880.39" y2="611.66"/>
+  </g>
+  <g id="LWPOLYLINE-368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="883.27" y1="610.7" x2="889.35" y2="608.78"/>
+  </g>
+  <g id="LWPOLYLINE-369" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="892.24" y1="607.82" x2="898.32" y2="605.9"/>
+  </g>
+  <g id="LWPOLYLINE-370" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="901.52" y1="604.94" x2="907.6" y2="602.69"/>
+  </g>
+  <g id="LWPOLYLINE-371" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="910.48" y1="601.74" x2="916.57" y2="599.81"/>
+  </g>
+  <g id="LWPOLYLINE-372" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="919.45" y1="598.86" x2="925.53" y2="596.93"/>
+  </g>
+  <g id="LWPOLYLINE-373" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="928.73" y1="595.97" x2="934.82" y2="593.73"/>
+  </g>
+  <g id="LWPOLYLINE-374" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="937.7" y1="592.77" x2="943.78" y2="590.85"/>
+  </g>
+  <g id="LWPOLYLINE-375" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="946.66" y1="589.89" x2="952.75" y2="587.97"/>
+  </g>
+  <g id="LWPOLYLINE-376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="955.95" y1="587.01" x2="961.71" y2="584.76"/>
+  </g>
+  <g id="LWPOLYLINE-377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="964.91" y1="583.81" x2="971" y2="581.89"/>
+  </g>
+  <g id="LWPOLYLINE-378" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="973.88" y1="580.93" x2="979.64" y2="579.01"/>
+  </g>
+  <g id="LWPOLYLINE-379" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1382.08" y1="441.34" x2="1375.04" y2="443.58"/>
+  </g>
+  <g id="LWPOLYLINE-380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.84" y1="444.54" x2="1366.08" y2="446.46"/>
+  </g>
+  <g id="LWPOLYLINE-381" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1362.87" y1="447.42" x2="1356.79" y2="449.66"/>
+  </g>
+  <g id="LWPOLYLINE-382" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1353.91" y1="450.62" x2="1347.83" y2="452.54"/>
+  </g>
+  <g id="LWPOLYLINE-383" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1344.95" y1="453.5" x2="1338.86" y2="455.43"/>
+  </g>
+  <g id="LWPOLYLINE-384" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1335.66" y1="456.38" x2="1329.58" y2="458.3"/>
+  </g>
+  <g id="LWPOLYLINE-385" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1326.69" y1="459.59" x2="1320.61" y2="461.5"/>
+  </g>
+  <g id="LWPOLYLINE-386" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1317.73" y1="462.47" x2="1311.65" y2="464.39"/>
+  </g>
+  <g id="LWPOLYLINE-387" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1308.45" y1="465.35" x2="1302.36" y2="467.27"/>
+  </g>
+  <g id="LWPOLYLINE-388" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1299.48" y1="468.23" x2="1293.4" y2="470.47"/>
+  </g>
+  <g id="LWPOLYLINE-389" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1290.52" y1="471.43" x2="1284.43" y2="473.35"/>
+  </g>
+  <g id="LWPOLYLINE-390" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1281.23" y1="474.31" x2="1275.15" y2="476.24"/>
+  </g>
+  <g id="LWPOLYLINE-391" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1272.27" y1="477.19" x2="1266.18" y2="479.44"/>
+  </g>
+  <g id="LWPOLYLINE-392" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1263.3" y1="480.39" x2="1257.22" y2="482.31"/>
+  </g>
+  <g id="LWPOLYLINE-393" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1254.02" y1="483.28" x2="1247.94" y2="485.2"/>
+  </g>
+  <g id="LWPOLYLINE-394" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1245.05" y1="486.16" x2="1238.01" y2="488.72"/>
+  </g>
+  <g id="LWPOLYLINE-395" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1222 499.28 1220.4 494.48 1214.64 496.4"/>
+  </g>
+  <g id="LWPOLYLINE-396" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1211.76" y1="497.36" x2="1205.67" y2="499.28"/>
+  </g>
+  <g id="LWPOLYLINE-397" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1202.47" y1="500.25" x2="1196.39" y2="502.17"/>
+  </g>
+  <g id="LWPOLYLINE-398" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1193.51" y1="503.13" x2="1187.42" y2="505.05"/>
+  </g>
+  <g id="LWPOLYLINE-399" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1184.54" y1="506.33" x2="1178.46" y2="508.25"/>
+  </g>
+  <g id="LWPOLYLINE-400" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1175.26" y1="509.21" x2="1169.18" y2="511.13"/>
+  </g>
+  <g id="LWPOLYLINE-401" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1166.3" y1="512.09" x2="1160.21" y2="514.02"/>
+  </g>
+  <g id="LWPOLYLINE-402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1157.33" y1="514.97" x2="1151.25" y2="517.22"/>
+  </g>
+  <g id="LWPOLYLINE-403" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1148.04" y1="518.18" x2="1141.96" y2="520.09"/>
+  </g>
+  <g id="LWPOLYLINE-404" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1139.08" y1="521.06" x2="1133" y2="522.98"/>
+  </g>
+  <g id="LWPOLYLINE-405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1130.12" y1="523.94" x2="1124.03" y2="526.18"/>
+  </g>
+  <g id="LWPOLYLINE-406" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1120.83" y1="527.14" x2="1115.07" y2="529.06"/>
+  </g>
+  <g id="LWPOLYLINE-407" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1111.87" y1="530.02" x2="1105.78" y2="531.94"/>
+  </g>
+  <g id="LWPOLYLINE-408" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1102.9" y1="532.9" x2="1096.82" y2="535.14"/>
+  </g>
+  <g id="LWPOLYLINE-409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1093.62" y1="536.1" x2="1087.86" y2="538.03"/>
+  </g>
+  <g id="LWPOLYLINE-410" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1084.65" y1="538.98" x2="1078.57" y2="540.9"/>
+  </g>
+  <g id="LWPOLYLINE-411" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1075.69" y1="541.87" x2="1069.6" y2="543.79"/>
+  </g>
+  <g id="LWPOLYLINE-412" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1066.72" y1="545.07" x2="1060.64" y2="546.99"/>
+  </g>
+  <g id="LWPOLYLINE-413" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1057.44" y1="547.95" x2="1051.68" y2="549.87"/>
+  </g>
+  <g id="LWPOLYLINE-414" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1382.08 441.34 1383.68 446.14 1380.48 447.42"/>
+  </g>
+  <g id="LWPOLYLINE-415" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1377.28" y1="448.38" x2="1371.2" y2="450.3"/>
+  </g>
+  <g id="LWPOLYLINE-416" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1368.32" y1="451.26" x2="1362.23" y2="453.18"/>
+  </g>
+  <g id="LWPOLYLINE-417" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1359.35" y1="454.46" x2="1353.27" y2="456.38"/>
+  </g>
+  <g id="LWPOLYLINE-418" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1350.07" y1="457.34" x2="1343.98" y2="459.26"/>
+  </g>
+  <g id="LWPOLYLINE-419" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1341.1" y1="460.23" x2="1335.02" y2="462.15"/>
+  </g>
+  <g id="LWPOLYLINE-420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1332.14" y1="463.11" x2="1326.05" y2="465.35"/>
+  </g>
+  <g id="LWPOLYLINE-421" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1322.85" y1="466.31" x2="1316.77" y2="468.23"/>
+  </g>
+  <g id="LWPOLYLINE-422" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1313.89" y1="469.19" x2="1307.81" y2="471.11"/>
+  </g>
+  <g id="LWPOLYLINE-423" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1304.92" y1="472.07" x2="1298.84" y2="474.31"/>
+  </g>
+  <g id="LWPOLYLINE-424" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1295.64" y1="475.27" x2="1289.56" y2="477.19"/>
+  </g>
+  <g id="LWPOLYLINE-425" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.67" y1="478.15" x2="1280.59" y2="480.07"/>
+  </g>
+  <g id="LWPOLYLINE-426" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1277.71" y1="481.04" x2="1271.63" y2="483.28"/>
+  </g>
+  <g id="LWPOLYLINE-427" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1268.43" y1="484.24" x2="1262.67" y2="486.16"/>
+  </g>
+  <g id="LWPOLYLINE-428" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1259.46" y1="487.12" x2="1253.38" y2="489.04"/>
+  </g>
+  <g id="LWPOLYLINE-429" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1250.5" y1="490" x2="1244.41" y2="491.92"/>
+  </g>
+  <g id="LWPOLYLINE-430" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1241.21" y1="493.2" x2="1238.01" y2="494.16"/>
+  </g>
+  <g id="LWPOLYLINE-431" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1222" y1="499.29" x2="1216.24" y2="501.2"/>
+  </g>
+  <g id="LWPOLYLINE-432" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1213.36" y1="502.17" x2="1207.27" y2="504.41"/>
+  </g>
+  <g id="LWPOLYLINE-433" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1204.07" y1="505.37" x2="1198.31" y2="507.29"/>
+  </g>
+  <g id="LWPOLYLINE-434" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1195.11" y1="508.25" x2="1189.03" y2="510.17"/>
+  </g>
+  <g id="LWPOLYLINE-435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1186.14" y1="511.13" x2="1180.06" y2="513.38"/>
+  </g>
+  <g id="LWPOLYLINE-436" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1176.86" y1="514.33" x2="1171.1" y2="516.26"/>
+  </g>
+  <g id="LWPOLYLINE-437" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1167.89" y1="517.21" x2="1161.81" y2="519.14"/>
+  </g>
+  <g id="LWPOLYLINE-438" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1158.93" y1="520.09" x2="1152.85" y2="522.02"/>
+  </g>
+  <g id="LWPOLYLINE-439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1149.97" y1="523.3" x2="1143.88" y2="525.22"/>
+  </g>
+  <g id="LWPOLYLINE-440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1140.68" y1="526.18" x2="1134.6" y2="528.1"/>
+  </g>
+  <g id="LWPOLYLINE-441" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1131.72" y1="529.06" x2="1125.63" y2="530.98"/>
+  </g>
+  <g id="LWPOLYLINE-442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1122.75" y1="531.94" x2="1116.67" y2="534.19"/>
+  </g>
+  <g id="LWPOLYLINE-443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1113.47" y1="535.14" x2="1107.38" y2="537.06"/>
+  </g>
+  <g id="LWPOLYLINE-444" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1104.5" y1="538.03" x2="1098.42" y2="539.95"/>
+  </g>
+  <g id="LWPOLYLINE-445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1095.54" y1="540.9" x2="1089.46" y2="543.15"/>
+  </g>
+  <g id="LWPOLYLINE-446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1086.25" y1="544.11" x2="1080.17" y2="546.03"/>
+  </g>
+  <g id="LWPOLYLINE-447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1077.29" y1="546.99" x2="1071.21" y2="548.91"/>
+  </g>
+  <g id="LWPOLYLINE-448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1068.32" y1="549.87" x2="1062.24" y2="551.79"/>
+  </g>
+  <g id="LWPOLYLINE-449" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1059.04" y1="553.07" x2="1053.6" y2="554.67"/>
+  </g>
+  <g id="LWPOLYLINE-450" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1636.94 362.9 1635.33 358.09 1628.28 360.34"/>
+  </g>
+  <g id="LWPOLYLINE-451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1625.41" y1="361.3" x2="1619.32" y2="363.22"/>
+  </g>
+  <g id="LWPOLYLINE-452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1616.12" y1="364.18" x2="1610.36" y2="366.1"/>
+  </g>
+  <g id="LWPOLYLINE-453" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1607.16" y1="367.38" x2="1601.07" y2="369.3"/>
+  </g>
+  <g id="LWPOLYLINE-454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1598.19" y1="370.26" x2="1592.11" y2="372.18"/>
+  </g>
+  <g id="LWPOLYLINE-455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1588.91" y1="373.14" x2="1583.15" y2="375.07"/>
+  </g>
+  <g id="LWPOLYLINE-456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1579.94" y1="376.02" x2="1573.86" y2="378.27"/>
+  </g>
+  <g id="LWPOLYLINE-457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1570.98" y1="379.22" x2="1564.9" y2="381.14"/>
+  </g>
+  <g id="LWPOLYLINE-458" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1562.01" y1="382.11" x2="1555.93" y2="384.03"/>
+  </g>
+  <g id="LWPOLYLINE-459" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1552.73" y1="384.99" x2="1546.65" y2="387.23"/>
+  </g>
+  <g id="LWPOLYLINE-460" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1543.77" y1="388.19" x2="1537.68" y2="390.11"/>
+  </g>
+  <g id="LWPOLYLINE-461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1534.8" y1="391.07" x2="1528.72" y2="392.99"/>
+  </g>
+  <g id="LWPOLYLINE-462" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1525.52" y1="393.95" x2="1519.43" y2="396.2"/>
+  </g>
+  <g id="LWPOLYLINE-463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1516.55" y1="397.15" x2="1510.47" y2="399.08"/>
+  </g>
+  <g id="LWPOLYLINE-464" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1507.59" y1="400.03" x2="1501.5" y2="401.96"/>
+  </g>
+  <g id="LWPOLYLINE-465" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1498.3" y1="402.92" x2="1492.22" y2="404.84"/>
+  </g>
+  <g id="LWPOLYLINE-466" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1489.34" y1="406.12" x2="1483.25" y2="408.04"/>
+  </g>
+  <g id="LWPOLYLINE-467" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1480.37" y1="409" x2="1473.32" y2="411.24"/>
+  </g>
+  <g id="LWPOLYLINE-468" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1636.93" y1="362.9" x2="1629.89" y2="365.45"/>
+  </g>
+  <g id="LWPOLYLINE-469" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1627.01" y1="366.42" x2="1620.92" y2="368.34"/>
+  </g>
+  <g id="LWPOLYLINE-470" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1618.04" y1="369.3" x2="1611.96" y2="371.22"/>
+  </g>
+  <g id="LWPOLYLINE-471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1608.76" y1="372.18" x2="1602.67" y2="374.1"/>
+  </g>
+  <g id="LWPOLYLINE-472" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1599.79" y1="375.38" x2="1593.71" y2="377.3"/>
+  </g>
+  <g id="LWPOLYLINE-473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1590.83" y1="378.26" x2="1584.74" y2="380.19"/>
+  </g>
+  <g id="LWPOLYLINE-474" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1581.55" y1="381.14" x2="1575.46" y2="383.07"/>
+  </g>
+  <g id="LWPOLYLINE-475" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1572.58" y1="384.03" x2="1566.5" y2="386.27"/>
+  </g>
+  <g id="LWPOLYLINE-476" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1563.61" y1="387.23" x2="1557.53" y2="389.15"/>
+  </g>
+  <g id="LWPOLYLINE-477" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1554.33" y1="390.11" x2="1548.57" y2="392.03"/>
+  </g>
+  <g id="LWPOLYLINE-478" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1545.37" y1="392.99" x2="1539.28" y2="395.24"/>
+  </g>
+  <g id="LWPOLYLINE-479" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1536.4" y1="396.19" x2="1530.32" y2="398.11"/>
+  </g>
+  <g id="LWPOLYLINE-480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1527.12" y1="399.08" x2="1521.36" y2="401"/>
+  </g>
+  <g id="LWPOLYLINE-481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1518.15" y1="401.96" x2="1512.07" y2="404.2"/>
+  </g>
+  <g id="LWPOLYLINE-482" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1509.19" y1="405.16" x2="1503.11" y2="407.08"/>
+  </g>
+  <g id="LWPOLYLINE-483" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1499.9" y1="408.04" x2="1494.14" y2="409.96"/>
+  </g>
+  <g id="LWPOLYLINE-484" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1490.94" y1="410.92" x2="1484.86" y2="412.84"/>
+  </g>
+  <g id="LWPOLYLINE-485" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1481.97" y1="414.12" x2="1474.93" y2="416.37"/>
+  </g>
+  <g id="LWPOLYLINE-486" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2081.95 685.94 2089 622.87 2094.44 623.51"/>
+  </g>
+  <g id="LWPOLYLINE-487" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2094.44" y1="574.2" x2="2099.89" y2="574.84"/>
+  </g>
+  <g id="LWPOLYLINE-488" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2102.45" y1="620.95" x2="2105.01" y2="600.14"/>
+  </g>
+  <g id="LWPOLYLINE-489" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2099.56 620.63 2087.72 619.35 2087.4 622.55 2098.93 623.82 2099.56 620.63"/>
+  </g>
+  <g id="LWPOLYLINE-490" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2104.37 578.68 2092.53 577.41 2092.84 574.2 2104.69 575.49 2104.37 578.68"/>
+  </g>
+  <g id="LWPOLYLINE-491" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2104.37 578.68 2108.85 579.01 2106.61 600.13 2105.01 600.13"/>
+  </g>
+  <g id="LWPOLYLINE-492" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2122.3 580.61 2179.29 587 2172.88 645.6 2115.57 639.19 2117.5 622.87 2105.33 621.26 2103.09 640.8 2175.44 649.12 2182.81 584.45 2110.45 576.12 2110.13 579.33 2122.3 580.61"/>
+  </g>
+  <g id="LWPOLYLINE-493" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2115.58 609.42 2106.61 608.46 2108.21 593.74 2117.49 594.69"/>
+  </g>
+  <g id="LWPOLYLINE-494" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2107.57" y1="600.78" x2="2113.01" y2="601.41"/>
+  </g>
+  <g id="LWPOLYLINE-495" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2121.66 595.33 2119.74 610.06 2128.38 611.02"/>
+  </g>
+  <g id="LWPOLYLINE-496" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2140.87 612.3 2131.9 611.34 2133.51 596.62 2142.79 597.57"/>
+  </g>
+  <g id="LWPOLYLINE-497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2132.86" y1="603.66" x2="2138.31" y2="604.3"/>
+  </g>
+  <g id="LWPOLYLINE-498" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2146.95 598.21 2150.79 613.58 2158.15 599.5"/>
+  </g>
+  <g id="LWPOLYLINE-499" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2160.08 613.26 2159.44 613.9 2160.08 614.54 2160.72 613.9"/>
+  </g>
+  <g id="LWPOLYLINE-500" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2168.08 603.98 2168.4 603.34 2169.04 602.06 2170 601.42 2171.28 600.78 2174.16 601.1 2175.45 602.06 2176.08 603.02 2176.72 604.3 2176.72 605.9 2175.76 607.18 2174.16 609.1 2166.16 615.18 2176.08 616.47"/>
+  </g>
+  <g id="LWPOLYLINE-501" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.65" y1="406.12" x2="2121.98" y2="407.08"/>
+  </g>
+  <g id="LWPOLYLINE-502" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2109.17 446.14 2109.49 444.22 2117.49 445.18"/>
+  </g>
+  <g id="LWPOLYLINE-503" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2094.44 574.2 2109.17 446.14 2119.74 447.42"/>
+  </g>
+  <g id="LWPOLYLINE-504" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2116.53" y1="455.1" x2="2118.78" y2="455.43"/>
+  </g>
+  <g id="LWPOLYLINE-505" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2137.34 509.85 2133.5 544.43 2187.93 550.51"/>
+  </g>
+  <g id="LWPOLYLINE-506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2108.21" y1="527.14" x2="2161.68" y2="533.54"/>
+  </g>
+  <g id="LWPOLYLINE-507" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.29 451.26 2161.68 534.5 2162.63 534.5"/>
+  </g>
+  <g id="LWPOLYLINE-508" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2109.49" y1="516.89" x2="2162.96" y2="522.98"/>
+  </g>
+  <g id="LWPOLYLINE-509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2110.45" y1="506.65" x2="2164.24" y2="512.73"/>
+  </g>
+  <g id="LWPOLYLINE-510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2129.34" y1="498.32" x2="2134.15" y2="498.96"/>
+  </g>
+  <g id="LWPOLYLINE-511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2137.66" y1="499.29" x2="2165.2" y2="502.49"/>
+  </g>
+  <g id="LWPOLYLINE-512" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.01" y1="486.16" x2="2139.26" y2="489.36"/>
+  </g>
+  <g id="LWPOLYLINE-513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.97" y1="475.91" x2="2167.76" y2="482"/>
+  </g>
+  <g id="LWPOLYLINE-514" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.25" y1="465.67" x2="2168.72" y2="471.75"/>
+  </g>
+  <g id="LWPOLYLINE-515" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2116.21" y1="455.42" x2="2170" y2="461.51"/>
+  </g>
+  <g id="LWPOLYLINE-516" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2117.5" y1="445.18" x2="2171.29" y2="451.26"/>
+  </g>
+  <g id="LWPOLYLINE-517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2091.24" y1="649.12" x2="2202.66" y2="661.93"/>
+  </g>
+  <g id="LWPOLYLINE-518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2100.21" y1="566.2" x2="2211.94" y2="578.69"/>
+  </g>
+  <g id="LWPOLYLINE-519" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2121.98" y1="405.16" x2="2121.98" y2="407.08"/>
+  </g>
+  <g id="LWPOLYLINE-520" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2117.18" y1="447.1" x2="2104.69" y2="558.84"/>
+  </g>
+  <g id="LWPOLYLINE-521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2119.74" y1="447.42" x2="2118.77" y2="455.42"/>
+  </g>
+  <g id="LWPOLYLINE-522" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.97" y1="446.78" x2="2100.21" y2="566.2"/>
+  </g>
+  <g id="LWPOLYLINE-523" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2224.43 159.91 2260.93 147.75 2232.76 396.19"/>
+  </g>
+  <g id="LWPOLYLINE-524" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2230.19" y1="417.32" x2="2202.01" y2="665.13"/>
+  </g>
+  <g id="LWPOLYLINE-525" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2202.02 665.13 2185.37 663.21 2182.81 684.34"/>
+  </g>
+  <g id="LWPOLYLINE-526" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2199.78" y1="686.26" x2="2168.72" y2="959.68"/>
+  </g>
+  <g id="LWPOLYLINE-527" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2149.51 978.89 2166.16 980.81 2134.78 1259.03"/>
+  </g>
+  <g id="LWPOLYLINE-528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.75" y1="957.76" x2="2149.51" y2="978.89"/>
+  </g>
+  <g id="LWPOLYLINE-529" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2232.75 396.2 2215.79 394.27 2213.54 415.41"/>
+  </g>
+  <g id="LWPOLYLINE-530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2271.49" y1="129.5" x2="2141.18" y2="1276.96"/>
+  </g>
+  <g id="LWPOLYLINE-531" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2087.72 619.98 2083.24 619.35 2079.71 649.76"/>
+  </g>
+  <g id="LWPOLYLINE-532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2094.44" y1="623.51" x2="2087.08" y2="685.94"/>
+  </g>
+  <g id="LWPOLYLINE-533" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2145.67 437.17 2121.97 407.08 2120.37 408.35 2144.07 438.14"/>
+  </g>
+  <g id="LWPOLYLINE-534" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2146.63 436.21 2142.79 439.1 2138.95 441.33 2135.1 442.94 2130.62 444.22 2126.46 445.18 2121.97 445.49 2117.5 445.18"/>
+  </g>
+  <g id="LWPOLYLINE-535" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2036.49 329.6 2070.75 346.57 2069.79 348.49 2035.86 331.2"/>
+  </g>
+  <g id="LWPOLYLINE-536" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2037.13 328.64 2035.22 332.48 2033.61 336.64 2032.97 341.13 2032.33 345.61 2032.65 350.09 2033.3 354.25 2034.25 358.73"/>
+  </g>
+  <g id="LWPOLYLINE-537" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.65 406.12 2113.97 404.2 2213.55 415.4"/>
+  </g>
+  <g id="LWPOLYLINE-538" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2104.69" y1="558.84" x2="2212.9" y2="571.33"/>
+  </g>
+  <g id="LWPOLYLINE-539" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2213.54" y1="415.4" x2="2230.19" y2="417.32"/>
+  </g>
+  <g id="LWPOLYLINE-540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2162.64" y1="534.5" x2="2170.96" y2="461.51"/>
+  </g>
+  <g id="LWPOLYLINE-541" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2146.31 448.06 2145.67 446.78 2144.39 446.14 2142.78 446.78 2142.15 448.06 2142.78 449.66 2144.39 450.3 2145.67 449.66 2146.31 448.06"/>
+  </g>
+  <g id="LWPOLYLINE-542" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2129.02 515.93 2137.35 509.85 2143.43 518.18"/>
+  </g>
+  <g id="LWPOLYLINE-543" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2112.37 491.6 2134.46 489.36 2137.34 493.52 2141.51 484.24 2144.39 488.4 2167.12 485.84"/>
+  </g>
+  <g id="LWPOLYLINE-544" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2148.55 431.41 2147.59 440.38 2148.23 442.3 2149.19 443.58 2150.79 444.54 2152.08 444.54 2153.99 444.22 2155.28 443.25 2156.23 441.33 2157.19 432.37"/>
+  </g>
+  <g id="LWPOLYLINE-545" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2160.72 445.5 2161.99 432.69 2167.44 433.33 2169.03 434.29 2169.68 434.93 2170 436.22 2170 437.81 2169.03 439.1 2168.4 439.74 2166.48 440.05 2161.36 439.41"/>
+  </g>
+  <g id="LWPOLYLINE-546" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2195.29" y1="685.62" x2="2179.93" y2="820.08"/>
+  </g>
+  <g id="LWPOLYLINE-547" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2163.28 958.72 2148.55 957.12 2145.99 980.17 2161.68 982.09 2151.75 1067.25"/>
+  </g>
+  <g id="LWPOLYLINE-548" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2153.35 1082.3 2150.15 1081.98 2145.67 1122.96"/>
+  </g>
+  <g id="LWPOLYLINE-549" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2154.96" y1="1067.89" x2="2153.35" y2="1082.3"/>
+  </g>
+  <g id="LWPOLYLINE-550" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2028.49 1127.12 2144.39 1127.12 2129.66 1259.03"/>
+  </g>
+  <g id="LWPOLYLINE-551" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2090.92" y1="654.56" x2="2185.05" y2="665.13"/>
+  </g>
+  <g id="LWPOLYLINE-552" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="312.74 1193.4 303.78 1193.4 303.78 1178.67 312.74 1178.67"/>
+  </g>
+  <g id="LWPOLYLINE-553" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="303.78" y1="1185.71" x2="309.22" y2="1185.71"/>
+  </g>
+  <g id="LWPOLYLINE-554" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="317.22 1178.67 317.22 1193.39 325.55 1193.39"/>
+  </g>
+  <g id="LWPOLYLINE-555" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="338.36 1193.4 329.07 1193.4 329.07 1178.67 338.36 1178.67"/>
+  </g>
+  <g id="LWPOLYLINE-556" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="329.07" y1="1185.71" x2="334.83" y2="1185.71"/>
+  </g>
+  <g id="LWPOLYLINE-557" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="342.52 1178.67 348.28 1193.39 353.72 1178.67"/>
+  </g>
+  <g id="LWPOLYLINE-558" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="357.25 1192.12 356.61 1192.75 357.25 1193.4 358.21 1192.75"/>
+  </g>
+  <g id="LWPOLYLINE-559" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="486.59 758.94 484.99 757.97 482.75 757.97 479.87 758.94 478.26 760.21 477.31 761.82 477.63 763.42 478.91 764.38 479.87 764.7 481.47 765.02 485.63 765.02 487.23 765.33 488.19 765.66 489.47 766.94 490.12 768.86 489.15 770.78 487.23 772.07 484.67 773.02 482.43 773.02 480.51 772.07"/>
+  </g>
+  <g id="LWPOLYLINE-560" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="494.92" y1="753.81" x2="499.4" y2="768.22"/>
+  </g>
+  <g id="LWPOLYLINE-561" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="490.11" y1="755.41" x2="499.39" y2="752.53"/>
+  </g>
+  <g id="LWPOLYLINE-562" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="506.76 765.66 507.4 749.65 517.65 762.14"/>
+  </g>
+  <g id="LWPOLYLINE-563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="507.4" y1="760.22" x2="514.13" y2="757.97"/>
+  </g>
+  <g id="LWPOLYLINE-564" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="521.49" y1="760.86" x2="517.01" y2="746.77"/>
+  </g>
+  <g id="LWPOLYLINE-565" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="526.93 758.94 522.45 744.85 528.53 742.93 530.46 742.93 531.41 743.57 532.69 744.53 533.01 745.81 532.69 747.41 532.38 748.37 530.46 749.65 524.37 751.57"/>
+  </g>
+  <g id="LWPOLYLINE-566" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="529.17" y1="749.97" x2="536.22" y2="756.05"/>
+  </g>
+  <g id="LWPOLYLINE-567" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="539.1" y1="748.37" x2="551.26" y2="744.53"/>
+  </g>
+  <g id="LWPOLYLINE-568" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="554.79 737.17 555.75 736.2 557.34 733.64 561.83 747.74"/>
+  </g>
+  <g id="LWPOLYLINE-569" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2232.43 554.99 2230.83 555.95 2229.88 558.19 2229.55 561.08 2229.88 563 2231.15 564.6 2232.76 564.92 2234.03 564.28 2235 563.63 2235.63 562.36 2237.55 558.19 2238.52 556.91 2239.15 556.27 2240.76 555.95 2243 555.95 2244.28 557.55 2244.6 559.79 2244.28 562.68 2243.32 564.6 2241.71 565.88"/>
+  </g>
+  <g id="LWPOLYLINE-570" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2231.15" y1="545.39" x2="2245.88" y2="547.31"/>
+  </g>
+  <g id="LWPOLYLINE-571" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2230.83" y1="550.51" x2="2231.79" y2="540.59"/>
+  </g>
+  <g id="LWPOLYLINE-572" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2246.84 539.3 2232.75 532.26 2248.12 528.1"/>
+  </g>
+  <g id="LWPOLYLINE-573" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2242.36" y1="536.74" x2="2243" y2="529.7"/>
+  </g>
+  <g id="LWPOLYLINE-574" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2248.76" y1="523.94" x2="2234.03" y2="522.33"/>
+  </g>
+  <g id="LWPOLYLINE-575" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2249.4 518.5 2234.68 516.58 2235.31 510.49 2236.27 508.25 2236.91 507.61 2238.52 507.29 2239.79 507.29 2241.07 508.25 2241.72 508.89 2242.36 511.13 2241.72 517.53"/>
+  </g>
+  <g id="LWPOLYLINE-576" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2242.04" y1="512.41" x2="2250.36" y2="508.57"/>
+  </g>
+  <g id="LWPOLYLINE-577" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2244.6" y1="502.81" x2="2246.2" y2="490.32"/>
+  </g>
+  <g id="LWPOLYLINE-578" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2242.04 483.28 2241.08 483.28 2239.79 482.31 2239.16 481.68 2238.84 480.08 2239.16 477.52 2239.79 475.91 2240.76 475.27 2242.04 474.95 2243.63 474.95 2244.92 475.91 2246.84 477.52 2252.92 485.2 2254.2 475.59"/>
+  </g>
+  <g id="LWPOLYLINE-579" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1011.65 1245.58 1011.65 1250.71 1007.17 1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-580" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1003.97" y1="1250.71" x2="997.56" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-581" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="994.37" y1="1250.71" x2="987.96" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-582" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="985.08" y1="1250.71" x2="978.67" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-583" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="975.48" y1="1250.71" x2="969.07" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-584" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="965.87" y1="1250.71" x2="959.47" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-585" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="956.27" y1="1250.71" x2="949.86" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-586" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="946.66" y1="1250.71" x2="940.26" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-587" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="937.38" y1="1250.71" x2="930.97" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-588" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="927.77" y1="1250.71" x2="921.37" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-589" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="918.17" y1="1250.71" x2="911.76" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-590" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="908.56" y1="1250.71" x2="902.16" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-591" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="898.96" y1="1250.71" x2="892.55" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-592" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="889.35" y1="1250.71" x2="883.27" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-593" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="880.07" y1="1250.71" x2="873.66" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-594" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="870.46" y1="1250.71" x2="864.06" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-595" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="860.86" y1="1250.71" x2="854.45" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-596" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="851.26" y1="1250.71" x2="844.85" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="841.65" y1="1250.71" x2="835.57" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-598" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="832.37" y1="1250.71" x2="825.96" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-599" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="822.76" y1="1250.71" x2="816.35" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-600" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="813.16" y1="1250.71" x2="808.67" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-601" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1011.65" y1="1245.58" x2="1007.17" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-602" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1003.97" y1="1245.58" x2="997.56" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-603" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="994.37" y1="1245.58" x2="987.96" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-604" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="985.08" y1="1245.58" x2="978.67" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-605" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="975.48" y1="1245.58" x2="969.07" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-606" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="965.87" y1="1245.58" x2="959.47" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-607" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="956.27" y1="1245.58" x2="949.86" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-608" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="946.66" y1="1245.58" x2="940.26" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-609" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="937.38" y1="1245.58" x2="930.97" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-610" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="927.77" y1="1245.58" x2="921.37" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-611" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="918.17" y1="1245.58" x2="911.76" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-612" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="908.56" y1="1245.58" x2="902.16" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-613" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="898.96" y1="1245.58" x2="892.55" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-614" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="889.35" y1="1245.58" x2="883.27" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-615" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="880.07" y1="1245.58" x2="873.66" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-616" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="870.46" y1="1245.58" x2="864.06" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-617" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="860.86" y1="1245.58" x2="854.45" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-618" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="851.26" y1="1245.58" x2="844.85" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="841.65" y1="1245.58" x2="835.57" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-620" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="832.37" y1="1245.58" x2="825.96" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-621" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="822.76" y1="1245.58" x2="816.35" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-622" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="813.16" y1="1245.58" x2="808.67" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-623" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1020.3 1245.58 1020.3 1250.71 1027.35 1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-624" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1030.54" y1="1250.71" x2="1036.95" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-625" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1040.15" y1="1250.71" x2="1046.56" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-626" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1049.76" y1="1250.71" x2="1055.84" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-627" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1059.04" y1="1250.71" x2="1065.45" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-628" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1068.65" y1="1250.71" x2="1075.05" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-629" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1078.25" y1="1250.71" x2="1084.66" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-630" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1087.85" y1="1250.71" x2="1094.26" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-631" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1097.46" y1="1250.71" x2="1103.87" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-632" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1106.74" y1="1250.71" x2="1113.15" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-633" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1116.35" y1="1250.71" x2="1122.76" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-634" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1125.95" y1="1250.71" x2="1132.36" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1135.56" y1="1250.71" x2="1141.97" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-636" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1145.16" y1="1250.71" x2="1151.57" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-637" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1154.45" y1="1250.71" x2="1160.86" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-638" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1164.05" y1="1250.71" x2="1170.46" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-639" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1173.66" y1="1250.71" x2="1180.06" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-640" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1183.26" y1="1250.71" x2="1189.67" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-641" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1192.87" y1="1250.71" x2="1199.28" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-642" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1202.47" y1="1250.71" x2="1208.56" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-643" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1211.76" y1="1250.71" x2="1219.12" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-644" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1020.3" y1="1245.58" x2="1027.35" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-645" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1030.54" y1="1245.58" x2="1036.95" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-646" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1040.15" y1="1245.58" x2="1046.56" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-647" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1049.76" y1="1245.58" x2="1055.84" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-648" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1059.04" y1="1245.58" x2="1065.45" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-649" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1068.65" y1="1245.58" x2="1075.05" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-650" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1078.25" y1="1245.58" x2="1084.66" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-651" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1087.85" y1="1245.58" x2="1094.26" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-652" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1097.46" y1="1245.58" x2="1103.87" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-653" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1106.74" y1="1245.58" x2="1113.15" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-654" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1116.35" y1="1245.58" x2="1122.76" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-655" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1125.95" y1="1245.58" x2="1132.36" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-656" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1135.56" y1="1245.58" x2="1141.97" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-657" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1145.16" y1="1245.58" x2="1151.57" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-658" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1154.45" y1="1245.58" x2="1160.86" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-659" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1164.05" y1="1245.58" x2="1170.46" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-660" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1173.66" y1="1245.58" x2="1180.06" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-661" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1183.26" y1="1245.58" x2="1189.67" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-662" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1192.87" y1="1245.58" x2="1199.28" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-663" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1202.47" y1="1245.58" x2="1208.56" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-664" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1211.76" y1="1245.58" x2="1219.12" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-665" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1219.12" y1="1250.71" x2="1219.12" y2="1245.58"/>
+  </g>
+  <g id="CIRCLE-17" data-name="CIRCLE">
+    <circle class="cls-3" cx="600.41" cy="969.77" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-666" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2168.72" y1="959.68" x2="2151.75" y2="957.76"/>
+  </g>
+  <g id="LWPOLYLINE-667" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2182.81" y1="684.34" x2="2199.78" y2="686.26"/>
+  </g>
+  <g id="LWPOLYLINE-668" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="361.09 1112.4 333.87 1139.29 335.47 1140.89 362.37 1113.68"/>
+  </g>
+  <g id="LWPOLYLINE-669" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="360.13 1111.75 363.33 1114.96 365.89 1118.48 368.13 1122.33 369.74 1126.48 371.01 1130.64 371.97 1134.81 372.29 1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-670" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="443.05" y1="1143.77" x2="443.05" y2="1136.09"/>
+  </g>
+  <g id="LWPOLYLINE-671" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="443.05" y1="1097.67" x2="443.05" y2="955.84"/>
+  </g>
+  <g id="LWPOLYLINE-672" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="446.57" y1="955.84" x2="446.57" y2="951.35"/>
+  </g>
+  <g id="LWPOLYLINE-673" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="351.48" y1="837.7" x2="376.45" y2="913.25"/>
+  </g>
+  <g id="LWPOLYLINE-674" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="347.64" y1="838.98" x2="372.61" y2="914.53"/>
+  </g>
+  <g id="LWPOLYLINE-675" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="379.98" y1="911.97" x2="381.9" y2="917.09"/>
+  </g>
+  <g id="LWPOLYLINE-676" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="379.98 911.97 369.73 915.5 371.33 920.62"/>
+  </g>
+  <g id="LWPOLYLINE-677" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="333.55" y1="927.34" x2="335.15" y2="932.46"/>
+  </g>
+  <g id="LWPOLYLINE-678" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="438.89 892.76 416.48 900.13 418.08 905.25"/>
+  </g>
+  <g id="LWPOLYLINE-679" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="357.89 1011.22 330.67 984.33 329.39 985.61 356.29 1012.5"/>
+  </g>
+  <g id="LWPOLYLINE-680" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="358.53 1010.58 355.32 1013.47 351.8 1016.34 347.96 1018.59 343.8 1020.19 339.64 1021.47 335.16 1022.11 330.67 1022.43"/>
+  </g>
+  <g id="LWPOLYLINE-681" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="215.41" y1="823.93" x2="574" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-682" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="229.18 876.12 235.26 866.83 351.48 828.41"/>
+  </g>
+  <g id="LWPOLYLINE-683" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="218.62 909.1 240.71 874.19 354.36 836.73"/>
+  </g>
+  <g id="LWPOLYLINE-684" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="327.79" y1="929.26" x2="333.55" y2="927.34"/>
+  </g>
+  <g id="LWPOLYLINE-685" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="330.67" y1="934.06" x2="335.15" y2="932.46"/>
+  </g>
+  <g id="LWPOLYLINE-686" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="371.33" y1="920.62" x2="381.9" y2="917.1"/>
+  </g>
+  <g id="LWPOLYLINE-687" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="418.08" y1="905.25" x2="438.88" y2="898.21"/>
+  </g>
+  <g id="LWPOLYLINE-688" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="170.91" y1="862.99" x2="185.64" y2="864.59"/>
+  </g>
+  <g id="LWPOLYLINE-689" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="397.27 878.04 379.97 911.97 381.9 912.94 398.87 879"/>
+  </g>
+  <g id="LWPOLYLINE-690" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="396.31 877.4 400.14 879.64 403.99 882.2 407.19 885.08 410.07 888.28 412.63 892.12 414.88 895.97 416.47 900.13"/>
+  </g>
+  <g id="LWPOLYLINE-691" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="438.89 817.21 438.89 955.84 446.57 955.84"/>
+  </g>
+  <g id="LWPOLYLINE-692" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="443.05 815.93 443.05 951.35 446.57 951.35"/>
+  </g>
+  <g id="LWPOLYLINE-693" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="486.27" y1="955.84" x2="800.35" y2="955.84"/>
+  </g>
+  <g id="LWPOLYLINE-694" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="486.27" y1="951.35" x2="795.87" y2="951.35"/>
+  </g>
+  <g id="LWPOLYLINE-695" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="590.96" y1="767.26" x2="601.53" y2="767.26"/>
+  </g>
+  <g id="LWPOLYLINE-696" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="639.63 763.1 639.63 767.26 643.47 767.26"/>
+  </g>
+  <g id="LWPOLYLINE-697" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="598.33" y1="763.1" x2="601.53" y2="763.1"/>
+  </g>
+  <g id="LWPOLYLINE-698" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="639.63" y1="763.1" x2="642.19" y2="763.1"/>
+  </g>
+  <g id="LWPOLYLINE-699" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="303.78 1200.44 303.78 1215.16 312.11 1215.16"/>
+  </g>
+  <g id="LWPOLYLINE-700" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="319.79 1200.44 318.5 1201.08 317.23 1202.68 316.26 1203.96 315.62 1206.2 315.62 1209.72 316.26 1211.64 317.23 1213.24 318.5 1214.53 319.79 1215.16 322.67 1215.16 324.27 1214.53 325.54 1213.24 326.19 1211.64 326.83 1209.72 326.83 1206.2 326.19 1203.96 325.54 1202.68 324.27 1201.08 322.67 1200.44 319.79 1200.44"/>
+  </g>
+  <g id="LWPOLYLINE-701" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="337.72 1207.48 339.64 1208.12 340.27 1208.76 341.24 1210.36 341.24 1212.6 340.27 1213.89 339.64 1214.53 337.72 1215.17 331.31 1215.17 331.31 1200.44 337.72 1200.44 339.64 1201.08 340.27 1201.72 341.24 1203.32 341.24 1204.6 340.27 1206.2 339.64 1206.84 337.72 1207.48 331.31 1207.48"/>
+  </g>
+  <g id="LWPOLYLINE-702" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="352.44 1207.48 354.69 1208.12 355.33 1208.76 355.97 1210.36 355.97 1212.6 355.33 1213.89 354.69 1214.53 352.44 1215.17 346.04 1215.17 346.04 1200.44 352.44 1200.44 354.69 1201.08 355.33 1201.72 355.97 1203.32 355.97 1204.6 355.33 1206.2 354.69 1206.84 352.44 1207.48 346.04 1207.48"/>
+  </g>
+  <g id="LWPOLYLINE-703" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="360.77 1200.44 366.53 1207.49 372.29 1200.44"/>
+  </g>
+  <g id="LWPOLYLINE-704" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="366.53" y1="1207.48" x2="366.53" y2="1215.17"/>
+  </g>
+  <g id="LWPOLYLINE-705" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="411.99 1108.87 438.88 1136.09 440.16 1134.49 413.27 1107.59"/>
+  </g>
+  <g id="LWPOLYLINE-706" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="411.03 1109.83 414.23 1106.63 418.08 1104.07 421.92 1101.83 425.76 1100.23 430.24 1098.95 434.4 1097.99 438.89 1097.67"/>
+  </g>
+  <g id="LWPOLYLINE-707" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="795.87" y1="947.83" x2="800.35" y2="947.83"/>
+  </g>
+  <g id="LWPOLYLINE-708" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="768.97 920.62 795.86 947.83 797.47 946.55 770.25 919.34"/>
+  </g>
+  <g id="LWPOLYLINE-709" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="768.33 921.58 771.53 918.38 775.05 915.82 778.9 913.58 783.06 911.98 787.22 910.69 791.7 909.74 795.87 909.74"/>
+  </g>
+  <g id="LWPOLYLINE-710" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="388.62" y1="1272.8" x2="565.99" y2="1272.8"/>
+  </g>
+  <g id="LWPOLYLINE-711" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="388.62" y="1263.83" width="1.28" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-712" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="391.82" y1="1265.11" x2="475.38" y2="1265.11"/>
+  </g>
+  <g id="LWPOLYLINE-713" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="391.82" y1="1264.15" x2="475.38" y2="1264.15"/>
+  </g>
+  <g id="LWPOLYLINE-714" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="389.9" y="1263.83" width="1.92" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-715" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="475.39" y="1259.03" width="3.84" height="6.41"/>
+  </g>
+  <g id="LWPOLYLINE-716" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="388.62" y1="1259.03" x2="565.99" y2="1259.03"/>
+  </g>
+  <g id="LWPOLYLINE-717" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="384.46" y1="1231.5" x2="389.9" y2="1231.5"/>
+  </g>
+  <g id="LWPOLYLINE-718" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="374.85" y1="1165.22" x2="380.3" y2="1165.22"/>
+  </g>
+  <g id="LWPOLYLINE-719" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="384.46" y1="1165.22" x2="389.9" y2="1165.22"/>
+  </g>
+  <g id="LWPOLYLINE-720" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="564.71" y="1263.83" width="1.28" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-721" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="562.79" y1="1265.11" x2="479.23" y2="1265.11"/>
+  </g>
+  <g id="LWPOLYLINE-722" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="562.79" y1="1264.15" x2="479.23" y2="1264.15"/>
+  </g>
+  <g id="LWPOLYLINE-723" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="562.79" y="1263.83" width="1.92" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-724" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1653.26" y1="524.26" x2="1653.26" y2="347.53"/>
+  </g>
+  <g id="LWPOLYLINE-725" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1657.42" y1="528.74" x2="1657.42" y2="346.25"/>
+  </g>
+  <g id="LWPOLYLINE-726" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1603.96 497.36 1631.17 524.25 1629.57 525.86 1602.68 498.97"/>
+  </g>
+  <g id="LWPOLYLINE-727" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1604.92 496.72 1601.71 499.93 1599.16 503.45 1596.91 507.29 1595.31 511.45 1594.03 515.61 1593.07 520.1 1592.75 524.26"/>
+  </g>
+  <g id="LWPOLYLINE-728" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1944.29 445.5 1944.29 477.83 1933.08 477.83"/>
+  </g>
+  <g id="LWPOLYLINE-729" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1882.18 473.67 1882.18 477.83 1874.49 477.83"/>
+  </g>
+  <g id="LWPOLYLINE-730" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1855.6" y1="477.83" x2="1836.71" y2="477.83"/>
+  </g>
+  <g id="LWPOLYLINE-731" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1798.61" y1="477.83" x2="1658.38" y2="477.83"/>
+  </g>
+  <g id="LWPOLYLINE-732" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1939.8 449.66 1939.8 473.67 1933.08 473.67"/>
+  </g>
+  <g id="LWPOLYLINE-733" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1939.8" y1="449.66" x2="1865.53" y2="449.66"/>
+  </g>
+  <g id="LWPOLYLINE-734" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1944.29" y1="445.5" x2="1865.52" y2="445.5"/>
+  </g>
+  <g id="LWPOLYLINE-735" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1882.18" y1="473.67" x2="1874.17" y2="473.67"/>
+  </g>
+  <g id="LWPOLYLINE-736" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1856.24" y1="473.67" x2="1836.71" y2="473.67"/>
+  </g>
+  <g id="LWPOLYLINE-737" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1797.01" y1="473.67" x2="1659.02" y2="473.67"/>
+  </g>
+  <g id="LWPOLYLINE-738" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1865.53" y1="467.27" x2="1865.53" y2="277.73"/>
+  </g>
+  <g id="LWPOLYLINE-739" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1861.37" y1="467.91" x2="1861.37" y2="279.02"/>
+  </g>
+  <g id="LWPOLYLINE-740" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1836.71" y1="477.83" x2="1836.71" y2="473.67"/>
+  </g>
+  <g id="LWPOLYLINE-741" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1809.82 446.46 1836.71 473.67 1835.43 474.95 1808.54 448.06"/>
+  </g>
+  <g id="LWPOLYLINE-742" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1810.46 445.82 1807.58 449.02 1805.01 452.54 1802.78 456.39 1800.85 460.55 1799.57 464.7 1798.93 469.19 1798.62 473.67"/>
+  </g>
+  <g id="LWPOLYLINE-743" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2016" y1="214.02" x2="1862.96" y2="264.29"/>
+  </g>
+  <g id="LWPOLYLINE-744" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2020.49" y1="226.83" x2="1867.13" y2="277.41"/>
+  </g>
+  <g id="LWPOLYLINE-745" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1984.31" y1="387.87" x2="1940.12" y2="253.4"/>
+  </g>
+  <g id="LWPOLYLINE-746" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1990.07" y1="373.14" x2="1949.73" y2="250.2"/>
+  </g>
+  <g id="LWPOLYLINE-747" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1987.19" y1="378.58" x2="1945.57" y2="251.48"/>
+  </g>
+  <g id="LWPOLYLINE-748" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2030.73" y1="257.24" x2="2020.48" y2="226.83"/>
+  </g>
+  <g id="LWPOLYLINE-749" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2030.73 257.24 2034.57 255.96 2024.65 225.55"/>
+  </g>
+  <g id="LWPOLYLINE-750" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2105.01 232.59 2101.17 233.87 2091.25 203.78"/>
+  </g>
+  <g id="LWPOLYLINE-751" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2104.37 199.3 2101.81 222.67 2095.08 202.17"/>
+  </g>
+  <g id="LWPOLYLINE-752" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1900.1 495.76 1882.17 477.84 1883.14 476.87 1901.06 494.8"/>
+  </g>
+  <g id="LWPOLYLINE-753" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1899.46 496.4 1901.71 494.16 1903.3 491.6 1904.91 489.04 1905.87 486.48 1906.83 483.6 1907.47 480.72 1907.47 477.83"/>
+  </g>
+  <g id="LWPOLYLINE-754" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1915.15 495.76 1933.08 477.84 1932.12 476.87 1914.19 494.8"/>
+  </g>
+  <g id="LWPOLYLINE-755" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1915.47 496.4 1913.55 494.16 1911.63 491.6 1910.35 489.04 1909.07 486.48 1908.11 483.6 1907.79 480.72 1907.47 477.83"/>
+  </g>
+  <g id="LWPOLYLINE-756" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2186.33" y1="349.13" x2="2180.25" y2="404.52"/>
+  </g>
+  <g id="LWPOLYLINE-757" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2190.49" y1="349.45" x2="2184.41" y2="405.16"/>
+  </g>
+  <g id="LWPOLYLINE-758" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2227.31 353.61 2105.33 339.85 2072.03 350.73"/>
+  </g>
+  <g id="LWPOLYLINE-759" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2097.64 342.4 2098.93 345.93 2095.09 346.89"/>
+  </g>
+  <g id="LWPOLYLINE-760" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2106.93" y1="369.94" x2="2103.09" y2="371.22"/>
+  </g>
+  <g id="LWPOLYLINE-761" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2035.53" y1="362.57" x2="1987.19" y2="378.58"/>
+  </g>
+  <g id="LWPOLYLINE-762" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2223.79 348.81 2105.01 335.36 2070.75 346.56"/>
+  </g>
+  <g id="LWPOLYLINE-763" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2092.52" y1="207.62" x2="2025.93" y2="229.39"/>
+  </g>
+  <g id="LWPOLYLINE-764" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2035.53 362.57 2034.25 358.73 1990.07 373.14"/>
+  </g>
+  <g id="LWPOLYLINE-765" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2070.75" y1="346.57" x2="2072.03" y2="350.73"/>
+  </g>
+  <g id="LWPOLYLINE-766" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2049.62" y1="500.57" x2="1988.79" y2="500.57"/>
+  </g>
+  <g id="LWPOLYLINE-767" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2053.46" y1="504.73" x2="1988.79" y2="504.73"/>
+  </g>
+  <g id="LWPOLYLINE-768" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2195.29" y1="685.94" x2="2031.37" y2="685.94"/>
+  </g>
+  <g id="LWPOLYLINE-769" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1993.27" y1="685.94" x2="1988.79" y2="685.94"/>
+  </g>
+  <g id="LWPOLYLINE-770" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2194.65" y1="690.1" x2="2031.37" y2="690.1"/>
+  </g>
+  <g id="LWPOLYLINE-771" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2191.77" y1="716.68" x2="2174.8" y2="716.68"/>
+  </g>
+  <g id="LWPOLYLINE-772" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2192.09" y1="712.51" x2="2178.96" y2="712.51"/>
+  </g>
+  <g id="LWPOLYLINE-773" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1993.27 685.94 1993.27 690.1 1984.31 690.1"/>
+  </g>
+  <g id="LWPOLYLINE-774" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1944.29" y1="474.95" x2="1945.25" y2="474.95"/>
+  </g>
+  <g id="LWPOLYLINE-775" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1983.35 470.79 1983.35 474.95 1984.31 474.95"/>
+  </g>
+  <g id="LWPOLYLINE-776" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1984.31 387.87 1984.31 508.89 1988.79 508.89"/>
+  </g>
+  <g id="LWPOLYLINE-777" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1984.31" y1="547.31" x2="1988.79" y2="547.31"/>
+  </g>
+  <g id="LWPOLYLINE-778" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1944.29" y1="470.79" x2="1945.25" y2="470.79"/>
+  </g>
+  <g id="LWPOLYLINE-779" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1983.35" y1="470.79" x2="1984.31" y2="470.79"/>
+  </g>
+  <g id="LWPOLYLINE-780" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2179.92" y1="820.09" x2="2028.49" y2="820.09"/>
+  </g>
+  <g id="LWPOLYLINE-781" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.92 882.84 2178.65 824.25 2032.65 824.25"/>
+  </g>
+  <g id="LWPOLYLINE-782" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2145.67" y1="1122.96" x2="2032.65" y2="1122.96"/>
+  </g>
+  <g id="LWPOLYLINE-783" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.78" y1="722.12" x2="2041.62" y2="722.12"/>
+  </g>
+  <g id="LWPOLYLINE-784" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2045.78 820.09 2045.78 772.7 2041.62 772.7"/>
+  </g>
+  <g id="LWPOLYLINE-785" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1984.31" y1="690.1" x2="1984.31" y2="547.31"/>
+  </g>
+  <g id="LWPOLYLINE-786" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.79" y1="685.94" x2="1988.79" y2="547.31"/>
+  </g>
+  <g id="LWPOLYLINE-787" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2031.37" y1="690.1" x2="2031.37" y2="685.94"/>
+  </g>
+  <g id="LWPOLYLINE-788" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2002.24 419.25 1988.47 418.28 1988.47 385.95"/>
+  </g>
+  <g id="LWPOLYLINE-789" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.79" y1="508.89" x2="1988.79" y2="424.68"/>
+  </g>
+  <g id="LWPOLYLINE-790" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1933.08" y1="477.83" x2="1933.08" y2="473.67"/>
+  </g>
+  <g id="LWPOLYLINE-791" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1945.25" y1="474.95" x2="1945.25" y2="470.79"/>
+  </g>
+  <g id="LWPOLYLINE-792" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2020.17 658.73 1993.27 685.94 1994.55 687.22 2021.45 660.33"/>
+  </g>
+  <g id="LWPOLYLINE-793" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2019.21 658.09 2022.4 661.28 2024.97 664.81 2027.21 668.66 2029.13 672.81 2030.41 676.97 2031.05 681.46 2031.37 685.94"/>
+  </g>
+  <g id="LWPOLYLINE-794" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2054.42 494.17 2050.26 493.84 2049.62 500.57"/>
+  </g>
+  <g id="LWPOLYLINE-795" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2062.43" y1="424.05" x2="2058.91" y2="456.38"/>
+  </g>
+  <g id="LWPOLYLINE-796" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2057.62" y1="430.13" x2="2056.35" y2="441.33"/>
+  </g>
+  <g id="LWPOLYLINE-797" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2055.7" y1="446.46" x2="2054.74" y2="455.74"/>
+  </g>
+  <g id="LWPOLYLINE-798" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2054.42" y1="494.16" x2="2053.46" y2="504.73"/>
+  </g>
+  <g id="LWPOLYLINE-799" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2054.74" y1="455.74" x2="2058.91" y2="456.38"/>
+  </g>
+  <g id="LWPOLYLINE-800" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1989.44 377.94 2006.72 419.89 2062.43 424.05"/>
+  </g>
+  <g id="LWPOLYLINE-801" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2082.6 486.16 2058.9 456.38 2057.3 457.66 2080.99 487.44"/>
+  </g>
+  <g id="LWPOLYLINE-802" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2083.56 485.52 2080.04 488.08 2076.19 490.32 2072.03 492.24 2067.87 493.52 2063.39 494.16 2058.91 494.48 2054.42 494.16"/>
+  </g>
+  <g id="LWPOLYLINE-803" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2041.62" y1="690.1" x2="2041.62" y2="722.12"/>
+  </g>
+  <g id="LWPOLYLINE-804" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2041.62" y1="772.7" x2="2041.62" y2="820.09"/>
+  </g>
+  <g id="LWPOLYLINE-805" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.78" y1="690.1" x2="2045.78" y2="722.12"/>
+  </g>
+  <g id="LWPOLYLINE-806" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2174.8" y1="690.1" x2="2174.8" y2="716.68"/>
+  </g>
+  <g id="LWPOLYLINE-807" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2178.97" y1="690.1" x2="2178.97" y2="712.51"/>
+  </g>
+  <g id="LWPOLYLINE-808" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2145.35" y="788.39" width="31.7" height="29.46"/>
+  </g>
+  <g id="LWPOLYLINE-809" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2146.31" y="789.35" width="29.78" height="27.53"/>
+  </g>
+  <g id="LWPOLYLINE-810" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2028.49" y1="820.09" x2="2028.49" y2="839.62"/>
+  </g>
+  <g id="LWPOLYLINE-811" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2028.49" y1="879.64" x2="2028.49" y2="1068.22"/>
+  </g>
+  <g id="LWPOLYLINE-812" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2032.65" y1="824.25" x2="2032.65" y2="839.62"/>
+  </g>
+  <g id="LWPOLYLINE-813" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2032.65" y1="879.64" x2="2032.65" y2="1068.22"/>
+  </g>
+  <g id="LWPOLYLINE-814" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2032.65" y1="1107.91" x2="2032.65" y2="1122.96"/>
+  </g>
+  <g id="LWPOLYLINE-815" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1851.12" y1="1272.8" x2="1673.11" y2="1272.8"/>
+  </g>
+  <g id="LWPOLYLINE-816" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1850.16" y="1263.19" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-817" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1848.24" y1="1264.79" x2="1764.03" y2="1264.79"/>
+  </g>
+  <g id="LWPOLYLINE-818" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1848.24" y1="1263.51" x2="1764.03" y2="1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-819" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1848.24" y="1263.19" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-820" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1673.11" y="1263.19" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-821" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1674.07" y="1263.19" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-822" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1676.31" y1="1264.79" x2="1760.19" y2="1264.79"/>
+  </g>
+  <g id="LWPOLYLINE-823" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1676.31" y1="1263.51" x2="1760.19" y2="1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-824" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2028.49" y1="839.62" x2="2032.65" y2="839.62"/>
+  </g>
+  <g id="LWPOLYLINE-825" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2059.54 866.83 2032.65 839.62 2031.37 841.22 2058.27 868.11"/>
+  </g>
+  <g id="LWPOLYLINE-826" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2060.51 865.87 2057.3 869.07 2053.78 871.63 2049.94 873.87 2045.78 875.48 2041.62 876.75 2037.14 877.71 2032.65 878.04"/>
+  </g>
+  <g id="LWPOLYLINE-827" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="774.1" y1="622.23" x2="617.86" y2="673.77"/>
+  </g>
+  <g id="LWPOLYLINE-828" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="776.34 628.95 776.66 630.55 775.7 630.87 775.37 629.27 776.34 628.95"/>
+  </g>
+  <g id="LWPOLYLINE-829" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="773.46" y1="630.23" x2="700.14" y2="654.24"/>
+  </g>
+  <g id="LWPOLYLINE-830" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="773.78" y1="631.19" x2="700.45" y2="655.52"/>
+  </g>
+  <g id="LWPOLYLINE-831" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="775.38 629.27 775.7 630.88 773.78 631.51 773.13 629.91 775.38 629.27"/>
+  </g>
+  <g id="LWPOLYLINE-832" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="620.39" y="679.96" width="1.01" height="2.03" transform="translate(-182.8 230.08) rotate(-18.35)"/>
+  </g>
+  <g id="LWPOLYLINE-833" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="621.33" y="679.48" width="2.03" height="2.03" transform="translate(-182.58 230.51) rotate(-18.35)"/>
+  </g>
+  <g id="LWPOLYLINE-834" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="699.82 653.92 702.06 660.33 698.54 661.61 696.29 655.2 699.82 653.92"/>
+  </g>
+  <g id="LWPOLYLINE-835" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="623.3" y1="679.54" x2="696.62" y2="655.53"/>
+  </g>
+  <g id="LWPOLYLINE-836" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="623.62" y1="680.5" x2="696.94" y2="656.49"/>
+  </g>
+  <g id="LWPOLYLINE-837" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="703.02" y="1254.54" width="3.84" height="6.41"/>
+  </g>
+  <g id="LWPOLYLINE-838" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="808.67" y1="1250.71" x2="808.67" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-839" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="910.48" y="1254.54" width="3.53" height="6.41"/>
+  </g>
+  <g id="LWPOLYLINE-840" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1038.87" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-841" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1042.07" y1="1260.31" x2="1117.63" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-842" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1042.07" y1="1259.35" x2="1117.63" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-843" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1039.83" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-844" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1199.27" y="1259.03" width="1.28" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-845" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1197.35" y="1259.03" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-846" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1197.35" y1="1260.31" x2="1121.47" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-847" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1197.35" y1="1259.35" x2="1121.47" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-848" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1038.87" y1="1254.55" x2="1200.55" y2="1254.55"/>
+  </g>
+  <g id="LWPOLYLINE-849" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1117.63" y="1254.54" width="3.84" height="6.41"/>
+  </g>
+  <g id="LWPOLYLINE-850" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1406.73" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-851" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1404.49" y1="1260.31" x2="1328.62" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-852" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1404.49" y1="1259.35" x2="1328.62" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-853" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1404.49" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-854" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1246.01" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-855" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1246.97" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-856" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.22" y1="1260.31" x2="1325.09" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-857" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.22" y1="1259.35" x2="1325.09" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-858" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1407.7" y1="1254.55" x2="1246.02" y2="1254.55"/>
+  </g>
+  <g id="LWPOLYLINE-859" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1325.09" y="1254.54" width="3.53" height="6.41"/>
+  </g>
+  <g id="LWPOLYLINE-860" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1453.48" y="1259.03" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-861" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1456.68" y1="1260.31" x2="1532.23" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-862" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1456.68" y1="1259.35" x2="1532.23" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-863" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1454.44" y="1259.03" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-864" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1613.88" y="1259.03" width="1.28" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-865" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1611.96" y="1259.03" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-866" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1611.96" y1="1260.31" x2="1536.08" y2="1260.31"/>
+  </g>
+  <g id="LWPOLYLINE-867" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1611.96" y1="1259.35" x2="1536.08" y2="1259.35"/>
+  </g>
+  <g id="LWPOLYLINE-868" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1453.48" y1="1254.55" x2="1615.16" y2="1254.55"/>
+  </g>
+  <g id="LWPOLYLINE-869" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1532.24" y="1254.54" width="3.84" height="6.41"/>
+  </g>
+  <g id="LWPOLYLINE-870" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1851.12" y1="1259.03" x2="1673.11" y2="1259.03"/>
+  </g>
+  <g id="LWPOLYLINE-871" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1426.27 1245.58 1426.27 1250.71 1419.22 1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-872" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1416.02" y1="1250.71" x2="1409.61" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-873" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1406.42" y1="1250.71" x2="1400.02" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-874" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1396.81" y1="1250.71" x2="1390.4" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-875" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1387.2" y1="1250.71" x2="1381.12" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-876" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1377.92" y1="1250.71" x2="1371.51" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-877" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1368.32" y1="1250.71" x2="1361.91" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-878" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1358.71" y1="1250.71" x2="1352.31" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-879" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1349.11" y1="1250.71" x2="1342.7" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-880" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1339.5" y1="1250.71" x2="1333.42" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-881" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1330.22" y1="1250.71" x2="1323.81" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-882" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1320.61" y1="1250.71" x2="1314.21" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-883" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.01" y1="1250.71" x2="1304.6" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-884" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1301.4" y1="1250.71" x2="1295" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-885" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1291.8" y1="1250.71" x2="1285.71" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-886" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1282.51" y1="1250.71" x2="1276.11" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-887" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1272.91" y1="1250.71" x2="1266.5" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-888" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1263.3" y1="1250.71" x2="1256.9" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-889" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1253.7" y1="1250.71" x2="1247.29" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-890" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1244.09" y1="1250.71" x2="1237.69" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-891" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1234.81" y1="1250.71" x2="1227.44" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-892" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1426.27" y1="1245.58" x2="1419.22" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-893" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1416.02" y1="1245.58" x2="1409.61" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-894" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1406.42" y1="1245.58" x2="1400.02" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-895" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1396.81" y1="1245.58" x2="1390.4" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-896" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1387.2" y1="1245.58" x2="1381.12" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-897" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1377.92" y1="1245.58" x2="1371.51" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-898" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1368.32" y1="1245.58" x2="1361.91" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-899" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1358.71" y1="1245.58" x2="1352.31" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-900" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1349.11" y1="1245.58" x2="1342.7" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-901" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1339.5" y1="1245.58" x2="1333.42" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-902" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1330.22" y1="1245.58" x2="1323.81" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-903" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1320.61" y1="1245.58" x2="1314.21" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-904" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.01" y1="1245.58" x2="1304.6" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-905" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1301.4" y1="1245.58" x2="1295" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-906" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1291.8" y1="1245.58" x2="1285.71" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-907" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1282.51" y1="1245.58" x2="1276.11" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-908" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1272.91" y1="1245.58" x2="1266.5" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-909" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1263.3" y1="1245.58" x2="1256.9" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-910" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1253.7" y1="1245.58" x2="1247.29" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-911" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1244.09" y1="1245.58" x2="1237.69" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-912" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1234.81" y1="1245.58" x2="1227.44" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-913" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1227.44" y1="1250.71" x2="1227.44" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-914" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1434.91 1245.58 1434.91 1250.71 1441.96 1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-915" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1445.16" y1="1250.71" x2="1451.55" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-916" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1454.76" y1="1250.71" x2="1461.17" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-917" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1464.37" y1="1250.71" x2="1470.45" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-918" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1473.65" y1="1250.71" x2="1480.06" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-919" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1483.25" y1="1250.71" x2="1489.66" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-920" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1492.86" y1="1250.71" x2="1499.26" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-921" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1502.46" y1="1250.71" x2="1508.87" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-922" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1512.07" y1="1250.71" x2="1518.15" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-923" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1521.35" y1="1250.71" x2="1527.76" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-924" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1530.96" y1="1250.71" x2="1537.36" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-925" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1540.56" y1="1250.71" x2="1546.97" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-926" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1550.17" y1="1250.71" x2="1556.57" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-927" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1559.77" y1="1250.71" x2="1566.17" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-928" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1569.06" y1="1250.71" x2="1575.46" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-929" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1578.66" y1="1250.71" x2="1585.06" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-930" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1588.27" y1="1250.71" x2="1594.67" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-931" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1597.87" y1="1250.71" x2="1604.27" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-932" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1607.48" y1="1250.71" x2="1613.88" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-933" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1616.76" y1="1250.71" x2="1623.17" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-934" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1626.37" y1="1250.71" x2="1633.73" y2="1250.71"/>
+  </g>
+  <g id="LWPOLYLINE-935" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1434.91" y1="1245.58" x2="1441.96" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-936" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1445.16" y1="1245.58" x2="1451.55" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-937" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1454.76" y1="1245.58" x2="1461.17" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-938" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1464.37" y1="1245.58" x2="1470.45" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-939" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1473.65" y1="1245.58" x2="1480.06" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-940" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1483.25" y1="1245.58" x2="1489.66" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-941" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1492.86" y1="1245.58" x2="1499.26" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-942" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1502.46" y1="1245.58" x2="1508.87" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-943" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1512.07" y1="1245.58" x2="1518.15" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-944" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1521.35" y1="1245.58" x2="1527.76" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-945" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1530.96" y1="1245.58" x2="1537.36" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-946" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1540.56" y1="1245.58" x2="1546.97" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-947" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1550.17" y1="1245.58" x2="1556.57" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-948" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1559.77" y1="1245.58" x2="1566.17" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-949" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1569.06" y1="1245.58" x2="1575.46" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-950" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1578.66" y1="1245.58" x2="1585.06" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-951" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1588.27" y1="1245.58" x2="1594.67" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-952" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1597.87" y1="1245.58" x2="1604.27" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-953" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1607.48" y1="1245.58" x2="1613.88" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-954" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1616.76" y1="1245.58" x2="1623.17" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-955" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1626.37" y1="1245.58" x2="1633.73" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-956" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1633.73" y1="1250.71" x2="1633.73" y2="1245.58"/>
+  </g>
+  <g id="LWPOLYLINE-957" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1760.19" y="1259.03" width="3.84" height="6.08"/>
+  </g>
+  <g id="LWPOLYLINE-958" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1905.23" y="1263.19" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-959" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1908.11" y1="1264.79" x2="1992.31" y2="1264.79"/>
+  </g>
+  <g id="LWPOLYLINE-960" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1908.11" y1="1263.51" x2="1992.31" y2="1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-961" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1906.19" y="1263.19" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-962" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2082.28" y="1263.19" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-963" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2080.03" y="1263.19" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-964" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.04" y1="1264.79" x2="1996.15" y2="1264.79"/>
+  </g>
+  <g id="LWPOLYLINE-965" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.04" y1="1263.51" x2="1996.15" y2="1263.51"/>
+  </g>
+  <g id="LWPOLYLINE-966" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1905.23" y1="1259.03" x2="2083.24" y2="1259.03"/>
+  </g>
+  <g id="LWPOLYLINE-967" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1992.31" y="1259.03" width="3.84" height="6.08"/>
+  </g>
+  <g id="LWPOLYLINE-968" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="643.47" y1="951.35" x2="643.47" y2="766.3"/>
+  </g>
+  <g id="LWPOLYLINE-969" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="601.53" y1="767.26" x2="601.53" y2="763.1"/>
+  </g>
+  <g id="LWPOLYLINE-970" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="647.63" y1="951.35" x2="647.63" y2="765.66"/>
+  </g>
+  <g id="LWPOLYLINE-971" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="189.8" y1="1096.71" x2="144.97" y2="1091.59"/>
+  </g>
+  <g id="LWPOLYLINE-972" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="191.08" y1="1085.18" x2="146.26" y2="1080.06"/>
+  </g>
+  <g id="LWPOLYLINE-973" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="192.36" y1="1073.34" x2="147.54" y2="1068.53"/>
+  </g>
+  <g id="LWPOLYLINE-974" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="193.64" y1="1061.81" x2="148.82" y2="1056.69"/>
+  </g>
+  <g id="LWPOLYLINE-975" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="194.92" y1="1050.28" x2="150.1" y2="1045.16"/>
+  </g>
+  <g id="LWPOLYLINE-976" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="196.2" y1="1038.76" x2="151.7" y2="1033.64"/>
+  </g>
+  <g id="LWPOLYLINE-977" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="197.48" y1="1027.23" x2="152.98" y2="1022.11"/>
+  </g>
+  <g id="LWPOLYLINE-978" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="205.49" y1="957.44" x2="160.66" y2="952.64"/>
+  </g>
+  <g id="LWPOLYLINE-979" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="204.21" y1="969.28" x2="159.38" y2="964.16"/>
+  </g>
+  <g id="LWPOLYLINE-980" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="202.93" y1="980.81" x2="158.1" y2="975.69"/>
+  </g>
+  <g id="LWPOLYLINE-981" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.65" y1="992.33" x2="156.82" y2="987.21"/>
+  </g>
+  <g id="LWPOLYLINE-982" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="200.37" y1="1003.86" x2="155.54" y2="998.74"/>
+  </g>
+  <g id="LWPOLYLINE-983" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="198.77" y1="1015.39" x2="154.26" y2="1010.58"/>
+  </g>
+  <g id="LWPOLYLINE-984" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.77" y1="945.91" x2="162.27" y2="940.79"/>
+  </g>
+  <g id="LWPOLYLINE-985" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="191.08 885.08 167.39 1094.14 161.3 1085.83"/>
+  </g>
+  <g id="LWPOLYLINE-986" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="167.39" y1="1094.15" x2="175.39" y2="1088.06"/>
+  </g>
+  <g id="LWPOLYLINE-987" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="230.46" y1="877.08" x2="211.25" y2="907.17"/>
+  </g>
+  <g id="LWPOLYLINE-988" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="351.48" y1="828.41" x2="354.36" y2="836.74"/>
+  </g>
+  <g id="LWPOLYLINE-989" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="438.89" y1="955.84" x2="438.89" y2="1097.67"/>
+  </g>
+  <g id="LWPOLYLINE-990" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="438.89 938.87 431.84 938.87 431.84 948.15"/>
+  </g>
+  <g id="LWPOLYLINE-991" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="431.84" y1="957.76" x2="431.84" y2="967.04"/>
+  </g>
+  <g id="LWPOLYLINE-992" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="443.05 1136.09 438.89 1136.09 438.89 1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-993" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="343.48" y1="830.97" x2="328.75" y2="786.79"/>
+  </g>
+  <g id="LWPOLYLINE-994" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="332.27" y1="834.49" x2="317.55" y2="790.31"/>
+  </g>
+  <g id="LWPOLYLINE-995" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="321.07" y1="838.34" x2="306.66" y2="793.84"/>
+  </g>
+  <g id="LWPOLYLINE-996" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="310.18" y1="841.86" x2="295.46" y2="797.68"/>
+  </g>
+  <g id="LWPOLYLINE-997" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="298.98" y1="845.7" x2="284.57" y2="801.2"/>
+  </g>
+  <g id="LWPOLYLINE-998" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="288.09" y1="849.22" x2="273.37" y2="805.04"/>
+  </g>
+  <g id="LWPOLYLINE-999" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="276.88" y1="852.74" x2="262.16" y2="808.56"/>
+  </g>
+  <g id="LWPOLYLINE-1000" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="265.68" y1="856.59" x2="251.27" y2="812.4"/>
+  </g>
+  <g id="LWPOLYLINE-1001" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="254.79" y1="860.11" x2="240.07" y2="815.92"/>
+  </g>
+  <g id="LWPOLYLINE-1002" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="243.59" y1="863.95" x2="229.18" y2="819.45"/>
+  </g>
+  <g id="LWPOLYLINE-1003" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="233.34" y1="869.71" x2="217.98" y2="823.29"/>
+  </g>
+  <g id="LWPOLYLINE-1004" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="225.66" y1="884.12" x2="206.77" y2="826.81"/>
+  </g>
+  <g id="LWPOLYLINE-1005" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="229.18" y1="876.12" x2="230.46" y2="877.08"/>
+  </g>
+  <g id="LWPOLYLINE-1006" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="336.11 808.88 214.13 848.9 191.08 885.08"/>
+  </g>
+  <g id="LWPOLYLINE-1007" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="395.34" y1="826.17" x2="376.77" y2="770.78"/>
+  </g>
+  <g id="LWPOLYLINE-1008" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="405.27" y1="822.97" x2="387.02" y2="767.58"/>
+  </g>
+  <g id="LWPOLYLINE-1009" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.19" y1="819.45" x2="396.95" y2="764.06"/>
+  </g>
+  <g id="LWPOLYLINE-1010" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="425.44" y1="816.24" x2="407.19" y2="760.86"/>
+  </g>
+  <g id="LWPOLYLINE-1011" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="435.36" y1="813.04" x2="417.11" y2="757.33"/>
+  </g>
+  <g id="LWPOLYLINE-1012" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="445.61" y1="809.52" x2="427.36" y2="754.14"/>
+  </g>
+  <g id="LWPOLYLINE-1013" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="455.53" y1="806.32" x2="437.28" y2="750.93"/>
+  </g>
+  <g id="LWPOLYLINE-1014" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="465.78" y1="802.8" x2="447.53" y2="747.41"/>
+  </g>
+  <g id="LWPOLYLINE-1015" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="475.71" y1="799.6" x2="466.1" y2="770.46"/>
+  </g>
+  <g id="LWPOLYLINE-1016" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="464.82" y1="766.94" x2="464.18" y2="764.06"/>
+  </g>
+  <g id="LWPOLYLINE-1017" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="388.3 798.64 387.66 797.03 386.06 796.39 384.46 797.03 383.82 798.64 384.46 799.91 386.06 800.56 387.66 799.91 388.3 798.64"/>
+  </g>
+  <g id="LWPOLYLINE-1018" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="386.06 798.64 456.49 775.27 452.02 784.23"/>
+  </g>
+  <g id="LWPOLYLINE-1019" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="456.5" y1="775.27" x2="447.53" y2="770.78"/>
+  </g>
+  <g id="LWPOLYLINE-1020" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="486.59 796.08 471.22 774.31 473.46 769.82 463.22 770.46 465.46 765.98 451.37 746.13"/>
+  </g>
+  <g id="LWPOLYLINE-1021" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="795.87" y="908.13" width="4.48" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1022" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="798.11" y1="908.13" x2="798.11" y2="845.06"/>
+  </g>
+  <g id="LWPOLYLINE-1023" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="798.43" y1="908.13" x2="798.43" y2="845.06"/>
+  </g>
+  <g id="LWPOLYLINE-1024" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="795.87" y="843.46" width="4.48" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1025" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="795.87" y="779.1" width="4.48" height="1.61"/>
+  </g>
+  <g id="LWPOLYLINE-1026" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="798.11" y1="780.71" x2="798.11" y2="843.46"/>
+  </g>
+  <g id="LWPOLYLINE-1027" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="798.43" y1="780.71" x2="798.43" y2="843.46"/>
+  </g>
+  <g id="LWPOLYLINE-1028" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="963.63" y="724.68" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1029" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="963.63" y1="726.92" x2="898.96" y2="726.92"/>
+  </g>
+  <g id="LWPOLYLINE-1030" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="963.63" y1="726.6" x2="898.96" y2="726.6"/>
+  </g>
+  <g id="LWPOLYLINE-1031" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="897.36" y="724.68" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1032" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="831.08" y="724.68" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1033" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="832.69" y1="726.92" x2="897.36" y2="726.92"/>
+  </g>
+  <g id="LWPOLYLINE-1034" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="832.69" y1="726.6" x2="897.36" y2="726.6"/>
+  </g>
+  <g id="LWPOLYLINE-1035" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1383.04" y="601.1" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1036" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1383.04" y1="603.34" x2="1318.37" y2="603.34"/>
+  </g>
+  <g id="LWPOLYLINE-1037" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1383.04" y1="603.02" x2="1318.37" y2="603.02"/>
+  </g>
+  <g id="LWPOLYLINE-1038" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1316.77" y="601.1" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1039" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1250.5" y="601.1" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1040" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1252.1" y1="603.34" x2="1316.77" y2="603.34"/>
+  </g>
+  <g id="LWPOLYLINE-1041" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1252.1" y1="603.02" x2="1316.77" y2="603.02"/>
+  </g>
+  <g id="LWPOLYLINE-1042" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1591.15" y="524.26" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-1043" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1591.15" y1="526.82" x2="1521.99" y2="526.82"/>
+  </g>
+  <g id="LWPOLYLINE-1044" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1591.15" y1="526.5" x2="1521.99" y2="526.5"/>
+  </g>
+  <g id="LWPOLYLINE-1045" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1520.39" y="524.26" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-1046" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1449.31" y="524.26" width="1.61" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-1047" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1450.92" y1="526.82" x2="1520.39" y2="526.82"/>
+  </g>
+  <g id="LWPOLYLINE-1048" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1450.92" y1="526.5" x2="1520.39" y2="526.5"/>
+  </g>
+  <g id="LWPOLYLINE-1049" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1797.01" y="473.67" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1050" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1797.01" y1="475.91" x2="1728.82" y2="475.91"/>
+  </g>
+  <g id="LWPOLYLINE-1051" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1797.01" y1="475.59" x2="1728.82" y2="475.59"/>
+  </g>
+  <g id="LWPOLYLINE-1052" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1727.22" y="473.67" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1053" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1657.42" y="473.67" width="1.61" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1054" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.98" y1="475.91" x2="1727.22" y2="475.91"/>
+  </g>
+  <g id="LWPOLYLINE-1055" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.98" y1="475.59" x2="1727.22" y2="475.59"/>
+  </g>
+  <g id="LWPOLYLINE-1056" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1956.45 443.9 1983.34 470.79 1982.07 472.07 1955.18 445.17"/>
+  </g>
+  <g id="LWPOLYLINE-1057" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1957.09 442.94 1954.21 446.46 1951.33 449.99 1949.41 453.82 1947.49 457.67 1946.21 462.15 1945.57 466.31 1945.25 470.79"/>
+  </g>
+  <g id="LWPOLYLINE-1058" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.26" y1="1078.78" x2="124.17" y2="1076.22"/>
+  </g>
+  <g id="LWPOLYLINE-1059" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="135.05" y1="1123.28" x2="140.17" y2="1077.82"/>
+  </g>
+  <g id="LWPOLYLINE-1060" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="129.61" y1="1080.38" x2="131.21" y2="1079.1"/>
+  </g>
+  <g id="LWPOLYLINE-1061" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="129.29" y1="1083.9" x2="131.21" y2="1082.3"/>
+  </g>
+  <g id="LWPOLYLINE-1062" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.65" y1="1087.74" x2="130.89" y2="1086.14"/>
+  </g>
+  <g id="LWPOLYLINE-1063" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.33" y1="1091.58" x2="130.57" y2="1089.66"/>
+  </g>
+  <g id="LWPOLYLINE-1064" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.01" y1="1095.11" x2="129.93" y2="1093.51"/>
+  </g>
+  <g id="LWPOLYLINE-1065" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="127.69" y1="1098.95" x2="129.61" y2="1097.35"/>
+  </g>
+  <g id="LWPOLYLINE-1066" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="127.05" y1="1102.79" x2="129.29" y2="1100.87"/>
+  </g>
+  <g id="LWPOLYLINE-1067" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="126.73" y1="1106.31" x2="128.65" y2="1104.71"/>
+  </g>
+  <g id="LWPOLYLINE-1068" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="126.41" y1="1110.15" x2="128.33" y2="1108.55"/>
+  </g>
+  <g id="LWPOLYLINE-1069" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="125.77" y1="1113.68" x2="128.01" y2="1112.08"/>
+  </g>
+  <g id="LWPOLYLINE-1070" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="126.41 1120.08 127.05 1119.76 125.45 1117.52 127.37 1115.92 125.77 1113.67"/>
+  </g>
+  <g id="LWPOLYLINE-1071" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.01" y1="1112.08" x2="126.41" y2="1110.16"/>
+  </g>
+  <g id="LWPOLYLINE-1072" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.33" y1="1108.55" x2="126.73" y2="1106.31"/>
+  </g>
+  <g id="LWPOLYLINE-1073" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.65" y1="1104.71" x2="127.05" y2="1102.79"/>
+  </g>
+  <g id="LWPOLYLINE-1074" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="129.29" y1="1100.87" x2="127.69" y2="1098.95"/>
+  </g>
+  <g id="LWPOLYLINE-1075" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="129.61" y1="1097.35" x2="128.01" y2="1095.1"/>
+  </g>
+  <g id="LWPOLYLINE-1076" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="129.93" y1="1093.51" x2="128.33" y2="1091.59"/>
+  </g>
+  <g id="LWPOLYLINE-1077" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="130.57" y1="1089.66" x2="128.65" y2="1087.74"/>
+  </g>
+  <g id="LWPOLYLINE-1078" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="130.89" y1="1086.14" x2="129.29" y2="1083.9"/>
+  </g>
+  <g id="LWPOLYLINE-1079" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="131.21" y1="1082.3" x2="129.61" y2="1080.38"/>
+  </g>
+  <g id="LWPOLYLINE-1080" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="128.65" y1="1076.54" x2="123.2" y2="1122"/>
+  </g>
+  <g id="LWPOLYLINE-1081" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="133.77 1077.18 133.45 1079.42 128.33 1078.78 128.65 1076.54 133.77 1077.18"/>
+  </g>
+  <g id="LWPOLYLINE-1082" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="128.97 1120.4 128.65 1122.64 123.21 1122 123.52 1119.76 128.97 1120.4"/>
+  </g>
+  <g id="LWPOLYLINE-1083" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="133.45" y1="1079.42" x2="128.65" y2="1122.64"/>
+  </g>
+  <g id="LWPOLYLINE-1084" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="123.21" y1="1122" x2="141.13" y2="1123.92"/>
+  </g>
+  <g id="LWPOLYLINE-1085" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.66" y1="1024.67" x2="130.57" y2="1022.11"/>
+  </g>
+  <g id="LWPOLYLINE-1086" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.26" y1="1024.03" x2="162.91" y2="877.08"/>
+  </g>
+  <g id="LWPOLYLINE-1087" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="169.31 877.72 151.38 875.8 147.22 875.16"/>
+  </g>
+  <g id="LWPOLYLINE-1088" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.66" y1="879.32" x2="154.26" y2="878.04"/>
+  </g>
+  <g id="LWPOLYLINE-1089" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.34" y1="883.16" x2="154.59" y2="881.56"/>
+  </g>
+  <g id="LWPOLYLINE-1090" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.02" y1="886.68" x2="153.94" y2="885.08"/>
+  </g>
+  <g id="LWPOLYLINE-1091" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="151.38" y1="890.52" x2="153.63" y2="888.92"/>
+  </g>
+  <g id="LWPOLYLINE-1092" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="151.06" y1="894.36" x2="153.31" y2="892.76"/>
+  </g>
+  <g id="LWPOLYLINE-1093" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="150.74" y1="897.89" x2="152.66" y2="896.29"/>
+  </g>
+  <g id="LWPOLYLINE-1094" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="150.1" y1="901.73" x2="152.34" y2="900.13"/>
+  </g>
+  <g id="LWPOLYLINE-1095" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="149.78" y1="905.57" x2="152.02" y2="903.65"/>
+  </g>
+  <g id="LWPOLYLINE-1096" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="149.46" y1="909.09" x2="151.38" y2="907.49"/>
+  </g>
+  <g id="LWPOLYLINE-1097" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.82" y1="912.93" x2="151.06" y2="911.33"/>
+  </g>
+  <g id="LWPOLYLINE-1098" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.5" y1="916.46" x2="150.74" y2="914.86"/>
+  </g>
+  <g id="LWPOLYLINE-1099" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.18" y1="920.3" x2="150.1" y2="918.7"/>
+  </g>
+  <g id="LWPOLYLINE-1100" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.54" y1="924.14" x2="149.78" y2="922.54"/>
+  </g>
+  <g id="LWPOLYLINE-1101" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.22" y1="927.66" x2="149.46" y2="926.06"/>
+  </g>
+  <g id="LWPOLYLINE-1102" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.9" y1="931.5" x2="148.82" y2="929.9"/>
+  </g>
+  <g id="LWPOLYLINE-1103" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.26" y1="935.34" x2="148.5" y2="933.43"/>
+  </g>
+  <g id="LWPOLYLINE-1104" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.94" y1="938.87" x2="148.18" y2="937.27"/>
+  </g>
+  <g id="LWPOLYLINE-1105" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.62" y1="942.71" x2="147.54" y2="941.11"/>
+  </g>
+  <g id="LWPOLYLINE-1106" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.3" y1="946.55" x2="147.22" y2="944.63"/>
+  </g>
+  <g id="LWPOLYLINE-1107" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.9" y1="948.47" x2="146.9" y2="948.47"/>
+  </g>
+  <g id="LWPOLYLINE-1108" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.34" y1="953.91" x2="146.26" y2="952.31"/>
+  </g>
+  <g id="LWPOLYLINE-1109" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.02" y1="957.44" x2="145.94" y2="955.84"/>
+  </g>
+  <g id="LWPOLYLINE-1110" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="143.38" y1="961.28" x2="145.62" y2="959.68"/>
+  </g>
+  <g id="LWPOLYLINE-1111" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="143.06" y1="965.12" x2="144.98" y2="963.52"/>
+  </g>
+  <g id="LWPOLYLINE-1112" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="142.74" y1="968.64" x2="144.66" y2="967.04"/>
+  </g>
+  <g id="LWPOLYLINE-1113" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="142.1" y1="972.48" x2="144.34" y2="970.88"/>
+  </g>
+  <g id="LWPOLYLINE-1114" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="141.78" y1="976.33" x2="143.69" y2="974.41"/>
+  </g>
+  <g id="LWPOLYLINE-1115" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="141.46" y1="979.85" x2="143.38" y2="978.25"/>
+  </g>
+  <g id="LWPOLYLINE-1116" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="140.82" y1="983.69" x2="143.06" y2="982.09"/>
+  </g>
+  <g id="LWPOLYLINE-1117" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="140.5" y1="987.21" x2="142.42" y2="985.61"/>
+  </g>
+  <g id="LWPOLYLINE-1118" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="140.18" y1="991.05" x2="142.1" y2="989.45"/>
+  </g>
+  <g id="LWPOLYLINE-1119" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="139.53" y1="994.9" x2="141.78" y2="993.3"/>
+  </g>
+  <g id="LWPOLYLINE-1120" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="139.21" y1="998.42" x2="141.13" y2="996.82"/>
+  </g>
+  <g id="LWPOLYLINE-1121" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="138.9" y1="1002.26" x2="140.82" y2="1000.66"/>
+  </g>
+  <g id="LWPOLYLINE-1122" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="138.25" y1="1006.1" x2="140.5" y2="1004.5"/>
+  </g>
+  <g id="LWPOLYLINE-1123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="137.94" y1="1009.62" x2="139.85" y2="1008.02"/>
+  </g>
+  <g id="LWPOLYLINE-1124" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="137.61" y1="1013.47" x2="139.53" y2="1011.87"/>
+  </g>
+  <g id="LWPOLYLINE-1125" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="136.97 1020.83 138.57 1019.23 136.97 1017.3 139.22 1015.38 137.61 1013.46"/>
+  </g>
+  <g id="LWPOLYLINE-1126" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="139.53" y1="1011.86" x2="137.93" y2="1009.62"/>
+  </g>
+  <g id="LWPOLYLINE-1127" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="139.86" y1="1008.02" x2="138.25" y2="1006.1"/>
+  </g>
+  <g id="LWPOLYLINE-1128" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="140.5" y1="1004.5" x2="138.9" y2="1002.26"/>
+  </g>
+  <g id="LWPOLYLINE-1129" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="140.82" y1="1000.66" x2="139.21" y2="998.41"/>
+  </g>
+  <g id="LWPOLYLINE-1130" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="141.14" y1="996.82" x2="139.54" y2="994.9"/>
+  </g>
+  <g id="LWPOLYLINE-1131" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="141.78" y1="993.29" x2="140.17" y2="991.05"/>
+  </g>
+  <g id="LWPOLYLINE-1132" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="142.1" y1="989.45" x2="140.5" y2="987.21"/>
+  </g>
+  <g id="LWPOLYLINE-1133" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="142.42" y1="985.61" x2="140.82" y2="983.69"/>
+  </g>
+  <g id="LWPOLYLINE-1134" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="143.06" y1="982.09" x2="141.46" y2="979.85"/>
+  </g>
+  <g id="LWPOLYLINE-1135" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="143.38" y1="978.25" x2="141.77" y2="976.33"/>
+  </g>
+  <g id="LWPOLYLINE-1136" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="143.7" y1="974.41" x2="142.1" y2="972.49"/>
+  </g>
+  <g id="LWPOLYLINE-1137" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.34" y1="970.88" x2="142.74" y2="968.64"/>
+  </g>
+  <g id="LWPOLYLINE-1138" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.66" y1="967.04" x2="143.06" y2="965.12"/>
+  </g>
+  <g id="LWPOLYLINE-1139" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.98" y1="963.52" x2="143.38" y2="961.28"/>
+  </g>
+  <g id="LWPOLYLINE-1140" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.62" y1="959.68" x2="144.02" y2="957.43"/>
+  </g>
+  <g id="LWPOLYLINE-1141" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.94" y1="955.84" x2="144.34" y2="953.92"/>
+  </g>
+  <g id="LWPOLYLINE-1142" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.26" y1="952.31" x2="144.98" y2="950.39"/>
+  </g>
+  <g id="LWPOLYLINE-1143" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.9" y1="948.47" x2="145.3" y2="946.55"/>
+  </g>
+  <g id="LWPOLYLINE-1144" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.22" y1="944.63" x2="145.62" y2="942.71"/>
+  </g>
+  <g id="LWPOLYLINE-1145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.54" y1="941.11" x2="145.94" y2="938.86"/>
+  </g>
+  <g id="LWPOLYLINE-1146" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.18" y1="937.27" x2="146.26" y2="935.35"/>
+  </g>
+  <g id="LWPOLYLINE-1147" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.5" y1="933.42" x2="146.9" y2="931.51"/>
+  </g>
+  <g id="LWPOLYLINE-1148" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.82" y1="929.9" x2="147.22" y2="927.66"/>
+  </g>
+  <g id="LWPOLYLINE-1149" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="149.46" y1="926.06" x2="147.54" y2="924.14"/>
+  </g>
+  <g id="LWPOLYLINE-1150" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="149.78" y1="922.54" x2="148.18" y2="920.3"/>
+  </g>
+  <g id="LWPOLYLINE-1151" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="150.1" y1="918.7" x2="148.5" y2="916.45"/>
+  </g>
+  <g id="LWPOLYLINE-1152" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="150.74" y1="914.86" x2="148.82" y2="912.94"/>
+  </g>
+  <g id="LWPOLYLINE-1153" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="151.06" y1="911.33" x2="149.46" y2="909.09"/>
+  </g>
+  <g id="LWPOLYLINE-1154" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="151.38" y1="907.49" x2="149.78" y2="905.57"/>
+  </g>
+  <g id="LWPOLYLINE-1155" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.02" y1="903.65" x2="150.1" y2="901.73"/>
+  </g>
+  <g id="LWPOLYLINE-1156" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.34" y1="900.13" x2="150.74" y2="897.88"/>
+  </g>
+  <g id="LWPOLYLINE-1157" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.66" y1="896.29" x2="151.06" y2="894.37"/>
+  </g>
+  <g id="LWPOLYLINE-1158" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="153.3" y1="892.76" x2="151.38" y2="890.52"/>
+  </g>
+  <g id="LWPOLYLINE-1159" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="153.62" y1="888.92" x2="152.02" y2="886.68"/>
+  </g>
+  <g id="LWPOLYLINE-1160" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="153.94" y1="885.08" x2="152.34" y2="883.16"/>
+  </g>
+  <g id="LWPOLYLINE-1161" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="154.58" y1="881.56" x2="152.66" y2="879.31"/>
+  </g>
+  <g id="LWPOLYLINE-1162" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="151.38" y1="875.8" x2="134.73" y2="1022.75"/>
+  </g>
+  <g id="LWPOLYLINE-1163" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="156.82 876.12 156.5 878.36 151.06 877.72 151.38 875.79 156.82 876.12"/>
+  </g>
+  <g id="LWPOLYLINE-1164" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="140.18 1021.15 139.85 1023.39 134.73 1022.75 135.06 1020.51 140.18 1021.15"/>
+  </g>
+  <g id="LWPOLYLINE-1165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="156.5" y1="878.36" x2="140.17" y2="1022.11"/>
+  </g>
+  <g id="LWPOLYLINE-1166" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="148.5 948.79 148.18 950.71 143.06 950.07 143.06 948.15 148.5 948.79"/>
+  </g>
+  <g id="LWPOLYLINE-1167" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="283.29" y1="1143.77" x2="333.87" y2="1143.77"/>
+  </g>
+  <g id="LWPOLYLINE-1168" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="438.89" y1="1097.67" x2="443.05" y2="1097.67"/>
+  </g>
+  <g id="LWPOLYLINE-1169" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M283.29,1234.22c.04,10.57,8.64,19.09,19.21,19.05h0s77.8,0,77.8,0"/>
+  </g>
+  <g id="LWPOLYLINE-1170" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="302.5" y1="1257.75" x2="380.3" y2="1257.75"/>
+  </g>
+  <g id="LWPOLYLINE-1171" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="330.67 1022.43 330.67 1139.29 333.87 1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-1172" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="326.51 933.42 326.51 984.33 330.67 984.33"/>
+  </g>
+  <g id="LWPOLYLINE-1173" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.51" y1="1022.43" x2="330.67" y2="1022.43"/>
+  </g>
+  <g id="LWPOLYLINE-1174" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="372.29" y1="1139.29" x2="438.89" y2="1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-1175" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="431.84" y1="967.04" x2="438.89" y2="967.04"/>
+  </g>
+  <g id="LWPOLYLINE-1176" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="380.3" y1="1166.18" x2="384.46" y2="1166.18"/>
+  </g>
+  <g id="LWPOLYLINE-1177" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="380.3" y1="1230.21" x2="384.46" y2="1230.21"/>
+  </g>
+  <g id="LWPOLYLINE-1178" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="382.22" y1="1166.82" x2="382.22" y2="1197.56"/>
+  </g>
+  <g id="LWPOLYLINE-1179" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="382.22" y1="1198.84" x2="382.22" y2="1229.89"/>
+  </g>
+  <g id="LWPOLYLINE-1180" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="382.54" y1="1166.82" x2="382.54" y2="1197.56"/>
+  </g>
+  <g id="LWPOLYLINE-1181" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="382.54" y1="1198.84" x2="382.54" y2="1229.89"/>
+  </g>
+  <g id="LWPOLYLINE-1182" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="381.9" y="1166.18" width=".96" height=".64"/>
+  </g>
+  <g id="LWPOLYLINE-1183" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="381.9" y="1229.89" width=".96" height=".32"/>
+  </g>
+  <g id="LWPOLYLINE-1184" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="381.9" y="1197.56" width=".96" height="1.28"/>
+  </g>
+  <g id="LWPOLYLINE-1185" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1151.45 378.38 1151.45 379.02 1158.5 379.02 1151.45"/>
+  </g>
+  <g id="LWPOLYLINE-1186" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1151.45 379.02 1158.5 378.38 1158.5 378.38 1151.45"/>
+  </g>
+  <g id="LWPOLYLINE-1187" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1161.7 378.38 1161.7 379.02 1168.11 379.02 1161.7"/>
+  </g>
+  <g id="LWPOLYLINE-1188" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1161.7 379.02 1168.11 378.38 1168.11 378.38 1161.7"/>
+  </g>
+  <g id="LWPOLYLINE-1189" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1171.3 378.38 1171.3 379.02 1177.71 379.02 1171.3"/>
+  </g>
+  <g id="LWPOLYLINE-1190" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1171.3 379.02 1177.71 378.38 1177.71 378.38 1171.3"/>
+  </g>
+  <g id="LWPOLYLINE-1191" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1180.59 378.38 1180.59 379.02 1187 379.02 1180.59"/>
+  </g>
+  <g id="LWPOLYLINE-1192" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1180.59 379.02 1187 378.38 1187 378.38 1180.59"/>
+  </g>
+  <g id="LWPOLYLINE-1193" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1190.19 378.38 1190.19 379.02 1196.6 379.02 1190.19"/>
+  </g>
+  <g id="LWPOLYLINE-1194" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1190.19 379.02 1196.6 378.38 1196.6 378.38 1190.19"/>
+  </g>
+  <g id="LWPOLYLINE-1195" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1199.8 378.38 1199.8 379.02 1206.21 379.02 1199.8"/>
+  </g>
+  <g id="LWPOLYLINE-1196" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1199.8 379.02 1206.21 378.38 1206.21 378.38 1199.8"/>
+  </g>
+  <g id="LWPOLYLINE-1197" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1209.4 378.38 1209.4 379.02 1215.81 379.02 1209.4"/>
+  </g>
+  <g id="LWPOLYLINE-1198" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1209.4 379.02 1215.81 378.38 1215.81 378.38 1209.4"/>
+  </g>
+  <g id="LWPOLYLINE-1199" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1219.01 378.38 1219.01 379.02 1225.42 379.02 1219.01"/>
+  </g>
+  <g id="LWPOLYLINE-1200" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1219.01 379.02 1225.42 378.38 1225.42 378.38 1219.01"/>
+  </g>
+  <g id="LWPOLYLINE-1201" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1228.61 378.38 1228.61 379.02 1234.7 379.02 1228.61"/>
+  </g>
+  <g id="LWPOLYLINE-1202" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1228.61 379.02 1234.7 378.38 1234.7 378.38 1228.61"/>
+  </g>
+  <g id="LWPOLYLINE-1203" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.02 1237.9 378.38 1237.9 379.02 1245.26 379.02 1237.9"/>
+  </g>
+  <g id="LWPOLYLINE-1204" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="378.38 1237.9 379.02 1245.26 378.38 1245.26 378.38 1237.9"/>
+  </g>
+  <g id="LWPOLYLINE-1205" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="379.02" y1="1245.26" x2="378.38" y2="1245.26"/>
+  </g>
+  <g id="LWPOLYLINE-1206" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.34 1245.26 380.3 1245.26 380.3 1245.59 378.06 1245.59 378.06 1243.34 378.37 1243.34 378.37 1245.26 379.01 1245.26 379.01 1243.34 379.34 1243.34 379.34 1245.26"/>
+  </g>
+  <g id="LWPOLYLINE-1207" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="379.34 1151.45 380.3 1151.45 380.3 1151.13 378.06 1151.13 378.06 1153.06 378.37 1153.06 378.37 1151.45 379.01 1151.45 379.01 1153.06 379.34 1153.06 379.34 1151.45"/>
+  </g>
+  <g id="ARC">
+    <path class="cls-3" d="M283.35,1247.56c4.35,6.18,11.43,9.86,18.99,9.86"/>
+  </g>
+  <g id="LWPOLYLINE-1208" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="330.67" y1="984.33" x2="330.67" y2="934.07"/>
+  </g>
+  <g id="LWPOLYLINE-1209" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.51" y1="1143.77" x2="326.51" y2="1022.43"/>
+  </g>
+  <g id="LWPOLYLINE-1210" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="550.3" y="951.35" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-1211" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="484.67" y="951.35" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-1212" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="550.3 953.6 486.27 953.6 550.3 953.6"/>
+  </g>
+  <g id="LWPOLYLINE-1213" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.51" y1="963.52" x2="213.81" y2="950.39"/>
+  </g>
+  <g id="LWPOLYLINE-1214" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="268.56" y1="1032.03" x2="205.17" y2="1024.67"/>
+  </g>
+  <g id="LWPOLYLINE-1215" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="267.6" y1="1036.2" x2="266.64" y2="1036.2"/>
+  </g>
+  <g id="LWPOLYLINE-1216" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M264.4,1068.21l.64-6.72h-1.28c-6.71-.82-12.81-4.28-16.97-9.61l19.85-15.69"/>
+  </g>
+  <g id="LWPOLYLINE-1217" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.51" y1="1074.62" x2="317.54" y2="1073.65"/>
+  </g>
+  <g id="LWPOLYLINE-1218" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M317.55,1073.66v1.28l-29.86,23.95c-6.37-7.9-9.33-18.02-8.24-28.11l.32-.96-78.76-8"/>
+  </g>
+  <g id="LWPOLYLINE-1219" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.51" y1="1075.9" x2="317.54" y2="1074.93"/>
+  </g>
+  <g id="LWPOLYLINE-1220" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.45" y1="1070.77" x2="201.01" y2="1062.77"/>
+  </g>
+  <g id="LWPOLYLINE-1221" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.51" y1="959.36" x2="214.13" y2="946.55"/>
+  </g>
+  <g id="LWPOLYLINE-1222" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="192.36" y1="1139.29" x2="326.51" y2="1139.29"/>
+  </g>
+  <g id="LWPOLYLINE-1223" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="303.78 853.39 303.78 929.58 327.79 929.26"/>
+  </g>
+  <g id="LWPOLYLINE-1224" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="299.62 854.98 299.62 934.06 326.51 933.43"/>
+  </g>
+  <g id="LWPOLYLINE-1225" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="335.47 898.21 369.73 915.49 368.77 917.09 334.84 900.13"/>
+  </g>
+  <g id="LWPOLYLINE-1226" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="336.11 897.25 334.2 901.41 332.91 905.57 331.95 910.05 331.63 914.21 331.63 918.7 332.28 923.18 333.56 927.34"/>
+  </g>
+  <g id="LWPOLYLINE-1227" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="240.71" y1="874.19" x2="245.19" y2="878.68"/>
+  </g>
+  <g id="LWPOLYLINE-1228" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="247.43" y1="880.92" x2="251.91" y2="885.4"/>
+  </g>
+  <g id="LWPOLYLINE-1229" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="254.15" y1="887.64" x2="258.64" y2="892.12"/>
+  </g>
+  <g id="LWPOLYLINE-1230" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.88" y1="894.36" x2="265.36" y2="898.85"/>
+  </g>
+  <g id="LWPOLYLINE-1231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="267.92" y1="901.09" x2="272.4" y2="905.58"/>
+  </g>
+  <g id="LWPOLYLINE-1232" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.64" y1="907.81" x2="279.13" y2="912.3"/>
+  </g>
+  <g id="LWPOLYLINE-1233" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="281.37" y1="914.54" x2="285.85" y2="919.02"/>
+  </g>
+  <g id="LWPOLYLINE-1234" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="288.09" y1="921.26" x2="292.57" y2="925.74"/>
+  </g>
+  <g id="LWPOLYLINE-1235" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="294.81" y1="927.98" x2="299.3" y2="932.46"/>
+  </g>
+  <g id="LWPOLYLINE-1236" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="301.54" y1="934.71" x2="306.34" y2="939.19"/>
+  </g>
+  <g id="LWPOLYLINE-1237" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="308.58" y1="941.43" x2="313.06" y2="945.91"/>
+  </g>
+  <g id="LWPOLYLINE-1238" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="315.3" y1="948.15" x2="319.79" y2="952.63"/>
+  </g>
+  <g id="LWPOLYLINE-1239" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="322.03" y1="954.88" x2="326.51" y2="959.36"/>
+  </g>
+  <g id="LWPOLYLINE-1240" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="214.13" y1="946.55" x2="218.93" y2="943.67"/>
+  </g>
+  <g id="LWPOLYLINE-1241" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="221.5" y1="942.07" x2="226.94" y2="938.87"/>
+  </g>
+  <g id="LWPOLYLINE-1242" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="229.82" y1="937.27" x2="235.26" y2="933.75"/>
+  </g>
+  <g id="LWPOLYLINE-1243" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="237.82" y1="932.14" x2="243.27" y2="928.94"/>
+  </g>
+  <g id="LWPOLYLINE-1244" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="246.15" y1="927.02" x2="251.59" y2="923.82"/>
+  </g>
+  <g id="LWPOLYLINE-1245" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="254.15" y1="922.22" x2="259.6" y2="919.02"/>
+  </g>
+  <g id="LWPOLYLINE-1246" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.16" y1="917.1" x2="267.6" y2="913.9"/>
+  </g>
+  <g id="LWPOLYLINE-1247" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="270.48" y1="912.29" x2="275.93" y2="908.77"/>
+  </g>
+  <g id="LWPOLYLINE-1248" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="278.49" y1="907.17" x2="283.93" y2="903.97"/>
+  </g>
+  <g id="LWPOLYLINE-1249" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.81" y1="902.37" x2="292.25" y2="898.84"/>
+  </g>
+  <g id="LWPOLYLINE-1250" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="294.81" y1="897.25" x2="299.62" y2="894.36"/>
+  </g>
+  <g id="LWPOLYLINE-1251" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="267.92" y1="1032.03" x2="267.6" y2="1036.2"/>
+  </g>
+  <g id="LWPOLYLINE-1252" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="266.96" y1="1031.71" x2="266.64" y2="1036.2"/>
+  </g>
+  <g id="LWPOLYLINE-1253" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="263.76" y1="1061.49" x2="263.12" y2="1068.21"/>
+  </g>
+  <g id="LWPOLYLINE-1254" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="240.07" y1="953.6" x2="232.06" y2="1023.39"/>
+  </g>
+  <g id="LWPOLYLINE-1255" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="215.73" y1="1006.74" x2="216.06" y2="1004.82"/>
+  </g>
+  <g id="ARC-2" data-name="ARC">
+    <path class="cls-3" d="M216.24,1013.26c4.75,1.05,9.45-1.96,10.5-6.71.03-.15.06-.29.08-.44"/>
+  </g>
+  <g id="LWPOLYLINE-1256" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.81" y1="1006.42" x2="214.14" y2="1001.3"/>
+  </g>
+  <g id="LWPOLYLINE-1257" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="214.45 995.22 213.49 1003.86 212.53 1012.19"/>
+  </g>
+  <g id="SPLINE">
+    <path class="cls-3" d="M213.49,1006.24c-.01.09.05.17.15.18"/>
+  </g>
+  <g id="LWPOLYLINE-1258" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M215.41,1006.6s0,0,0,0c.04.04.04.11,0,.15h-1.61"/>
+  </g>
+  <g id="LWPOLYLINE-1259" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M214.71,1002.93c.12-.03.25-.04.38-.03l4.05.96s0,0,0,0c.27.06.43.32.38.59s-.32.43-.59.38h-3.84"/>
+  </g>
+  <g id="LWPOLYLINE-1260" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.05" y1="1003.22" x2="216.38" y2="1001.3"/>
+  </g>
+  <g id="ARC-3" data-name="ARC">
+    <path class="cls-3" d="M226.67,1005.86c1.19-4.71-1.66-9.49-6.37-10.68-.66-.17-1.35-.26-2.03-.27"/>
+  </g>
+  <g id="SPLINE-2" data-name="SPLINE">
+    <path class="cls-3" d="M214.31,1000.98c-.09,0-.17.05-.17.15"/>
+  </g>
+  <g id="SPLINE-3" data-name="SPLINE">
+    <path class="cls-3" d="M216.05,1001.16c0-.09-.05-.17-.15-.18"/>
+  </g>
+  <g id="LWPOLYLINE-1261" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.05" y1="1001.3" x2="214.45" y2="1000.97"/>
+  </g>
+  <g id="ARC-4" data-name="ARC">
+    <path class="cls-3" d="M214.84,1004.5c.06,0,.12,0,.18,0"/>
+  </g>
+  <g id="SPLINE-4" data-name="SPLINE">
+    <path class="cls-3" d="M214.71,1002.93c-.1.03-.2.08-.28.15"/>
+  </g>
+  <g id="SPLINE-5" data-name="SPLINE">
+    <path class="cls-3" d="M214.81,1004.81c.21.02.43,0,.62-.11"/>
+  </g>
+  <g id="SPLINE-6" data-name="SPLINE">
+    <path class="cls-3" d="M214.39,1004.68c.13.07.27.12.42.13"/>
+  </g>
+  <g id="ARC-5" data-name="ARC">
+    <path class="cls-3" d="M214.06,1004.4c.09.11.2.21.33.28"/>
+  </g>
+  <g id="SPLINE-7" data-name="SPLINE">
+    <path class="cls-3" d="M213.86,1004.01c.04.15.11.28.2.39"/>
+  </g>
+  <g id="SPLINE-8" data-name="SPLINE">
+    <path class="cls-3" d="M213.82,1003.57c-.02.15,0,.29.03.44"/>
+  </g>
+  <g id="SPLINE-9" data-name="SPLINE">
+    <path class="cls-3" d="M213.95,1003.16c-.07.13-.11.28-.13.42"/>
+  </g>
+  <g id="ARC-6" data-name="ARC">
+    <path class="cls-3" d="M214.24,1002.82c-.11.09-.21.21-.28.33"/>
+  </g>
+  <g id="SPLINE-10" data-name="SPLINE">
+    <path class="cls-3" d="M214.62,1002.62c-.15.04-.28.11-.39.2"/>
+  </g>
+  <g id="ARC-7" data-name="ARC">
+    <path class="cls-3" d="M215.63,1002.82c-.28-.23-.66-.3-1.01-.2"/>
+  </g>
+  <g id="LWPOLYLINE-1262" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="220.86" y1="965.76" x2="220.53" y2="967.68"/>
+  </g>
+  <g id="ARC-8" data-name="ARC">
+    <path class="cls-3" d="M231.4,968.71c.31-4.83-3.35-9-8.18-9.31-.16-.01-.31-.02-.47-.02"/>
+  </g>
+  <g id="ARC-9" data-name="ARC">
+    <path class="cls-3" d="M220.79,967.62c.24-2.35.37-4.71.38-7.07"/>
+  </g>
+  <g id="LWPOLYLINE-1263" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="218.62" y1="965.76" x2="217.98" y2="970.88"/>
+  </g>
+  <g id="LWPOLYLINE-1264" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="217.01 976.65 217.98 968.32 218.94 959.68"/>
+  </g>
+  <g id="ARC-10" data-name="ARC">
+    <path class="cls-3" d="M222.74,959.69c-.61-.07-1.17.37-1.24.98,0,0,0,0,0,0"/>
+  </g>
+  <g id="SPLINE-11" data-name="SPLINE">
+    <path class="cls-3" d="M220.54,965.62c0-.09-.05-.17-.15-.18"/>
+  </g>
+  <g id="SPLINE-12" data-name="SPLINE">
+    <path class="cls-3" d="M218.79,965.44c-.09,0-.17.05-.17.15"/>
+  </g>
+  <g id="LWPOLYLINE-1265" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="220.54" y1="965.76" x2="218.94" y2="965.44"/>
+  </g>
+  <g id="LWPOLYLINE-1266" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M223.74,968.32l-4.16-.96c-.13-.01-.25,0-.38.03"/>
+  </g>
+  <g id="LWPOLYLINE-1267" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="220.22" y1="969.28" x2="220.22" y2="971.2"/>
+  </g>
+  <g id="ARC-11" data-name="ARC">
+    <path class="cls-3" d="M219.4,976.16c.52-2.31.92-4.63,1.22-6.98"/>
+  </g>
+  <g id="SPLINE-13" data-name="SPLINE">
+    <path class="cls-3" d="M217.98,970.71c-.01.09.05.17.15.18"/>
+  </g>
+  <g id="SPLINE-14" data-name="SPLINE">
+    <path class="cls-3" d="M219.72,971.2c.09,0,.17-.05.18-.15"/>
+  </g>
+  <g id="LWPOLYLINE-1268" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="219.9" y1="971.2" x2="218.3" y2="971.2"/>
+  </g>
+  <g id="SPLINE-15" data-name="SPLINE">
+    <path class="cls-3" d="M219.68,967.41c-.05-.02-.12-.03-.18-.04"/>
+  </g>
+  <g id="SPLINE-16" data-name="SPLINE">
+    <path class="cls-3" d="M219.19,967.39c-.1.03-.2.08-.28.15"/>
+  </g>
+  <g id="SPLINE-17" data-name="SPLINE">
+    <path class="cls-3" d="M218.62,968.07c-.01.1,0,.21.02.31"/>
+  </g>
+  <g id="ARC-12" data-name="ARC">
+    <path class="cls-3" d="M220.12,967.29c-.17-.14-.37-.22-.59-.25"/>
+  </g>
+  <g id="SPLINE-18" data-name="SPLINE">
+    <path class="cls-3" d="M219.54,967.05c-.15-.02-.29,0-.44.03"/>
+  </g>
+  <g id="SPLINE-19" data-name="SPLINE">
+    <path class="cls-3" d="M219.11,967.08c-.15.04-.28.11-.39.2"/>
+  </g>
+  <g id="ARC-13" data-name="ARC">
+    <path class="cls-3" d="M218.72,967.29c-.11.09-.21.21-.28.33"/>
+  </g>
+  <g id="SPLINE-20" data-name="SPLINE">
+    <path class="cls-3" d="M218.44,967.62c-.07.13-.11.27-.13.42"/>
+  </g>
+  <g id="SPLINE-21" data-name="SPLINE">
+    <path class="cls-3" d="M218.3,968.03c-.02.15,0,.29.03.44"/>
+  </g>
+  <g id="SPLINE-22" data-name="SPLINE">
+    <path class="cls-3" d="M218.34,968.47c.04.15.11.28.2.39"/>
+  </g>
+  <g id="SPLINE-23" data-name="SPLINE">
+    <path class="cls-3" d="M218.54,968.86c.1.11.2.21.33.28"/>
+  </g>
+  <g id="ARC-14" data-name="ARC">
+    <path class="cls-3" d="M218.87,969.14c.32.18.7.19,1.03.03"/>
+  </g>
+  <g id="SPLINE-24" data-name="SPLINE">
+    <path class="cls-3" d="M223.74,968.85c.03-.26-.16-.5-.43-.53"/>
+  </g>
+  <g id="ARC-15" data-name="ARC">
+    <path class="cls-3" d="M223.2,969.28c.26.03.5-.16.53-.43"/>
+  </g>
+  <g id="LWPOLYLINE-1269" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="223.42" y1="969.28" x2="219.25" y2="969.28"/>
+  </g>
+  <g id="LWPOLYLINE-1270" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="242.31" y1="1069.17" x2="210.29" y2="1065.33"/>
+  </g>
+  <g id="LWPOLYLINE-1271" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M209.65,1065.01v-.32h.64l.32-.31v-.32l-3.21-.64v.64l.32.32h.32v.24c-.1,1.17.75,2.2,1.92,2.32l32.02,3.84"/>
+  </g>
+  <g id="LWPOLYLINE-1272" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="208.05 1079.1 206.45 1078.77 205.49 1086.14 207.09 1086.46"/>
+  </g>
+  <g id="ARC-16" data-name="ARC">
+    <path class="cls-3" d="M223.23,1088.6c.21-.16.24-.45.09-.66-.05-.06-.11-.11-.18-.14"/>
+  </g>
+  <g id="LWPOLYLINE-1273" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="223.1" y1="1088.06" x2="220.85" y2="1086.78"/>
+  </g>
+  <g id="SPLINE-25" data-name="SPLINE">
+    <path class="cls-3" d="M220.9,1086.83c-.14-.07-.3-.06-.44.02"/>
+  </g>
+  <g id="ARC-17" data-name="ARC">
+    <path class="cls-3" d="M218.13,1087.62c.73-.14,1.42-.39,2.07-.74"/>
+  </g>
+  <g id="ARC-18" data-name="ARC">
+    <path class="cls-3" d="M209.83,1081.02c-.91.98-1.08,2.44-.41,3.6"/>
+  </g>
+  <g id="ARC-19" data-name="ARC">
+    <path class="cls-3" d="M220.82,1081.51c-.55-.49-1.17-.9-1.85-1.19"/>
+  </g>
+  <g id="LWPOLYLINE-1274" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M221.02,1081.54c.13.12.31.16.48.12l2.56-.32"/>
+  </g>
+  <g id="SPLINE-26" data-name="SPLINE">
+    <path class="cls-3" d="M223.68,1081.01c.16-.03.29-.15.35-.3"/>
+  </g>
+  <g id="ARC-20" data-name="ARC">
+    <path class="cls-3" d="M222.03,1089.71c1.13-.56,2.12-1.35,2.92-2.33"/>
+  </g>
+  <g id="ARC-21" data-name="ARC">
+    <path class="cls-3" d="M225.39,1082.09c-.32-.64-.71-1.24-1.17-1.78"/>
+  </g>
+  <g id="ARC-22" data-name="ARC">
+    <path class="cls-3" d="M223.96,1082.79c-.27-.54-.61-1.05-1-1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1275" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="221.18" y1="1081.66" x2="221.18" y2="1081.66"/>
+  </g>
+  <g id="LWPOLYLINE-1276" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="224.38" y1="1081.02" x2="224.38" y2="1081.02"/>
+  </g>
+  <g id="ARC-23" data-name="ARC">
+    <path class="cls-3" d="M222.49,1087.56c.45-.34.86-.74,1.22-1.18"/>
+  </g>
+  <g id="LWPOLYLINE-1277" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="244.55" y1="1068.53" x2="242.95" y2="1068.21"/>
+  </g>
+  <g id="LWPOLYLINE-1278" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="244.87 1068.53 245.19 1068.53 245.51 1067.89 242.31 1067.57 241.99 1067.89 242.31 1068.21 242.95 1068.21 242.95 1068.53"/>
+  </g>
+  <g id="ARC-24" data-name="ARC">
+    <path class="cls-3" d="M242.09,1068.85c.26.03.5-.16.53-.43"/>
+  </g>
+  <g id="LWPOLYLINE-1279" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="244.55 1068.85 244.55 1068.53 244.87 1068.53"/>
+  </g>
+  <g id="ARC-25" data-name="ARC">
+    <path class="cls-3" d="M241.91,1070.44c1.14.13,2.17-.69,2.3-1.83"/>
+  </g>
+  <g id="LWPOLYLINE-1280" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M200.05,1069.81l-.32,3.2.65.32.31-.32v-.64s.21,0,.21,0c.29.06.49.34.43.64l-3.53,32.02"/>
+  </g>
+  <g id="LWPOLYLINE-1281" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="199.41" y1="1105.35" x2="202.93" y2="1073.34"/>
+  </g>
+  <g id="LWPOLYLINE-1282" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="197.16 1105.67 196.84 1105.67 196.84 1105.03 196.84 1104.71 196.2 1104.71 195.88 1107.92 196.53 1107.92 196.53 1107.59 196.84 1107.27 197.16 1107.27"/>
+  </g>
+  <g id="ARC-26" data-name="ARC">
+    <path class="cls-3" d="M196.95,1105.35c.26.03.5-.16.53-.43"/>
+  </g>
+  <g id="LWPOLYLINE-1283" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="196.85" y1="1105.67" x2="196.85" y2="1107.27"/>
+  </g>
+  <g id="ARC-27" data-name="ARC">
+    <path class="cls-3" d="M196.77,1106.94c1.14.13,2.17-.69,2.3-1.83,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-28" data-name="ARC">
+    <path class="cls-3" d="M216.61,1076.27c-.53-.11-1.06-.19-1.59-.25"/>
+  </g>
+  <g id="LWPOLYLINE-1284" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="215.41" y1="1076.22" x2="202.92" y2="1074.94"/>
+  </g>
+  <g id="LWPOLYLINE-1285" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.01" y1="1089.66" x2="213.81" y2="1090.95"/>
+  </g>
+  <g id="LWPOLYLINE-1286" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="201.33 1074.62 199.73 1074.29 199.08 1078.78 198.77 1081.66 198.44 1084.86 198.13 1089.34 199.73 1089.34"/>
+  </g>
+  <g id="LWPOLYLINE-1287" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M202.91,1073.09c.11-1.17-.74-2.2-1.91-2.32l-.32,1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1288" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="201.01 1070.78 201.01 1070.45 200.68 1070.13 200.04 1069.82"/>
+  </g>
+  <g id="LWPOLYLINE-1289" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M210.08,1065.33c-.29-.06-.49-.34-.43-.64l-1.6-.32"/>
+  </g>
+  <g id="LWPOLYLINE-1290" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M221.09,1038.49c-.5-.14-1.01-.27-1.52-.37l-15.69-1.6-.32,4.16-.32,3.2-.32,3.21-.64,4.16,15.69,1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1291" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="228.86" y1="1042.92" x2="228.86" y2="1042.92"/>
+  </g>
+  <g id="LWPOLYLINE-1292" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="225.66" y1="1043.56" x2="225.66" y2="1043.56"/>
+  </g>
+  <g id="ARC-29" data-name="ARC">
+    <path class="cls-3" d="M217.73,1052.73c1.54.17,3.09.15,4.62-.08"/>
+  </g>
+  <g id="ARC-30" data-name="ARC">
+    <path class="cls-3" d="M227.39,1050.5c.21-.16.24-.45.09-.66-.05-.06-.11-.11-.18-.14"/>
+  </g>
+  <g id="LWPOLYLINE-1293" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="227.58" y1="1049.96" x2="225.34" y2="1049"/>
+  </g>
+  <g id="SPLINE-27" data-name="SPLINE">
+    <path class="cls-3" d="M225.06,1048.73c-.14-.07-.3-.05-.44.02"/>
+  </g>
+  <g id="ARC-31" data-name="ARC">
+    <path class="cls-3" d="M214.31,1042.92c-.91.98-1.08,2.44-.41,3.6"/>
+  </g>
+  <g id="LWPOLYLINE-1294" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M225.5,1043.44c.13.12.31.16.48.12l2.24-.32"/>
+  </g>
+  <g id="SPLINE-28" data-name="SPLINE">
+    <path class="cls-3" d="M228.16,1042.91c.16-.03.29-.15.35-.3"/>
+  </g>
+  <g id="SPLINE-29" data-name="SPLINE">
+    <path class="cls-3" d="M228.51,1042.61c.05-.15.03-.32-.07-.45"/>
+  </g>
+  <g id="LWPOLYLINE-1295" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="212.21 1041 210.61 1040.68 209.97 1048.04 211.57 1048.36"/>
+  </g>
+  <g id="ARC-32" data-name="ARC">
+    <path class="cls-3" d="M215.37,1051.73c1.81.79,3.76,1.17,5.73,1.11"/>
+  </g>
+  <g id="ARC-33" data-name="ARC">
+    <path class="cls-3" d="M228.44,1044.69c-.27-.54-.6-1.05-1-1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1296" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="248.07 997.78 251.6 1012.5 255.12 997.78 258.64 1012.5 262.16 997.78"/>
+  </g>
+  <g id="LWPOLYLINE-1297" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="269.2 997.78 267.92 998.42 266.32 1000.02 265.68 1001.3 265.04 1003.54 265.04 1007.06 265.68 1008.98 266.32 1010.58 267.92 1011.86 269.2 1012.5 272.08 1012.5 273.68 1011.86 274.96 1010.58 275.61 1008.98 276.25 1007.06 276.25 1003.54 275.61 1001.3 274.96 1000.02 273.68 998.42 272.08 997.78 269.2 997.78"/>
+  </g>
+  <g id="LWPOLYLINE-1298" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="280.73 1012.5 280.73 997.78 286.17 1012.5 291.93 997.78 291.93 1012.5"/>
+  </g>
+  <g id="LWPOLYLINE-1299" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="306.66 1012.5 297.7 1012.5 297.7 997.78 306.66 997.78"/>
+  </g>
+  <g id="LWPOLYLINE-1300" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="297.7" y1="1004.82" x2="303.14" y2="1004.82"/>
+  </g>
+  <g id="LWPOLYLINE-1301" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="311.14 1012.5 311.14 997.78 321.06 1012.5 321.06 997.78"/>
+  </g>
+  <g id="LWPOLYLINE-1302" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="321.39 877.4 321.39 888.6 320.43 890.84 319.79 891.48 318.51 892.12 316.9 892.12 315.63 891.48 314.98 890.84 314.02 888.6 314.02 887.32"/>
+  </g>
+  <g id="LWPOLYLINE-1303" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="325.55 892.12 330.99 877.4 336.76 892.12"/>
+  </g>
+  <g id="LWPOLYLINE-1304" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="327.47" y1="887.32" x2="334.83" y2="887.32"/>
+  </g>
+  <g id="LWPOLYLINE-1305" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="340.92 892.12 340.92 877.4 350.84 892.12 350.84 877.4"/>
+  </g>
+  <g id="LWPOLYLINE-1306" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="357.25 890.84 356.61 891.48 357.25 892.13 357.88 891.48"/>
+  </g>
+  <g id="LWPOLYLINE-1307" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M429.24,948.48c.85-.22,1.73-.33,2.61-.32v-2.89h5.44v15.05h-5.44v-2.56l-2.24-9.28"/>
+  </g>
+  <g id="LWPOLYLINE-1308" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="414.23 960.96 406.55 960.96 406.55 948.15 414.23 948.15"/>
+  </g>
+  <g id="LWPOLYLINE-1309" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.55" y1="954.23" x2="411.35" y2="954.23"/>
+  </g>
+  <g id="LWPOLYLINE-1310" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="418.08 960.96 418.08 948.15 423.52 948.15 425.12 948.79 425.76 949.43 426.4 950.71 426.4 952.63 425.76 953.59 425.12 954.24 423.52 954.88 418.08 954.88"/>
+  </g>
+  <g id="LWPOLYLINE-1311" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="500.36 848.58 500.36 833.86 506.76 833.86 508.68 834.5 509.32 835.45 510.28 836.74 510.28 838.02 509.32 839.62 508.68 840.25 506.76 840.9 500.36 840.9"/>
+  </g>
+  <g id="LWPOLYLINE-1312" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="505.16" y1="840.9" x2="510.28" y2="848.58"/>
+  </g>
+  <g id="LWPOLYLINE-1313" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="524.37 848.58 515.08 848.58 515.08 833.86 524.37 833.86"/>
+  </g>
+  <g id="LWPOLYLINE-1314" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="515.08" y1="840.9" x2="520.84" y2="840.9"/>
+  </g>
+  <g id="LWPOLYLINE-1315" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="539.1 837.38 538.46 836.1 537.18 834.49 535.57 833.86 532.69 833.86 531.41 834.49 529.81 836.1 529.17 837.38 528.53 839.62 528.53 843.14 529.17 845.06 529.81 846.66 531.41 847.95 532.69 848.58 535.57 848.58 537.18 847.95 538.46 846.66 539.1 845.06"/>
+  </g>
+  <g id="LWPOLYLINE-1316" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="547.74 833.85 546.14 834.49 544.86 836.1 544.22 837.38 543.26 839.61 543.26 843.14 544.22 845.06 544.86 846.66 546.14 847.94 547.74 848.58 550.3 848.58 551.9 847.94 553.19 846.66 554.15 845.06 554.79 843.14 554.79 839.61 554.15 837.38 553.19 836.1 551.9 834.49 550.3 833.85 547.74 833.85"/>
+  </g>
+  <g id="LWPOLYLINE-1317" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="558.95 848.58 558.95 833.86 565.35 833.86 567.27 834.5 568.23 835.45 568.87 836.74 568.87 838.02 568.23 839.62 567.27 840.25 565.35 840.9 558.95 840.9"/>
+  </g>
+  <g id="LWPOLYLINE-1318" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="563.75" y1="840.9" x2="568.87" y2="848.58"/>
+  </g>
+  <g id="LWPOLYLINE-1319" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="573.67 848.58 573.67 833.86 578.8 833.86 580.72 834.5 582.32 836.09 582.96 837.38 583.6 839.62 583.6 843.14 582.96 845.06 582.32 846.66 580.72 847.94 578.8 848.58 573.67 848.58"/>
+  </g>
+  <g id="LWPOLYLINE-1320" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="514.44 862.03 513.81 860.75 512.2 859.47 510.92 858.5 508.04 858.5 506.76 859.47 505.16 860.75 504.52 862.03 503.87 864.27 503.87 867.79 504.52 870.03 505.16 871.31 506.76 872.91 508.04 873.56 510.92 873.56 512.2 872.91 513.81 871.31 514.44 870.03"/>
+  </g>
+  <g id="LWPOLYLINE-1321" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="527.89 873.56 518.61 873.56 518.61 858.51 527.89 858.51"/>
+  </g>
+  <g id="LWPOLYLINE-1322" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="518.61" y1="865.55" x2="524.37" y2="865.55"/>
+  </g>
+  <g id="LWPOLYLINE-1323" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="532.05 873.56 532.05 858.51 541.98 873.56 541.98 858.51"/>
+  </g>
+  <g id="LWPOLYLINE-1324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="552.54" y1="858.51" x2="552.54" y2="873.56"/>
+  </g>
+  <g id="LWPOLYLINE-1325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="547.74" y1="858.51" x2="557.66" y2="858.51"/>
+  </g>
+  <g id="LWPOLYLINE-1326" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="569.51 873.56 560.23 873.56 560.23 858.51 569.51 858.51"/>
+  </g>
+  <g id="LWPOLYLINE-1327" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="560.23" y1="865.55" x2="565.99" y2="865.55"/>
+  </g>
+  <g id="LWPOLYLINE-1328" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="573.67 873.56 573.67 858.51 580.08 858.51 582.32 859.47 582.96 860.11 583.6 861.39 583.6 862.99 582.96 864.27 582.32 864.91 580.08 865.55 573.67 865.55"/>
+  </g>
+  <g id="LWPOLYLINE-1329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="578.8" y1="865.55" x2="583.6" y2="873.55"/>
+  </g>
+  <g id="LWPOLYLINE-1330" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="612.74 794.16 639.63 767.26 638.35 765.97 611.45 792.87"/>
+  </g>
+  <g id="LWPOLYLINE-1331" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="613.37 795.11 610.49 791.91 607.62 788.07 605.37 784.23 603.77 780.39 602.49 775.9 601.85 771.74 601.53 767.26"/>
+  </g>
+  <g id="LWPOLYLINE-1332" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="611.77 749.97 610.81 751.58 611.14 753.81 612.1 756.7 613.37 758.3 614.97 759.26 616.58 758.61 617.53 757.66 617.86 756.7 618.18 755.09 618.18 750.61 618.18 749.01 618.82 748.05 619.78 747.09 621.7 746.45 623.62 747.09 624.9 749.01 625.86 751.58 625.86 753.81 625.22 755.73"/>
+  </g>
+  <g id="LWPOLYLINE-1333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="606.65" y1="741.97" x2="620.74" y2="736.85"/>
+  </g>
+  <g id="LWPOLYLINE-1334" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="608.25" y1="746.77" x2="605.05" y2="737.16"/>
+  </g>
+  <g id="LWPOLYLINE-1335" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="602.49 730.76 603.77 731.72 605.69 732.69 606.97 732.69 609.21 732.69 612.74 731.4 614.33 730.12 615.62 729.16 616.26 727.24 616.57 725.64 615.62 723.08 614.33 721.8 612.74 721.16 611.13 720.84 608.9 720.84 605.37 722.12 603.77 723.4 602.81 724.68 601.85 726.28 601.53 727.88 602.49 730.76"/>
+  </g>
+  <g id="LWPOLYLINE-1336" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="612.74 715.07 598.65 719.87 596.73 714.11 596.41 711.87 597.05 710.91 598.01 709.63 599.29 709.31 600.89 709.31 601.85 709.95 603.13 711.55 605.37 717.63"/>
+  </g>
+  <g id="LWPOLYLINE-1337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="603.77" y1="712.83" x2="609.53" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1338" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="606.01 700.99 606.97 701.31 607.61 700.35 606.65 700.02"/>
+  </g>
+  <g id="LWPOLYLINE-1339" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="661.72 837.7 661.08 836.1 659.48 834.81 658.2 834.18 655.31 834.18 654.04 834.81 652.44 836.1 651.8 837.7 651.15 839.94 651.15 843.45 651.8 845.38 652.44 846.98 654.04 848.27 655.31 848.9 658.2 848.9 659.48 848.27 661.08 846.98 661.72 845.38"/>
+  </g>
+  <g id="LWPOLYLINE-1340" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="670.36 834.17 668.76 834.81 667.48 836.09 666.84 837.7 665.88 839.93 665.88 843.46 666.84 845.38 667.48 846.98 668.76 848.26 670.36 848.9 672.92 848.9 674.53 848.26 675.81 846.98 676.45 845.38 677.41 843.46 677.41 839.93 676.45 837.7 675.81 836.09 674.53 834.81 672.92 834.17 670.36 834.17"/>
+  </g>
+  <g id="LWPOLYLINE-1341" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="681.57 848.9 681.57 834.18 691.49 848.9 691.49 834.18"/>
+  </g>
+  <g id="LWPOLYLINE-1342" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="696.94 848.9 696.94 834.18 706.22 834.18"/>
+  </g>
+  <g id="LWPOLYLINE-1343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="696.94" y1="841.22" x2="702.7" y2="841.22"/>
+  </g>
+  <g id="LWPOLYLINE-1344" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="719.03 848.9 709.74 848.9 709.74 834.18 719.03 834.18"/>
+  </g>
+  <g id="LWPOLYLINE-1345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="709.74" y1="841.22" x2="715.5" y2="841.22"/>
+  </g>
+  <g id="LWPOLYLINE-1346" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="723.19 848.9 723.19 834.18 729.6 834.18 731.83 834.82 732.47 835.45 733.11 837.06 733.11 838.34 732.47 839.94 731.83 840.57 729.6 841.22 723.19 841.22"/>
+  </g>
+  <g id="LWPOLYLINE-1347" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="728.31" y1="841.22" x2="733.11" y2="848.9"/>
+  </g>
+  <g id="LWPOLYLINE-1348" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="747.2 848.9 738.24 848.9 738.24 834.18 747.2 834.18"/>
+  </g>
+  <g id="LWPOLYLINE-1349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="738.24" y1="841.22" x2="743.68" y2="841.22"/>
+  </g>
+  <g id="LWPOLYLINE-1350" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="751.36 848.9 751.36 834.18 761.29 848.9 761.29 834.18"/>
+  </g>
+  <g id="LWPOLYLINE-1351" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="777.62 837.7 776.98 836.1 775.7 834.81 774.09 834.18 771.21 834.18 769.93 834.81 768.33 836.1 767.7 837.7 767.05 839.94 767.05 843.45 767.7 845.38 768.33 846.98 769.93 848.27 771.21 848.9 774.09 848.9 775.7 848.27 776.98 846.98 777.62 845.38"/>
+  </g>
+  <g id="LWPOLYLINE-1352" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="791.06 848.9 781.78 848.9 781.78 834.18 791.06 834.18"/>
+  </g>
+  <g id="LWPOLYLINE-1353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="781.78" y1="841.22" x2="787.54" y2="841.22"/>
+  </g>
+  <g id="LWPOLYLINE-1354" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="979.64" y1="579" x2="978.04" y2="574.2"/>
+  </g>
+  <g id="LWPOLYLINE-1355" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1242.17 689.14 1209.84 689.14 1209.84 684.98"/>
+  </g>
+  <g id="LWPOLYLINE-1356" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1170.14" y="684.98" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1170.14" y1="687.22" x2="1105.14" y2="687.22"/>
+  </g>
+  <g id="LWPOLYLINE-1358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1170.14" y1="686.9" x2="1105.14" y2="686.9"/>
+  </g>
+  <g id="LWPOLYLINE-1359" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1103.54" y="684.98" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1360" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1036.95" y="684.98" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1038.55" y1="687.22" x2="1103.54" y2="687.22"/>
+  </g>
+  <g id="LWPOLYLINE-1362" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1038.55" y1="686.9" x2="1103.54" y2="686.9"/>
+  </g>
+  <g id="LWPOLYLINE-1363" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1209.84" y1="684.98" x2="1238.01" y2="684.98"/>
+  </g>
+  <g id="LWPOLYLINE-1364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1053.6" y1="554.67" x2="1051.68" y2="549.87"/>
+  </g>
+  <g id="LWPOLYLINE-1365" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1445.8 659.05 1446.44 659.05 1446.44 667.37 1413.46 667.37 1413.46 659.05 1414.1 659.05 1441.63 643.04 1443.23 646.88 1444.83 650.72 1445.47 654.88 1445.8 659.05"/>
+  </g>
+  <g id="LWPOLYLINE-1366" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1474.93" y1="416.36" x2="1473.33" y2="411.24"/>
+  </g>
+  <g id="LWPOLYLINE-1367" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1659.02" y1="477.83" x2="1797.02" y2="477.83"/>
+  </g>
+  <g id="LWPOLYLINE-1368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="621.38" y1="686.9" x2="778.26" y2="635.35"/>
+  </g>
+  <g id="LWPOLYLINE-1369" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1944.29 245.08 1946.21 251.16 1942.68 252.44 1940.76 246.04 1944.29 245.08"/>
+  </g>
+  <g id="LWPOLYLINE-1370" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1887.3 458.62 1886.66 457.02 1885.05 455.74 1883.77 454.78 1880.89 454.78 1879.61 455.74 1878.02 457.02 1877.38 458.3 1876.73 460.55 1876.73 464.07 1877.38 466.31 1878.02 467.59 1879.61 469.19 1880.89 469.83 1883.77 469.83 1885.05 469.19 1886.66 467.59 1887.3 466.31"/>
+  </g>
+  <g id="LWPOLYLINE-1371" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1891.46 454.78 1891.46 469.83 1900.1 469.83"/>
+  </g>
+  <g id="LWPOLYLINE-1372" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1907.79 454.78 1906.19 455.75 1904.91 457.03 1904.27 458.62 1903.62 460.54 1903.62 464.06 1904.27 466.31 1904.91 467.59 1906.19 469.19 1907.79 469.83 1910.67 469.83 1911.95 469.19 1913.55 467.59 1914.19 466.31 1914.83 464.06 1914.83 460.54 1914.19 458.62 1913.55 457.03 1911.95 455.75 1910.67 454.78 1907.79 454.78"/>
+  </g>
+  <g id="LWPOLYLINE-1373" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1928.92 457.02 1927.64 455.74 1925.4 454.78 1922.52 454.78 1920.6 455.74 1919 457.02 1919 458.62 1919.64 459.91 1920.6 460.55 1921.87 461.19 1926.04 462.78 1927.64 463.43 1928.28 464.07 1928.92 465.67 1928.92 467.59 1927.64 469.19 1925.4 469.83 1922.52 469.83 1920.6 469.19 1919 467.59"/>
+  </g>
+  <g id="LWPOLYLINE-1374" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1934.04 468.23 1933.08 469.19 1934.04 469.83 1934.68 469.19"/>
+  </g>
+  <g id="LWPOLYLINE-1375" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2079.72" y1="649.76" x2="2085.8" y2="650.4"/>
+  </g>
+  <g id="LWPOLYLINE-1376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.56" y1="620.63" x2="2102.45" y2="620.94"/>
+  </g>
+  <g id="LWPOLYLINE-1377" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2092.84 576.76 2088.36 576.13 2091.56 547.94 2097.64 548.59"/>
+  </g>
+  <g id="LWPOLYLINE-1378" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2100.53 522.65 2094.44 522.02 2092.84 535.14 2098.93 535.78"/>
+  </g>
+  <g id="LWPOLYLINE-1379" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2117.5" y1="445.18" x2="2117.17" y2="447.1"/>
+  </g>
+  <g id="LWPOLYLINE-1380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2224.75" y1="467.59" x2="2170.96" y2="461.51"/>
+  </g>
+  <g id="LWPOLYLINE-1381" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2223.47" y1="477.83" x2="2170" y2="471.75"/>
+  </g>
+  <g id="LWPOLYLINE-1382" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2222.19" y1="488.08" x2="2168.72" y2="482"/>
+  </g>
+  <g id="LWPOLYLINE-1383" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2221.23" y1="498.64" x2="2167.44" y2="492.56"/>
+  </g>
+  <g id="LWPOLYLINE-1384" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2219.95" y1="508.89" x2="2166.48" y2="502.81"/>
+  </g>
+  <g id="LWPOLYLINE-1385" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2218.67" y1="519.14" x2="2165.2" y2="513.05"/>
+  </g>
+  <g id="LWPOLYLINE-1386" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2217.71" y1="529.38" x2="2163.91" y2="523.3"/>
+  </g>
+  <g id="LWPOLYLINE-1387" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2216.43" y1="539.63" x2="2162.96" y2="533.54"/>
+  </g>
+  <g id="LWPOLYLINE-1388" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2111.09 500.25 2133.5 498 2136.39 502.17 2140.54 492.88 2143.75 497.05 2166.16 494.49"/>
+  </g>
+  <g id="LWPOLYLINE-1389" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.87" y1="479.12" x2="2144.39" y2="448.06"/>
+  </g>
+  <g id="LWPOLYLINE-1390" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2197.86" y1="464.71" x2="2187.92" y2="550.51"/>
+  </g>
+  <g id="LWPOLYLINE-1391" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2199.78 464.71 2199.45 463.11 2197.86 462.46 2196.25 463.11 2195.61 464.71 2196.25 465.99 2197.86 466.63 2199.45 465.99 2199.78 464.71"/>
+  </g>
+  <g id="LWPOLYLINE-1392" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2134.14 471.43 2140.87 479.12 2148.54 472.39"/>
+  </g>
+  <g id="LWPOLYLINE-1393" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2188.25 459.91 2189.86 447.42 2194.01 447.74 2195.61 448.38 2196.89 449.98 2197.21 451.27 2197.53 452.86 2197.21 456.07 2196.58 457.66 2195.93 458.94 2194.33 459.91 2192.73 460.23 2188.25 459.91"/>
+  </g>
+  <g id="LWPOLYLINE-1394" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2201.06 461.18 2202.34 448.69 2209.38 462.15 2210.66 449.34"/>
+  </g>
+  <g id="LWPOLYLINE-1395" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.97" y1="404.2" x2="2103.09" y2="371.22"/>
+  </g>
+  <g id="LWPOLYLINE-1396" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2095.08" y1="346.89" x2="2093.81" y2="343.37"/>
+  </g>
+  <g id="LWPOLYLINE-1397" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2214.18 408.36 2115.89 397.15 2106.93 369.94"/>
+  </g>
+  <g id="LWPOLYLINE-1398" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2002.24" y1="419.24" x2="1988.47" y2="385.95"/>
+  </g>
+  <g id="LWPOLYLINE-1399" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.79" y1="424.69" x2="2057.62" y2="430.13"/>
+  </g>
+  <g id="LWPOLYLINE-1400" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1996.53,488.68c-.85.23-1.73.35-2.61.36v1.92h-5.12v-14.73h5.12v2.24l2.88,10.25"/>
+  </g>
+  <g id="LWPOLYLINE-1401" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2008.96 492.24 2000.95 492.24 2000.95 479.75 2008.96 479.75"/>
+  </g>
+  <g id="LWPOLYLINE-1402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2000.95" y1="485.84" x2="2005.76" y2="485.84"/>
+  </g>
+  <g id="LWPOLYLINE-1403" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2012.48 492.24 2012.48 479.75 2017.93 479.75 2019.85 480.4 2020.48 480.71 2021.12 482 2021.12 483.92 2020.48 485.2 2019.85 485.84 2017.93 486.16 2012.48 486.16"/>
+  </g>
+  <g id="LWPOLYLINE-1404" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2004.16 457.34 2002.56 456.06 2000.64 455.42 1997.76 455.42 1995.52 456.06 1994.23 457.34 1994.23 458.94 1994.88 460.23 1995.52 460.86 1997.11 461.83 2001.27 463.1 2002.56 463.74 2003.19 464.71 2004.16 465.99 2004.16 468.23 2002.56 469.51 2000.64 470.15 1997.76 470.15 1995.52 469.51 1994.23 468.23"/>
+  </g>
+  <g id="LWPOLYLINE-1405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2013.12" y1="455.42" x2="2013.12" y2="470.15"/>
+  </g>
+  <g id="LWPOLYLINE-1406" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2008.32" y1="455.42" x2="2018.24" y2="455.42"/>
+  </g>
+  <g id="LWPOLYLINE-1407" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2025.29 455.42 2023.69 456.06 2022.41 457.34 2021.77 458.94 2021.12 460.86 2021.12 464.7 2021.77 466.62 2022.41 468.23 2023.69 469.51 2025.29 470.15 2028.17 470.15 2029.45 469.51 2031.05 468.23 2031.69 466.62 2032.34 464.7 2032.34 460.86 2031.69 458.94 2031.05 457.34 2029.45 456.06 2028.17 455.42 2025.29 455.42"/>
+  </g>
+  <g id="LWPOLYLINE-1408" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2036.49 470.15 2036.49 455.43 2042.9 455.43 2045.13 456.06 2045.78 456.7 2046.42 458.31 2046.42 459.58 2045.78 460.87 2045.13 461.82 2042.9 462.47 2036.49 462.47"/>
+  </g>
+  <g id="LWPOLYLINE-1409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2041.62" y1="462.47" x2="2046.42" y2="470.15"/>
+  </g>
+  <g id="LWPOLYLINE-1410" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2052.18 468.87 2051.54 469.51 2052.18 470.15 2052.82 469.51"/>
+  </g>
+  <g id="LWPOLYLINE-1411" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2083.56 369.62 2095.08 346.88 2096.37 347.53 2084.84 370.26"/>
+  </g>
+  <g id="LWPOLYLINE-1412" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2082.92 369.3 2085.8 370.58 2088.36 371.54 2091.25 372.18 2094.44 372.5 2097.32 372.5 2100.2 371.86 2103.09 371.22"/>
+  </g>
+  <g id="LWPOLYLINE-1413" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2245.88" y1="152.87" x2="2223.79" y2="348.81"/>
+  </g>
+  <g id="LWPOLYLINE-1414" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2227.63 314.23 2202.34 311.35 2202.34 312.31"/>
+  </g>
+  <g id="LWPOLYLINE-1415" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2174.8" y1="234.83" x2="2173.84" y2="241.88"/>
+  </g>
+  <g id="LWPOLYLINE-1416" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2172.24 267.17 2170.96 267.17 2170.32 273.57"/>
+  </g>
+  <g id="LWPOLYLINE-1417" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2175.76" y1="234.83" x2="2175.13" y2="242.2"/>
+  </g>
+  <g id="LWPOLYLINE-1418" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2192.09 251.48 2172.24 267.17 2171.6 272.61"/>
+  </g>
+  <g id="LWPOLYLINE-1419" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2250.36" y1="151.27" x2="2227.31" y2="353.61"/>
+  </g>
+  <g id="LWPOLYLINE-1420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2170.32" y1="273.57" x2="2231.48" y2="280.62"/>
+  </g>
+  <g id="LWPOLYLINE-1421" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2171.6" y1="272.61" x2="2231.47" y2="279.34"/>
+  </g>
+  <g id="LWPOLYLINE-1422" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2173.84" y1="241.88" x2="2175.12" y2="242.19"/>
+  </g>
+  <g id="LWPOLYLINE-1423" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2105.65" y1="226.83" x2="2116.53" y2="228.11"/>
+  </g>
+  <g id="LWPOLYLINE-1424" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2154.64 231.31 2154.31 232.59 2235.95 241.87"/>
+  </g>
+  <g id="LWPOLYLINE-1425" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2105.97" y1="225.87" x2="2116.53" y2="227.14"/>
+  </g>
+  <g id="LWPOLYLINE-1426" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2154.63" y1="231.31" x2="2235.95" y2="240.59"/>
+  </g>
+  <g id="LWPOLYLINE-1427" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2194.34 169.84 2195.29 172.72 2243 178.16"/>
+  </g>
+  <g id="LWPOLYLINE-1428" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2198.49 168.55 2198.49 168.88 2243.63 174"/>
+  </g>
+  <g id="LWPOLYLINE-1429" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2105.01" y1="232.59" x2="2108.85" y2="198.01"/>
+  </g>
+  <g id="LWPOLYLINE-1430" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2154.39,232.22c-1.13,10.1-6.22,19.33-14.17,25.67l-23.69-29.78v-.96"/>
+  </g>
+  <g id="LWPOLYLINE-1431" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.89" y1="397.15" x2="2114.93" y2="404.2"/>
+  </g>
+  <g id="LWPOLYLINE-1432" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2092.52 532.9 2087.72 576.12 2085.48 575.81 2090.28 532.9"/>
+  </g>
+  <g id="LWPOLYLINE-1433" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2093.8 533.22 2088.68 532.58 2083.87 532.9 2078.75 533.55 2073.95 534.83 2069.15 536.75 2064.67 539.3 2060.51 542.19"/>
+  </g>
+  <g id="ARC-34" data-name="ARC">
+    <path class="cls-3" d="M2060.4,541.88c-18.82,14.83-22.06,42.1-7.23,60.92,7.33,9.3,18.14,15.2,29.93,16.34"/>
+  </g>
+  <g id="LWPOLYLINE-1434" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.78" y1="715.71" x2="2174.8" y2="715.71"/>
+  </g>
+  <g id="LWPOLYLINE-1435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.78" y1="705.79" x2="2051.54" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1436" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2054.74" y1="705.79" x2="2061.15" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1437" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2064.35" y1="705.79" x2="2070.43" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1438" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2073.63" y1="705.79" x2="2080.04" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2083.24" y1="705.79" x2="2089.64" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2092.84" y1="705.79" x2="2099.25" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1441" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2102.45" y1="705.79" x2="2108.85" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.05" y1="705.79" x2="2118.45" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2121.34" y1="705.79" x2="2127.74" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1444" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2130.94" y1="705.79" x2="2137.34" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.55" y1="705.79" x2="2146.95" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2150.15" y1="705.79" x2="2156.55" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2159.76" y1="705.79" x2="2166.16" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2169.04" y1="705.79" x2="2174.8" y2="705.79"/>
+  </g>
+  <g id="LWPOLYLINE-1449" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.78" y1="798.96" x2="2050.58" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1450" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2053.78" y1="798.96" x2="2060.18" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2063.39" y1="798.96" x2="2069.47" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2072.67" y1="798.96" x2="2079.07" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1453" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2082.28" y1="798.96" x2="2088.68" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2091.88" y1="798.96" x2="2098.29" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2101.49" y1="798.96" x2="2107.88" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2111.09" y1="798.96" x2="2117.17" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2120.38" y1="798.96" x2="2126.77" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1458" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2129.98" y1="798.96" x2="2136.39" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1459" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2139.58" y1="798.96" x2="2145.99" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1460" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2149.19" y1="798.96" x2="2155.59" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2158.79" y1="798.96" x2="2165.2" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1462" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2168.08" y1="798.96" x2="2174.48" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2177.69" y1="798.96" x2="2182.49" y2="798.96"/>
+  </g>
+  <g id="LWPOLYLINE-1464" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2151.75 809.84 2151.75 797.03 2159.44 797.03"/>
+  </g>
+  <g id="LWPOLYLINE-1465" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.75" y1="803.12" x2="2156.55" y2="803.12"/>
+  </g>
+  <g id="LWPOLYLINE-1466" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2162.64 809.84 2162.64 797.03 2168.08 797.03 2169.68 797.68 2170.32 798.32 2170.96 799.28 2170.96 800.56 2170.32 801.84 2169.68 802.48 2168.08 803.12 2162.64 803.12"/>
+  </g>
+  <g id="LWPOLYLINE-1467" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2166.8" y1="803.12" x2="2170.96" y2="809.84"/>
+  </g>
+  <g id="LWPOLYLINE-1468" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2067.87" y1="757.01" x2="2067.87" y2="742.29"/>
+  </g>
+  <g id="LWPOLYLINE-1469" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2077.8" y1="742.29" x2="2067.86" y2="751.9"/>
+  </g>
+  <g id="LWPOLYLINE-1470" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2071.39" y1="748.37" x2="2077.8" y2="757.01"/>
+  </g>
+  <g id="LWPOLYLINE-1471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2082.92" y1="757.01" x2="2082.92" y2="742.29"/>
+  </g>
+  <g id="LWPOLYLINE-1472" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2093.48" y1="742.29" x2="2093.48" y2="757.01"/>
+  </g>
+  <g id="LWPOLYLINE-1473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2088.36" y1="742.29" x2="2098.28" y2="742.29"/>
+  </g>
+  <g id="LWPOLYLINE-1474" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2111.73 745.81 2111.09 744.21 2109.81 742.93 2108.21 742.29 2105.33 742.29 2104.05 742.93 2102.45 744.21 2101.81 745.81 2101.17 747.73 2101.17 751.26 2101.81 753.49 2102.45 754.78 2104.05 756.38 2105.33 757.01 2108.21 757.01 2109.81 756.38 2111.09 754.78 2111.73 753.49"/>
+  </g>
+  <g id="LWPOLYLINE-1475" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.89" y1="757.01" x2="2115.89" y2="742.29"/>
+  </g>
+  <g id="LWPOLYLINE-1476" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2125.82" y1="742.29" x2="2125.82" y2="757.01"/>
+  </g>
+  <g id="LWPOLYLINE-1477" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.89" y1="749.33" x2="2125.82" y2="749.33"/>
+  </g>
+  <g id="LWPOLYLINE-1478" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2140.86 757.01 2131.58 757.01 2131.58 742.29 2140.86 742.29"/>
+  </g>
+  <g id="LWPOLYLINE-1479" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2131.58" y1="749.33" x2="2137.34" y2="749.33"/>
+  </g>
+  <g id="LWPOLYLINE-1480" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2145.03 757.01 2145.03 742.29 2154.95 757.01 2154.95 742.29"/>
+  </g>
+  <g id="LWPOLYLINE-1481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.59" y1="697.47" x2="2141.51" y2="697.47"/>
+  </g>
+  <g id="CIRCLE-18" data-name="CIRCLE">
+    <circle class="cls-3" cx="2148.39" cy="704.35" r="1.44"/>
+  </g>
+  <g id="LWPOLYLINE-1482" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2149.83" y1="695.86" x2="2147.27" y2="695.86"/>
+  </g>
+  <g id="CIRCLE-19" data-name="CIRCLE">
+    <circle class="cls-3" cx="2146.47" cy="696.02" r=".8"/>
+  </g>
+  <g id="CIRCLE-20" data-name="CIRCLE">
+    <circle class="cls-3" cx="2150.63" cy="696.03" r=".8"/>
+  </g>
+  <g id="LWPOLYLINE-1483" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2149.83 696.83 2149.19 701.95 2148.23 701.95 2147.27 696.83"/>
+  </g>
+  <g id="ARC-35" data-name="ARC">
+    <path class="cls-3" d="M2138.79,693.94c-.8,0-1.44.65-1.44,1.44"/>
+  </g>
+  <g id="LWPOLYLINE-1484" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.95" y1="694.26" x2="2158.16" y2="694.26"/>
+  </g>
+  <g id="LWPOLYLINE-1485" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2137.66" y1="711.87" x2="2137.66" y2="695.55"/>
+  </g>
+  <g id="LWPOLYLINE-1486" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2157.99,693.94c.84.05,1.49.76,1.44,1.6v16.17s0,0,0,0c.04.75-.53,1.39-1.28,1.44h-19.21c-.84.04-1.56-.6-1.6-1.44"/>
+  </g>
+  <g id="ARC-36" data-name="ARC">
+    <path class="cls-3" d="M2141.35,697.15c-1.5,0-2.72,1.22-2.72,2.72,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1487" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.95" y1="700.03" x2="2138.95" y2="709.31"/>
+  </g>
+  <g id="LWPOLYLINE-1488" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2138.63,709.15c.04,1.55,1.33,2.76,2.88,2.72,0,0,0,0,0,0h14.09c1.41,0,2.56-1.15,2.56-2.56v-9.28c.04-1.55-1.17-2.84-2.72-2.88,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1489" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2155.59" y1="697.47" x2="2149.83" y2="697.47"/>
+  </g>
+  <g id="LWPOLYLINE-1490" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2028.49" y="940.47" width="4.16" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1491" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2030.41" y1="940.47" x2="2030.41" y2="879.64"/>
+  </g>
+  <g id="LWPOLYLINE-1492" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2030.73" y1="940.47" x2="2030.73" y2="879.64"/>
+  </g>
+  <g id="LWPOLYLINE-1493" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2028.49" y="878.04" width="4.16" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1494" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2028.49" y="1068.21" width="4.16" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1495" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2030.41" y1="1068.21" x2="2030.41" y2="1007.06"/>
+  </g>
+  <g id="LWPOLYLINE-1496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2030.73" y1="1068.21" x2="2030.73" y2="1007.06"/>
+  </g>
+  <g id="LWPOLYLINE-1497" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2028.49" y="1005.46" width="4.16" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1498" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2049.94 937.59 2049.94 952.31 2058.27 952.31"/>
+  </g>
+  <g id="LWPOLYLINE-1499" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2061.79" y1="952.31" x2="2061.79" y2="937.59"/>
+  </g>
+  <g id="LWPOLYLINE-1500" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2073.95 944.63 2075.87 945.27 2076.83 945.91 2077.48 947.51 2077.48 949.43 2076.83 951.04 2075.87 951.67 2073.95 952.31 2067.54 952.31 2067.54 937.58 2073.95 937.58 2075.87 938.22 2076.83 938.87 2077.48 940.47 2077.48 941.75 2076.83 943.03 2075.87 943.99 2073.95 944.63 2067.54 944.63"/>
+  </g>
+  <g id="LWPOLYLINE-1501" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2082.28 952.31 2082.28 937.59 2088.68 937.59 2090.92 938.23 2091.56 938.87 2092.2 940.47 2092.2 941.75 2091.56 943.03 2090.92 943.99 2088.68 944.63 2082.28 944.63"/>
+  </g>
+  <g id="LWPOLYLINE-1502" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2087.4" y1="944.63" x2="2092.2" y2="952.31"/>
+  </g>
+  <g id="LWPOLYLINE-1503" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2097.32 952.31 2102.77 937.59 2108.53 952.31"/>
+  </g>
+  <g id="LWPOLYLINE-1504" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.25" y1="947.51" x2="2106.29" y2="947.51"/>
+  </g>
+  <g id="LWPOLYLINE-1505" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2112.69 952.31 2112.69 937.59 2119.09 937.59 2121.33 938.23 2121.97 938.87 2122.62 940.47 2122.62 941.75 2121.97 943.03 2121.33 943.99 2119.09 944.63 2112.69 944.63"/>
+  </g>
+  <g id="LWPOLYLINE-1506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2117.82" y1="944.63" x2="2122.62" y2="952.31"/>
+  </g>
+  <g id="LWPOLYLINE-1507" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2127.42 937.59 2133.18 944.63 2138.95 937.59"/>
+  </g>
+  <g id="LWPOLYLINE-1508" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2133.18" y1="944.63" x2="2133.18" y2="952.31"/>
+  </g>
+  <g id="LWPOLYLINE-1509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.75" y1="1067.25" x2="2154.95" y2="1067.89"/>
+  </g>
+  <g id="LWPOLYLINE-1510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2170.32" y1="896.61" x2="2163.28" y2="958.72"/>
+  </g>
+  <g id="LWPOLYLINE-1511" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.92 882.84 2175.12 883.16 2173.53 896.93 2170.32 896.61"/>
+  </g>
+  <g id="LWPOLYLINE-1512" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2180.89" y1="368.66" x2="2179.92" y2="374.42"/>
+  </g>
+  <g id="CIRCLE-21" data-name="CIRCLE">
+    <circle class="cls-3" cx="2173.99" cy="366.59" r="1.46"/>
+  </g>
+  <g id="LWPOLYLINE-1513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2182.81" y1="366.42" x2="2182.48" y2="368.98"/>
+  </g>
+  <g id="SPLINE-30" data-name="SPLINE">
+    <path class="cls-3" d="M2182.48,369.87c.05-.44-.27-.84-.71-.89"/>
+  </g>
+  <g id="SPLINE-31" data-name="SPLINE">
+    <path class="cls-3" d="M2181.6,370.58c.44.05.84-.27.88-.71"/>
+  </g>
+  <g id="ARC-37" data-name="ARC">
+    <path class="cls-3" d="M2181.78,368.98c-.44-.05-.84.27-.89.72s.27.83.71.88"/>
+  </g>
+  <g id="SPLINE-32" data-name="SPLINE">
+    <path class="cls-3" d="M2183.12,365.39c.05-.44-.27-.84-.71-.89"/>
+  </g>
+  <g id="SPLINE-33" data-name="SPLINE">
+    <path class="cls-3" d="M2182.24,366.1c.43.04.83-.27.88-.71"/>
+  </g>
+  <g id="ARC-38" data-name="ARC">
+    <path class="cls-3" d="M2182.42,364.5c-.44-.05-.84.27-.89.72s.27.84.71.89"/>
+  </g>
+  <g id="LWPOLYLINE-1514" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2181.85 366.42 2176.73 366.74 2176.73 367.38 2181.52 368.98"/>
+  </g>
+  <g id="ARC-39" data-name="ARC">
+    <path class="cls-3" d="M2181.53,378.58c.79.09,1.5-.48,1.6-1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1515" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2183.13,377.62l2.24-19.21c.08-.79-.49-1.5-1.28-1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1516" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2164.25,375.06c-.09.79.48,1.51,1.27,1.6l16.33,1.92"/>
+  </g>
+  <g id="LWPOLYLINE-1517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2166.8" y1="356.17" x2="2164.55" y2="375.38"/>
+  </g>
+  <g id="ARC-40" data-name="ARC">
+    <path class="cls-3" d="M2168.08,354.9c-.79-.09-1.51.48-1.6,1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2184.09" y1="357.13" x2="2168.08" y2="355.21"/>
+  </g>
+  <g id="LWPOLYLINE-1519" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2180.23,374.25s0,0,0,0c-.13,1.45-1.41,2.53-2.87,2.4l-8.97-.96c-1.54-.13-2.68-1.49-2.54-3.03"/>
+  </g>
+  <g id="LWPOLYLINE-1520" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2166.16" y1="372.82" x2="2167.76" y2="359.05"/>
+  </g>
+  <g id="ARC-41" data-name="ARC">
+    <path class="cls-3" d="M2170.47,356.51c-1.49-.17-2.84.9-3.01,2.4"/>
+  </g>
+  <g id="LWPOLYLINE-1521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2170.64" y1="356.81" x2="2179.28" y2="357.77"/>
+  </g>
+  <g id="LWPOLYLINE-1522" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2179.11,357.47c1.55.21,2.63,1.64,2.42,3.19l-.64,5.76"/>
+  </g>
+  <g id="LWPOLYLINE-1523" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2121.98 358.41 2120.7 369.62 2119.73 371.54 2118.78 372.18 2117.49 372.82 2115.89 372.5 2114.61 371.86 2113.97 370.9 2113.65 368.66 2113.65 367.38"/>
+  </g>
+  <g id="LWPOLYLINE-1524" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2124.22 373.46 2131.58 359.37 2135.75 374.74"/>
+  </g>
+  <g id="LWPOLYLINE-1525" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2127.1" y1="368.98" x2="2134.15" y2="369.62"/>
+  </g>
+  <g id="LWPOLYLINE-1526" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2139.9 375.38 2141.51 360.66 2149.51 376.35 2151.43 361.62"/>
+  </g>
+  <g id="LWPOLYLINE-1527" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.23 375.7 2155.27 376.34 2155.91 376.98 2156.87 376.66"/>
+  </g>
+  <g id="LWPOLYLINE-1528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2202.34" y1="312.31" x2="2227.63" y2="315.19"/>
+  </g>
+  <g id="LWPOLYLINE-1529" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2194.65,234.51l32.01,3.53c.24.06.38.3.32.53"/>
+  </g>
+  <g id="LWPOLYLINE-1530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2226.99" y1="236.43" x2="2194.97" y2="232.91"/>
+  </g>
+  <g id="LWPOLYLINE-1531" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2228.91 224.59 2230.51 224.59 2231.47 217.22 2229.87 217.22"/>
+  </g>
+  <g id="ARC-42" data-name="ARC">
+    <path class="cls-3" d="M2229.67,216.79c-.36-.59-.81-1.13-1.31-1.61"/>
+  </g>
+  <g id="ARC-43" data-name="ARC">
+    <path class="cls-3" d="M2228.29,215.47c-.84-.79-1.8-1.42-2.86-1.89"/>
+  </g>
+  <g id="ARC-44" data-name="ARC">
+    <path class="cls-3" d="M2225.43,213.21c-1.81-.79-3.77-1.17-5.74-1.11"/>
+  </g>
+  <g id="SPLINE-34" data-name="SPLINE">
+    <path class="cls-3" d="M2213.41,214.44c-.13.1-.2.27-.18.43"/>
+  </g>
+  <g id="SPLINE-35" data-name="SPLINE">
+    <path class="cls-3" d="M2213.23,214.87c0,.17.13.31.28.39"/>
+  </g>
+  <g id="LWPOLYLINE-1532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2213.86" y1="215.62" x2="2216.11" y2="216.58"/>
+  </g>
+  <g id="SPLINE-36" data-name="SPLINE">
+    <path class="cls-3" d="M2215.74,216.22c.15.07.3.06.44-.02"/>
+  </g>
+  <g id="ARC-45" data-name="ARC">
+    <path class="cls-3" d="M2218.51,215.74c-.72.14-1.42.39-2.06.74"/>
+  </g>
+  <g id="ARC-46" data-name="ARC">
+    <path class="cls-3" d="M2226.1,217.8c-.57-.54-1.23-.97-1.95-1.28"/>
+  </g>
+  <g id="ARC-47" data-name="ARC">
+    <path class="cls-3" d="M2226.94,218.47c-.21-.35-.47-.67-.77-.95"/>
+  </g>
+  <g id="ARC-48" data-name="ARC">
+    <path class="cls-3" d="M2226.81,222.02c.92-.98,1.08-2.44.41-3.6"/>
+  </g>
+  <g id="ARC-49" data-name="ARC">
+    <path class="cls-3" d="M2215.82,221.86c.55.49,1.17.9,1.85,1.19"/>
+  </g>
+  <g id="SPLINE-37" data-name="SPLINE">
+    <path class="cls-3" d="M2215.63,221.83c-.11-.1-.27-.15-.42-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1533" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2215.46" y1="221.7" x2="2212.91" y2="222.34"/>
+  </g>
+  <g id="SPLINE-38" data-name="SPLINE">
+    <path class="cls-3" d="M2212.97,222.04c-.16.03-.29.15-.35.3"/>
+  </g>
+  <g id="SPLINE-39" data-name="SPLINE">
+    <path class="cls-3" d="M2212.61,222.34c-.05.15-.03.33.07.46"/>
+  </g>
+  <g id="ARC-50" data-name="ARC">
+    <path class="cls-3" d="M2218.57,212.24c-1.3.19-2.56.59-3.74,1.17"/>
+  </g>
+  <g id="LWPOLYLINE-1534" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2215.79" y1="221.7" x2="2215.79" y2="221.7"/>
+  </g>
+  <g id="LWPOLYLINE-1535" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2212.58" y1="222.67" x2="2212.58" y2="222.67"/>
+  </g>
+  <g id="LWPOLYLINE-1536" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2192.41" y1="234.83" x2="2194.01" y2="235.15"/>
+  </g>
+  <g id="LWPOLYLINE-1537" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2192.42 234.83 2192.09 234.83 2191.77 235.15 2191.45 235.79 2194.65 236.11 2194.98 235.47 2194.65 235.15 2194.01 235.15 2194.01 234.83"/>
+  </g>
+  <g id="ARC-51" data-name="ARC">
+    <path class="cls-3" d="M2194.55,234.2c-.26-.03-.5.16-.53.43"/>
+  </g>
+  <g id="ARC-52" data-name="ARC">
+    <path class="cls-3" d="M2194.73,232.6c-1.14-.13-2.17.69-2.3,1.83,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1538" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2235.63" y1="230.35" x2="2239.16" y2="198.33"/>
+  </g>
+  <g id="LWPOLYLINE-1539" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2237.56" y1="198.33" x2="2234.03" y2="230.35"/>
+  </g>
+  <g id="LWPOLYLINE-1540" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2239.8 198.01 2240.12 198.01 2240.12 198.34 2240.12 198.65 2240.76 198.65 2241.07 195.77 2240.43 195.46 2240.12 195.77 2240.12 196.41 2239.8 196.41"/>
+  </g>
+  <g id="ARC-53" data-name="ARC">
+    <path class="cls-3" d="M2239.69,197.7c-.26-.03-.5.16-.53.43"/>
+  </g>
+  <g id="LWPOLYLINE-1541" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2240.12" y1="198.01" x2="2240.12" y2="196.41"/>
+  </g>
+  <g id="ARC-54" data-name="ARC">
+    <path class="cls-3" d="M2239.87,196.11c-1.14-.13-2.17.69-2.3,1.83,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1542" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2220.03,226.78c.5.14,1.01.26,1.52.37l12.49,1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1543" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2235.95,214.02l-12.8-1.6c-1.57-.14-3.14-.08-4.69.19"/>
+  </g>
+  <g id="LWPOLYLINE-1544" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2235.63 228.75 2237.24 229.07 2237.88 224.91 2238.2 221.7 2238.51 218.5 2238.83 214.34 2237.24 214.02"/>
+  </g>
+  <g id="LWPOLYLINE-1545" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2235.95" y1="232.59" x2="2236.28" y2="230.99"/>
+  </g>
+  <g id="LWPOLYLINE-1546" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2235.95 232.59 2235.95 233.23 2236.28 233.55 2236.91 233.55"/>
+  </g>
+  <g id="LWPOLYLINE-1547" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2236.28" y1="230.99" x2="2235.95" y2="230.99"/>
+  </g>
+  <g id="LWPOLYLINE-1548" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2236.91 233.55 2237.24 230.35 2236.59 230.35 2236.28 230.67 2236.28 230.99"/>
+  </g>
+  <g id="ARC-55" data-name="ARC">
+    <path class="cls-3" d="M2235.32,230.46c-.03.26.16.5.43.53"/>
+  </g>
+  <g id="ARC-56" data-name="ARC">
+    <path class="cls-3" d="M2233.73,230.27c-.13,1.14.69,2.17,1.83,2.3,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1549" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2227.31 238.67 2227.31 239 2226.67 239 2226.35 239 2226.35 239.64 2229.56 239.95 2229.56 239.31 2229.23 239 2228.91 239 2228.91 238.67"/>
+  </g>
+  <g id="LWPOLYLINE-1550" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2227.31" y1="238.99" x2="2228.91" y2="238.99"/>
+  </g>
+  <g id="ARC-57" data-name="ARC">
+    <path class="cls-3" d="M2228.58,238.75c.13-1.14-.69-2.17-1.83-2.3,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-58" data-name="ARC">
+    <path class="cls-3" d="M2191.93,251.07c-4.23-5.26-10.37-8.63-17.08-9.36"/>
+  </g>
+  <g id="ARC-59" data-name="ARC">
+    <path class="cls-3" d="M2215.23,267.76c.53.11,1.06.19,1.59.26"/>
+  </g>
+  <g id="LWPOLYLINE-1551" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2217.06 268.13 2232.75 270.05 2233.07 265.57 2233.39 262.68 2233.71 259.49 2234.35 255 2218.67 253.4"/>
+  </g>
+  <g id="LWPOLYLINE-1552" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2208.1" y1="263.33" x2="2208.1" y2="263.33"/>
+  </g>
+  <g id="LWPOLYLINE-1553" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2210.98" y1="262.69" x2="2210.98" y2="262.69"/>
+  </g>
+  <g id="ARC-60" data-name="ARC">
+    <path class="cls-3" d="M2218.59,253.19c-1.54-.18-3.09-.15-4.62.08"/>
+  </g>
+  <g id="SPLINE-40" data-name="SPLINE">
+    <path class="cls-3" d="M2208.93,255.42c-.13.1-.2.27-.18.44"/>
+  </g>
+  <g id="SPLINE-41" data-name="SPLINE">
+    <path class="cls-3" d="M2208.75,255.86c0,.17.12.31.28.38"/>
+  </g>
+  <g id="LWPOLYLINE-1554" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2209.06" y1="256.28" x2="2211.3" y2="257.56"/>
+  </g>
+  <g id="SPLINE-42" data-name="SPLINE">
+    <path class="cls-3" d="M2211.26,257.2c.14.06.3.05.43-.02"/>
+  </g>
+  <g id="ARC-61" data-name="ARC">
+    <path class="cls-3" d="M2213.71,256.72c-.72.14-1.42.39-2.06.74"/>
+  </g>
+  <g id="ARC-62" data-name="ARC">
+    <path class="cls-3" d="M2222.14,259.45c-.21-.35-.47-.67-.77-.95"/>
+  </g>
+  <g id="ARC-63" data-name="ARC">
+    <path class="cls-3" d="M2222.01,263c.91-.98,1.08-2.44.41-3.6"/>
+  </g>
+  <g id="ARC-64" data-name="ARC">
+    <path class="cls-3" d="M2211.02,262.52c.55.49,1.17.9,1.85,1.19"/>
+  </g>
+  <g id="SPLINE-43" data-name="SPLINE">
+    <path class="cls-3" d="M2211.14,262.49c-.11-.1-.28-.15-.42-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1555" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2210.66" y1="262.69" x2="2208.42" y2="263.01"/>
+  </g>
+  <g id="SPLINE-44" data-name="SPLINE">
+    <path class="cls-3" d="M2208.16,263.02c-.16.03-.29.15-.35.3"/>
+  </g>
+  <g id="SPLINE-45" data-name="SPLINE">
+    <path class="cls-3" d="M2207.81,263.32c-.05.15-.03.33.07.46"/>
+  </g>
+  <g id="LWPOLYLINE-1556" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2224.43 265.25 2226.03 265.57 2226.67 258.2 2225.07 257.88"/>
+  </g>
+  <g id="ARC-65" data-name="ARC">
+    <path class="cls-3" d="M2224.86,257.77c-.37-.59-.81-1.13-1.31-1.61"/>
+  </g>
+  <g id="ARC-66" data-name="ARC">
+    <path class="cls-3" d="M2207.88,261.23c.27.54.61,1.05,1,1.51"/>
+  </g>
+  <g id="ARC-67" data-name="ARC">
+    <path class="cls-3" d="M2209.67,256.47c-.45.35-.86.74-1.22,1.18"/>
+  </g>
+  <g id="LWPOLYLINE-1557" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2100.53" y1="232.59" x2="2034.26" y2="254.68"/>
+  </g>
+  <g id="LWPOLYLINE-1558" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2042.26,232.59l1.6-.32c-2.22.76-4.48,1.4-6.77,1.93"/>
+  </g>
+  <g id="LWPOLYLINE-1559" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2041.62" y1="230.67" x2="2046.74" y2="229.06"/>
+  </g>
+  <g id="LWPOLYLINE-1560" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2052.18 226.83 2043.86 229.71 2035.85 232.27"/>
+  </g>
+  <g id="SPLINE-46" data-name="SPLINE">
+    <path class="cls-3" d="M2041.94,232.48c.03.08.12.13.2.1"/>
+  </g>
+  <g id="SPLINE-47" data-name="SPLINE">
+    <path class="cls-3" d="M2041.41,230.68c-.08.02-.13.12-.1.2"/>
+  </g>
+  <g id="LWPOLYLINE-1561" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2041.94" y1="232.59" x2="2041.61" y2="230.99"/>
+  </g>
+  <g id="ARC-68" data-name="ARC">
+    <path class="cls-3" d="M2035.54,231.9c-1.15.61-1.61,2.02-1.04,3.19"/>
+  </g>
+  <g id="LWPOLYLINE-1562" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.14" y1="235.15" x2="2043.53" y2="231.31"/>
+  </g>
+  <g id="LWPOLYLINE-1563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2045.46" y1="231.63" x2="2047.38" y2="230.99"/>
+  </g>
+  <g id="SPLINE-48" data-name="SPLINE">
+    <path class="cls-3" d="M2046.73,229.18c-.02-.08-.12-.13-.2-.1"/>
+  </g>
+  <g id="SPLINE-49" data-name="SPLINE">
+    <path class="cls-3" d="M2046.95,230.98c.08-.03.13-.12.1-.2"/>
+  </g>
+  <g id="LWPOLYLINE-1564" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2047.38" y1="230.67" x2="2046.74" y2="229.39"/>
+  </g>
+  <g id="SPLINE-50" data-name="SPLINE">
+    <path class="cls-3" d="M2043.58,231.08c.02.06.05.11.08.17"/>
+  </g>
+  <g id="SPLINE-51" data-name="SPLINE">
+    <path class="cls-3" d="M2043.54,230.77c0,.1,0,.21.04.31"/>
+  </g>
+  <g id="ARC-69" data-name="ARC">
+    <path class="cls-3" d="M2043.63,230.47c-.05.09-.08.19-.08.3"/>
+  </g>
+  <g id="SPLINE-52" data-name="SPLINE">
+    <path class="cls-3" d="M2043.81,230.22c-.08.07-.15.15-.19.25"/>
+  </g>
+  <g id="SPLINE-53" data-name="SPLINE">
+    <path class="cls-3" d="M2044.09,230.07c-.1.03-.19.08-.28.15"/>
+  </g>
+  <g id="ARC-70" data-name="ARC">
+    <path class="cls-3" d="M2044.4,230.03c-.1,0-.21,0-.31.03"/>
+  </g>
+  <g id="SPLINE-54" data-name="SPLINE">
+    <path class="cls-3" d="M2044.7,230.11c-.1-.05-.2-.08-.3-.08"/>
+  </g>
+  <g id="SPLINE-55" data-name="SPLINE">
+    <path class="cls-3" d="M2044.95,230.31c-.07-.08-.15-.15-.25-.19"/>
+  </g>
+  <g id="ARC-71" data-name="ARC">
+    <path class="cls-3" d="M2043.27,231.18c.07.2.19.38.36.52"/>
+  </g>
+  <g id="SPLINE-56" data-name="SPLINE">
+    <path class="cls-3" d="M2043.22,230.75c-.01.15,0,.29.05.44"/>
+  </g>
+  <g id="SPLINE-57" data-name="SPLINE">
+    <path class="cls-3" d="M2043.34,230.32c-.07.13-.11.28-.12.43"/>
+  </g>
+  <g id="SPLINE-58" data-name="SPLINE">
+    <path class="cls-3" d="M2044.84,229.83c-.13-.07-.28-.1-.43-.12"/>
+  </g>
+  <g id="SPLINE-59" data-name="SPLINE">
+    <path class="cls-3" d="M2045.16,234.82c.08.26.36.39.61.3"/>
+  </g>
+  <g id="SPLINE-60" data-name="SPLINE">
+    <path class="cls-3" d="M2045.77,235.12c.25-.08.39-.35.3-.6"/>
+  </g>
+  <g id="LWPOLYLINE-1565" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2046.1,234.83l-.96-4.16c-.04-.13-.11-.26-.19-.36"/>
+  </g>
+  <g id="ARC-72" data-name="ARC">
+    <path class="cls-3" d="M2054.7,228.48c-.23-1.28-1.44-2.14-2.73-1.94"/>
+  </g>
+  <g id="ARC-73" data-name="ARC">
+    <path class="cls-3" d="M2055.38,234.1c-.02-1.83-.33-3.65-.9-5.4"/>
+  </g>
+  <g id="LWPOLYLINE-1566" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2081.32" y1="220.11" x2="2079.72" y2="220.74"/>
+  </g>
+  <g id="ARC-74" data-name="ARC">
+    <path class="cls-3" d="M2079.68,221.33c2.24-.76,4.44-1.63,6.59-2.61"/>
+  </g>
+  <g id="LWPOLYLINE-1567" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.68" y1="218.18" x2="2075.87" y2="220.11"/>
+  </g>
+  <g id="LWPOLYLINE-1568" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2070.11 221.38 2078.12 218.82 2086.12 215.94"/>
+  </g>
+  <g id="SPLINE-61" data-name="SPLINE">
+    <path class="cls-3" d="M2087.66,219.27c-.19-.59-.83-.9-1.41-.72"/>
+  </g>
+  <g id="SPLINE-62" data-name="SPLINE">
+    <path class="cls-3" d="M2081.21,220.1c.08-.03.13-.12.1-.2"/>
+  </g>
+  <g id="SPLINE-63" data-name="SPLINE">
+    <path class="cls-3" d="M2080.67,218.29c-.03-.08-.12-.13-.2-.1"/>
+  </g>
+  <g id="LWPOLYLINE-1569" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2081.64" y1="220.11" x2="2081" y2="218.5"/>
+  </g>
+  <g id="ARC-75" data-name="ARC">
+    <path class="cls-3" d="M2088.64,217.59c-.23-1.28-1.44-2.14-2.73-1.94"/>
+  </g>
+  <g id="LWPOLYLINE-1570" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2080.36,223.95l-.96-3.84c.03-.17.01-.35-.05-.51-.05-.14-.12-.27-.21-.38-.1-.11-.22-.21-.35-.27"/>
+  </g>
+  <g id="LWPOLYLINE-1571" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2078.12" y1="221.38" x2="2076.51" y2="222.02"/>
+  </g>
+  <g id="SPLINE-64" data-name="SPLINE">
+    <path class="cls-3" d="M2075.66,219.79c-.08.03-.13.12-.1.2"/>
+  </g>
+  <g id="SPLINE-65" data-name="SPLINE">
+    <path class="cls-3" d="M2075.88,221.6c.03.08.12.13.2.1"/>
+  </g>
+  <g id="LWPOLYLINE-1572" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2076.19" y1="221.7" x2="2075.56" y2="220.1"/>
+  </g>
+  <g id="SPLINE-66" data-name="SPLINE">
+    <path class="cls-3" d="M2079.07,219.87c0-.06-.02-.12-.03-.18"/>
+  </g>
+  <g id="SPLINE-67" data-name="SPLINE">
+    <path class="cls-3" d="M2079.04,219.69c-.04-.1-.08-.19-.15-.28"/>
+  </g>
+  <g id="SPLINE-68" data-name="SPLINE">
+    <path class="cls-3" d="M2078.88,219.42c-.07-.08-.15-.15-.25-.19"/>
+  </g>
+  <g id="SPLINE-69" data-name="SPLINE">
+    <path class="cls-3" d="M2078.63,219.23c-.1-.05-.2-.08-.3-.08"/>
+  </g>
+  <g id="SPLINE-70" data-name="SPLINE">
+    <path class="cls-3" d="M2078.34,219.15c-.1,0-.21,0-.31.04"/>
+  </g>
+  <g id="SPLINE-71" data-name="SPLINE">
+    <path class="cls-3" d="M2078.02,219.18c-.1.03-.19.08-.28.15"/>
+  </g>
+  <g id="SPLINE-72" data-name="SPLINE">
+    <path class="cls-3" d="M2077.75,219.34c-.08.07-.15.15-.19.25"/>
+  </g>
+  <g id="SPLINE-73" data-name="SPLINE">
+    <path class="cls-3" d="M2077.56,219.58c-.05.1-.08.2-.08.3"/>
+  </g>
+  <g id="ARC-76" data-name="ARC">
+    <path class="cls-3" d="M2077.48,219.88c0,.1,0,.21.03.31"/>
+  </g>
+  <g id="SPLINE-74" data-name="SPLINE">
+    <path class="cls-3" d="M2078.78,218.94c-.13-.07-.28-.1-.43-.12"/>
+  </g>
+  <g id="SPLINE-75" data-name="SPLINE">
+    <path class="cls-3" d="M2078.36,218.83c-.15,0-.29,0-.43.05"/>
+  </g>
+  <g id="SPLINE-76" data-name="SPLINE">
+    <path class="cls-3" d="M2077.27,219.44c-.07.13-.11.28-.12.43"/>
+  </g>
+  <g id="ARC-77" data-name="ARC">
+    <path class="cls-3" d="M2077.16,219.86c-.03.36.12.71.4.94"/>
+  </g>
+  <g id="SPLINE-77" data-name="SPLINE">
+    <path class="cls-3" d="M2079.1,223.93c.08.26.36.39.61.3"/>
+  </g>
+  <g id="SPLINE-78" data-name="SPLINE">
+    <path class="cls-3" d="M2079.71,224.24c.25-.08.39-.35.3-.6"/>
+  </g>
+  <g id="LWPOLYLINE-1573" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2079.4" y1="224.27" x2="2077.8" y2="220.43"/>
+  </g>
+  <g id="ARC-78" data-name="ARC">
+    <path class="cls-3" d="M2074.87,232.55c1.28.89,2.74,1.5,4.27,1.78"/>
+  </g>
+  <g id="SPLINE-79" data-name="SPLINE">
+    <path class="cls-3" d="M2224.74,331.81c.07-.61-.38-1.17-.99-1.24"/>
+  </g>
+  <g id="ARC-79" data-name="ARC">
+    <path class="cls-3" d="M2223.75,330.56c-.62-.07-1.17.38-1.24,1s.38,1.17,1,1.24,1.16-.37,1.24-.98"/>
+  </g>
+  <g id="LWPOLYLINE-1574" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2226.03" y1="327.04" x2="2222.83" y2="326.72"/>
+  </g>
+  <g id="LWPOLYLINE-1575" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2212.58 336.33 2213.22 336.64 2214.18 337.28 2214.82 337.61 2215.79 337.61 2216.75 337.92 2218.02 338.25 2219.62 338.56 2221.55 338.88 2224.75 339.21 2225.71 332.16 2226.35 324.8 2223.14 324.48"/>
+  </g>
+  <g id="LWPOLYLINE-1576" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2225.07 337.28 2221.87 336.65 2222.19 331.84"/>
+  </g>
+  <g id="LWPOLYLINE-1577" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2221.87 334.4 2221.87 334.73 2221.87 335.04 2221.87 335.36 2221.54 335.36 2221.54 335.68 2221.23 335.68 2220.91 335.68 2220.59 335.68 2220.26 335.68 2219.94 335.68 2219.62 335.68 2219.31 335.68 2218.99 335.68 2218.67 335.68 2218.35 335.68 2218.03 335.68 2217.7 335.68 2217.39 335.68 2217.06 335.68 2216.75 335.68 2216.42 335.68 2216.11 335.68 2215.79 335.68 2215.46 335.68 2215.14 335.68 2214.82 335.68 2214.5 335.36 2214.18 335.36 2213.87 335.36 2213.54 335.36 2213.23 335.04 2212.9 335.04 2212.58 334.73 2212.58 334.4 2212.26 334.4 2212.26 334.08 2212.26 333.76 2212.26 333.44 2212.26 333.12 2211.94 332.8 2211.94 332.48 2211.94 331.84 2211.94 331.2 2212.26 330.56"/>
+  </g>
+  <g id="LWPOLYLINE-1578" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2221.87 336.64 2220.91 336.64 2220.26 336.97 2219.62 336.97 2219.31 336.97 2218.67 336.97 2218.03 336.97 2217.7 336.97 2217.06 336.97 2216.75 336.64 2216.11 336.64 2215.79 336.64 2215.46 336.64 2214.82 336.64 2214.5 336.64 2214.18 336.64 2213.87 336.64 2213.54 336.64 2213.23 336.64 2212.9 336.64 2212.58 336.64 2212.26 336.32 2211.94 336.32 2211.62 336 2211.31 336 2211.31 335.37 2210.98 335.04 2210.98 334.4 2210.66 333.44 2210.66 332.16 2210.98 330.56 2210.98 328.96 2211.31 327.68 2211.62 326.72 2211.94 326.08 2212.26 325.44 2212.58 325.11 2212.9 325.11 2213.23 325.11 2213.23 324.8 2213.54 324.8 2213.87 324.8 2214.18 324.8 2214.5 324.8 2214.82 325.11 2215.14 325.11 2215.46 325.11 2215.79 325.11 2216.42 325.11 2216.75 325.11 2217.06 325.44 2217.39 325.44 2218.03 325.44 2218.35 325.76 2218.99 325.76 2219.31 325.76 2219.94 325.76 2220.26 326.08 2220.91 326.08 2221.54 326.4 2222.19 326.4 2222.83 326.72"/>
+  </g>
+  <g id="LWPOLYLINE-1579" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2223.15 324.48 2221.23 324.48 2219.63 324.48 2218.35 324.48 2217.39 324.48 2216.43 324.48 2215.46 324.48 2214.51 324.79 2213.87 324.79"/>
+  </g>
+  <g id="LWPOLYLINE-1580" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2222.51 328.96 2222.51 328.63 2222.51 328.32 2222.51 328 2222.51 327.68 2222.19 327.68 2221.87 327.68 2221.54 327.36 2221.23 327.36 2220.91 327.36 2220.59 327.36 2220.59 327.04 2220.26 327.04 2219.95 327.04 2219.63 327.04 2219.31 327.04 2218.99 326.72 2218.67 326.72 2218.34 326.72 2218.02 326.72 2217.71 326.72 2217.39 326.4 2217.06 326.4 2216.75 326.4 2216.42 326.4 2216.11 326.4 2215.79 326.4 2215.46 326.4 2215.14 326.4 2214.82 326.4 2214.5 326.4 2214.19 326.4 2213.87 326.4 2213.54 326.72 2213.23 326.72 2213.23 327.04 2212.9 327.36 2212.9 327.68 2212.58 328 2212.58 328.32 2212.58 328.63 2212.26 329.28 2212.26 329.92 2212.26 330.56"/>
+  </g>
+  <g id="LWPOLYLINE-1581" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2222.83" y1="326.72" x2="2222.19" y2="331.84"/>
+  </g>
+  <g id="CIRCLE-22" data-name="CIRCLE">
+    <circle class="cls-3" cx="2227.79" cy="297.11" r="1.12"/>
+  </g>
+  <g id="LWPOLYLINE-1582" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2228.91" y1="302.39" x2="2225.71" y2="302.06"/>
+  </g>
+  <g id="LWPOLYLINE-1583" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2217.71 290.22 2218.35 289.9 2219.31 289.9 2220.26 289.58 2221.23 289.58 2222.19 289.58 2223.47 289.58 2225.07 289.58 2226.99 289.58 2230.19 290.22 2229.55 297.26 2228.59 304.63 2225.39 304.3"/>
+  </g>
+  <g id="LWPOLYLINE-1584" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2230.19 292.14 2226.67 291.82 2226.35 296.94"/>
+  </g>
+  <g id="LWPOLYLINE-1585" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2226.67 294.38 2226.67 294.06 2226.35 293.74 2226.35 293.42 2226.35 293.1 2226.35 292.78 2226.03 292.78 2225.71 292.78 2225.39 292.78 2225.07 292.46 2224.75 292.46 2224.43 292.46 2224.11 292.46 2223.79 292.14 2223.47 292.14 2223.15 292.14 2222.83 292.14 2222.51 292.14 2222.19 291.82 2221.87 291.82 2221.55 291.82 2221.23 291.82 2220.91 291.82 2220.59 291.82 2220.26 291.5 2219.94 291.5 2219.63 291.5 2219.31 291.5 2218.99 291.5 2218.67 291.5 2218.34 291.5 2218.03 291.5 2218.03 291.82 2217.71 291.82 2217.39 291.82 2217.39 292.14 2217.06 292.14 2217.06 292.46 2216.75 292.78 2216.75 293.1 2216.75 293.42 2216.42 293.74 2216.42 294.06 2216.42 294.38 2216.1 295.02 2216.1 295.66"/>
+  </g>
+  <g id="LWPOLYLINE-1586" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2226.67 291.82 2226.03 291.82 2225.39 291.5 2225.07 291.5 2224.43 291.18 2223.79 291.18 2223.47 291.18 2222.83 290.86 2222.51 290.86 2221.87 290.86 2221.55 290.54 2220.91 290.54 2220.59 290.54 2220.26 290.54 2219.94 290.22 2219.63 290.22 2219.31 290.22 2218.99 290.22 2218.67 290.22 2218.34 290.22 2218.03 290.22 2217.71 290.22 2217.39 290.22 2217.06 290.22 2216.75 290.22 2216.42 290.54 2216.1 290.86 2216.1 291.18 2215.79 291.82 2215.46 292.78 2215.14 294.06 2214.83 295.66 2214.83 297.27 2214.83 298.54 2214.83 299.5 2214.83 300.15 2215.14 300.79 2215.46 301.1 2215.46 301.43 2215.79 301.43 2216.1 301.43 2216.1 301.74 2216.42 301.74 2216.75 301.74 2217.06 301.74 2217.39 301.74 2217.71 302.07 2218.03 302.07 2218.67 302.07 2218.99 302.07 2219.31 302.07 2219.63 302.07 2220.26 302.07 2220.59 302.07 2221.23 302.07 2221.55 302.07 2222.19 302.07 2222.51 302.07 2223.15 302.07 2223.79 302.07 2224.43 302.07 2225.07 302.07 2225.71 302.07"/>
+  </g>
+  <g id="LWPOLYLINE-1587" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2225.39 304.31 2223.47 303.98 2221.87 303.67 2220.59 303.34 2219.63 303.03 2218.99 302.71 2218.02 302.39 2217.06 302.06 2216.42 301.75"/>
+  </g>
+  <g id="LWPOLYLINE-1588" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2226.03 299.5 2225.71 299.83 2225.71 300.14 2225.71 300.47 2225.39 300.78 2225.07 300.78 2224.75 300.78 2224.43 300.78 2224.11 301.1 2223.79 301.1 2223.47 301.1 2223.15 301.1 2222.83 301.1 2222.5 301.1 2222.19 300.78 2221.87 300.78 2221.55 300.78 2221.23 300.78 2220.91 300.78 2220.58 300.78 2220.27 300.78 2219.95 300.78 2219.62 300.78 2219.31 300.78 2218.98 300.78 2218.67 300.78 2218.35 300.78 2218.03 300.78 2217.7 300.47 2217.39 300.47 2217.06 300.47 2217.06 300.14 2216.75 300.14 2216.75 299.83 2216.42 299.83 2216.42 299.5 2216.11 299.18 2216.11 298.87 2216.11 298.54 2216.11 298.22 2216.11 297.9 2216.11 297.58 2216.11 297.26 2216.11 296.62 2216.11 295.66"/>
+  </g>
+  <g id="LWPOLYLINE-1589" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2225.71" y1="302.07" x2="2226.35" y2="296.94"/>
+  </g>
+  <g id="LWPOLYLINE-1590" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2063.39 292.14 2063.39 277.41 2068.83 292.14 2074.59 277.41 2074.59 292.14"/>
+  </g>
+  <g id="LWPOLYLINE-1591" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2089.32 292.14 2080.36 292.14 2080.36 277.41 2089.32 277.41"/>
+  </g>
+  <g id="LWPOLYLINE-1592" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.36" y1="284.46" x2="2085.8" y2="284.46"/>
+  </g>
+  <g id="LWPOLYLINE-1593" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2093.8 292.14 2093.8 277.41 2103.41 292.14 2103.41 277.41"/>
+  </g>
+  <g id="LWPOLYLINE-1594" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="983.8 560.76 984.44 562.36 983.16 562.68 982.84 561.08 983.8 560.76"/>
+  </g>
+  <g id="LWPOLYLINE-1595" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="982.84 561.08 983.17 562.68 981.24 563.32 980.6 561.72 982.84 561.08"/>
+  </g>
+  <g id="LWPOLYLINE-1596" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="903.76 587.01 906 593.09 909.52 592.13 907.29 585.73 903.76 587.01"/>
+  </g>
+  <g id="LWPOLYLINE-1597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="980.92" y1="562.04" x2="907.6" y2="586.05"/>
+  </g>
+  <g id="LWPOLYLINE-1598" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="981.24" y1="563" x2="907.92" y2="587.33"/>
+  </g>
+  <g id="LWPOLYLINE-1599" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="827.86" y="611.77" width="1.01" height="2.03" transform="translate(-151.03 292.66) rotate(-18.39)"/>
+  </g>
+  <g id="LWPOLYLINE-1600" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="830.76" y1="611.34" x2="904.09" y2="587.33"/>
+  </g>
+  <g id="LWPOLYLINE-1601" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="831.08" y1="612.3" x2="904.41" y2="588.29"/>
+  </g>
+  <g id="LWPOLYLINE-1602" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="828.52 611.66 829.16 613.58 831.09 612.94 830.77 611.02 828.52 611.66"/>
+  </g>
+  <g id="LWPOLYLINE-1603" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="903.76 587.01 906 593.09 909.52 592.13 907.29 585.73 903.76 587.01"/>
+  </g>
+  <g id="LWPOLYLINE-1604" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1115.07 517.53 1116.99 523.94 1113.47 524.9 1111.54 518.82 1115.07 517.53"/>
+  </g>
+  <g id="LWPOLYLINE-1605" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1191.27 492.56 1191.91 494.16 1190.94 494.48 1190.3 492.88 1191.27 492.56"/>
+  </g>
+  <g id="LWPOLYLINE-1606" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1188.39" y1="493.84" x2="1115.07" y2="517.85"/>
+  </g>
+  <g id="LWPOLYLINE-1607" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1188.71" y1="494.8" x2="1115.38" y2="518.81"/>
+  </g>
+  <g id="LWPOLYLINE-1608" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1190.31 492.88 1190.95 494.49 1188.71 495.12 1188.06 493.52 1190.31 492.88"/>
+  </g>
+  <g id="LWPOLYLINE-1609" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1115.07 517.53 1116.99 523.94 1113.47 524.9 1111.54 518.82 1115.07 517.53"/>
+  </g>
+  <g id="LWPOLYLINE-1610" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1035.32" y="543.58" width="1.01" height="2.03" transform="translate(-118.77 353.76) rotate(-18.35)"/>
+  </g>
+  <g id="LWPOLYLINE-1611" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1035.99 543.47 1036.63 545.39 1038.87 544.75 1038.23 542.83 1035.99 543.47"/>
+  </g>
+  <g id="LWPOLYLINE-1612" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1115.07 517.53 1116.99 523.94 1113.47 524.9 1111.54 518.82 1115.07 517.53"/>
+  </g>
+  <g id="LWPOLYLINE-1613" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1038.23" y1="543.15" x2="1111.55" y2="519.14"/>
+  </g>
+  <g id="LWPOLYLINE-1614" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1038.55" y1="544.11" x2="1111.87" y2="520.1"/>
+  </g>
+  <g id="LWPOLYLINE-1615" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1115.07 517.53 1116.99 523.94 1113.47 524.9 1111.54 518.82 1115.07 517.53"/>
+  </g>
+  <g id="LWPOLYLINE-1616" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1319.01 450.62 1320.93 456.7 1324.46 455.74 1322.54 449.34 1319.01 450.62"/>
+  </g>
+  <g id="LWPOLYLINE-1617" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1242.49 475.59 1243.13 477.51 1244.09 476.87 1243.77 475.27 1242.49 475.59"/>
+  </g>
+  <g id="LWPOLYLINE-1618" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1245.69" y1="474.95" x2="1319.02" y2="450.94"/>
+  </g>
+  <g id="LWPOLYLINE-1619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1246.01" y1="475.91" x2="1319.34" y2="451.91"/>
+  </g>
+  <g id="LWPOLYLINE-1620" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1243.77 475.27 1244.1 476.87 1246.33 476.23 1245.69 474.63 1243.77 475.27"/>
+  </g>
+  <g id="LWPOLYLINE-1621" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1319.01 450.62 1322.54 449.34 1324.46 455.74 1320.93 456.7 1319.01 450.62 1322.54 449.34 1324.46 455.74 1320.93 456.7 1319.01 450.62 1320.93 456.7 1324.46 455.74 1322.54 449.34 1319.01 450.62"/>
+  </g>
+  <g id="LWPOLYLINE-1622" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1398.73 424.37 1399.37 425.97 1398.41 426.29 1397.77 424.69 1398.73 424.37"/>
+  </g>
+  <g id="LWPOLYLINE-1623" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1397.77 424.69 1398.41 426.29 1396.17 426.93 1395.85 425.33 1397.77 424.69"/>
+  </g>
+  <g id="LWPOLYLINE-1624" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1395.85" y1="425.65" x2="1322.53" y2="449.66"/>
+  </g>
+  <g id="LWPOLYLINE-1625" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1396.17" y1="426.61" x2="1322.85" y2="450.62"/>
+  </g>
+  <g id="LWPOLYLINE-1626" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1530 381.14 1531.92 387.55 1528.4 388.51 1526.48 382.43 1530 381.14"/>
+  </g>
+  <g id="LWPOLYLINE-1627" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1606.19 356.17 1606.83 357.77 1605.88 358.09 1605.23 356.5 1606.19 356.17"/>
+  </g>
+  <g id="LWPOLYLINE-1628" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1603.31" y1="357.45" x2="1530" y2="381.46"/>
+  </g>
+  <g id="LWPOLYLINE-1629" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1603.63" y1="358.41" x2="1530.32" y2="382.42"/>
+  </g>
+  <g id="LWPOLYLINE-1630" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1605.24 356.49 1605.87 358.09 1603.96 358.74 1603.31 357.13 1605.24 356.49"/>
+  </g>
+  <g id="LWPOLYLINE-1631" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1530 381.14 1526.48 382.43 1528.4 388.51 1531.92 387.55 1530 381.14 1526.48 382.43 1528.4 388.51 1531.92 387.55 1530 381.14 1531.92 387.55 1528.4 388.51 1526.48 382.43 1530 381.14"/>
+  </g>
+  <g id="LWPOLYLINE-1632" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1450.28 407.4 1450.6 409 1451.87 408.68 1451.24 407.08 1450.28 407.4"/>
+  </g>
+  <g id="LWPOLYLINE-1633" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1451.24 407.08 1451.88 408.68 1453.8 408.04 1453.16 406.44 1451.24 407.08"/>
+  </g>
+  <g id="LWPOLYLINE-1634" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1453.16" y1="406.76" x2="1526.47" y2="382.75"/>
+  </g>
+  <g id="LWPOLYLINE-1635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1453.48" y1="407.72" x2="1526.79" y2="383.71"/>
+  </g>
+  <g id="LWPOLYLINE-1636" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1733.94 314.23 1736.19 320.31 1739.7 319.35 1737.46 312.95 1733.94 314.23"/>
+  </g>
+  <g id="LWPOLYLINE-1637" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1657.74 339.2 1658.38 340.81 1659.34 340.49 1658.7 338.88 1657.74 339.2"/>
+  </g>
+  <g id="LWPOLYLINE-1638" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1660.94" y1="338.56" x2="1733.94" y2="314.55"/>
+  </g>
+  <g id="LWPOLYLINE-1639" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1661.27" y1="339.52" x2="1734.26" y2="315.52"/>
+  </g>
+  <g id="LWPOLYLINE-1640" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1658.7 338.88 1659.34 340.49 1661.27 339.85 1660.62 338.25 1658.7 338.88"/>
+  </g>
+  <g id="LWPOLYLINE-1641" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1733.94 314.23 1737.46 312.95 1739.7 319.35 1736.19 320.31 1733.94 314.23 1737.46 312.95 1739.7 319.35 1736.19 320.31 1733.94 314.23 1736.19 320.31 1739.7 319.35 1737.46 312.95 1733.94 314.23"/>
+  </g>
+  <g id="LWPOLYLINE-1642" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1813.66 287.98 1814.3 289.58 1813.34 289.9 1812.7 288.3 1813.66 287.98"/>
+  </g>
+  <g id="LWPOLYLINE-1643" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1812.7 288.3 1813.34 289.9 1811.42 290.54 1810.78 288.94 1812.7 288.3"/>
+  </g>
+  <g id="LWPOLYLINE-1644" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1810.78" y1="289.26" x2="1737.46" y2="313.27"/>
+  </g>
+  <g id="LWPOLYLINE-1645" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1811.1" y1="290.22" x2="1737.78" y2="314.23"/>
+  </g>
+  <g id="LWPOLYLINE-1646" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1865.21 271.01 1865.84 272.61 1866.81 272.29 1866.16 270.69 1865.21 271.01"/>
+  </g>
+  <g id="LWPOLYLINE-1647" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1866.17 270.69 1866.81 272.29 1868.73 271.65 1868.09 270.05 1866.17 270.69"/>
+  </g>
+  <g id="LWPOLYLINE-1648" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1868.41" y1="270.37" x2="1940.77" y2="246.36"/>
+  </g>
+  <g id="LWPOLYLINE-1649" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1868.73" y1="271.33" x2="1941.09" y2="247.64"/>
+  </g>
+  <g id="LWPOLYLINE-1650" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2018.24 220.74 2018.88 222.35 2017.92 222.67 2017.28 221.07 2018.24 220.74"/>
+  </g>
+  <g id="LWPOLYLINE-1651" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2017.28 221.06 2017.92 222.67 2015.68 223.31 2015.36 221.7 2017.28 221.06"/>
+  </g>
+  <g id="LWPOLYLINE-1652" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2015.36" y1="222.03" x2="1944.29" y2="245.4"/>
+  </g>
+  <g id="LWPOLYLINE-1653" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2015.68" y1="222.99" x2="1944.61" y2="246.36"/>
+  </g>
+  <g id="CIRCLE-23" data-name="CIRCLE">
+    <circle class="cls-3" cx="2104.53" cy="388.67" r="2.72"/>
+  </g>
+  <g id="LWPOLYLINE-1654" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2104.05" y1="391.39" x2="2101.81" y2="392.03"/>
+  </g>
+  <g id="CIRCLE-24" data-name="CIRCLE">
+    <circle class="cls-3" cx="2104.53" cy="388.67" r="2.08"/>
+  </g>
+  <g id="LWPOLYLINE-1655" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2103.73,386.91l.64,1.92-1.61.64c-.11-.12-.2-.26-.28-.4"/>
+  </g>
+  <g id="LWPOLYLINE-1656" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2102.77 389.79 2104.69 389.15 2105.33 391.07"/>
+  </g>
+  <g id="SPLINE-80" data-name="SPLINE">
+    <path class="cls-3" d="M2104.93,390.71c.08-.02.16-.04.26-.07"/>
+  </g>
+  <g id="SPLINE-81" data-name="SPLINE">
+    <path class="cls-3" d="M2105.18,390.65c.08-.03.16-.06.24-.1"/>
+  </g>
+  <g id="LWPOLYLINE-1657" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2105.65 390.75 2105.01 389.15 2106.93 388.51"/>
+  </g>
+  <g id="ARC-80" data-name="ARC">
+    <path class="cls-3" d="M2106.57,388.27c-.03-.17-.09-.34-.16-.49"/>
+  </g>
+  <g id="LWPOLYLINE-1658" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2106.61 387.87 2105 388.51 2104.37 386.91"/>
+  </g>
+  <g id="ARC-81" data-name="ARC">
+    <path class="cls-3" d="M2104.13,386.63c-.08.02-.17.04-.25.07"/>
+  </g>
+  <g id="SPLINE-82" data-name="SPLINE">
+    <path class="cls-3" d="M2103.88,386.69c-.08.03-.17.06-.25.1"/>
+  </g>
+  <g id="LWPOLYLINE-1659" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2101.81 392.03 2100.53 388.19 2102.77 387.23"/>
+  </g>
+  <g id="LWPOLYLINE-1660" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2106.93 390.43 2109.17 389.79 2107.89 385.63 2105.65 386.27"/>
+  </g>
+  <g id="CIRCLE-25" data-name="CIRCLE">
+    <circle class="cls-3" cx="365.73" cy="778.62" r="2.72"/>
+  </g>
+  <g id="LWPOLYLINE-1661" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="364.93" y1="781.35" x2="362.69" y2="781.98"/>
+  </g>
+  <g id="CIRCLE-26" data-name="CIRCLE">
+    <circle class="cls-3" cx="365.73" cy="778.63" r="2.08"/>
+  </g>
+  <g id="LWPOLYLINE-1662" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="365.57" y1="778.79" x2="363.65" y2="779.42"/>
+  </g>
+  <g id="SPLINE-83" data-name="SPLINE">
+    <path class="cls-3" d="M363.69,779.03c.03.17.09.33.16.49"/>
+  </g>
+  <g id="LWPOLYLINE-1663" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="363.97 779.75 365.57 779.11 366.21 781.02"/>
+  </g>
+  <g id="SPLINE-84" data-name="SPLINE">
+    <path class="cls-3" d="M366.13,780.67c.08-.02.16-.04.26-.07"/>
+  </g>
+  <g id="SPLINE-85" data-name="SPLINE">
+    <path class="cls-3" d="M366.38,780.6c.08-.03.16-.06.24-.1"/>
+  </g>
+  <g id="LWPOLYLINE-1664" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="366.53 780.71 366.21 779.1 367.81 778.46"/>
+  </g>
+  <g id="LWPOLYLINE-1665" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M367.61,777.73c.08.13.15.27.2.41l-1.92.31-.64-1.6"/>
+  </g>
+  <g id="ARC-82" data-name="ARC">
+    <path class="cls-3" d="M365.33,776.58c-.08.02-.17.04-.25.07"/>
+  </g>
+  <g id="SPLINE-86" data-name="SPLINE">
+    <path class="cls-3" d="M365.08,776.65c-.08.03-.17.06-.25.1"/>
+  </g>
+  <g id="LWPOLYLINE-1666" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="364.93" y1="776.87" x2="365.57" y2="778.79"/>
+  </g>
+  <g id="LWPOLYLINE-1667" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="362.69 781.99 361.41 778.15 363.65 777.51"/>
+  </g>
+  <g id="LWPOLYLINE-1668" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="367.81" y1="780.39" x2="371.01" y2="779.43"/>
+  </g>
+  <g id="LWPOLYLINE-1669" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="366.53" y1="776.54" x2="369.73" y2="775.27"/>
+  </g>
+  <g id="CIRCLE-27" data-name="CIRCLE">
+    <circle class="cls-3" cx="371.81" cy="776.7" r="2.72"/>
+  </g>
+  <g id="SPLINE-87" data-name="SPLINE">
+    <path class="cls-3" d="M2010.73,386.33c-.22.09-.39.28-.46.51"/>
+  </g>
+  <g id="ARC-83" data-name="ARC">
+    <path class="cls-3" d="M2011.41,386.36c-.21-.11-.46-.12-.68-.03"/>
+  </g>
+  <g id="CIRCLE-28" data-name="CIRCLE">
+    <circle class="cls-3" cx="2010.4" cy="385.79" r=".8"/>
+  </g>
+  <g id="CIRCLE-29" data-name="CIRCLE">
+    <circle class="cls-3" cx="2007.84" cy="394.43" r=".8"/>
+  </g>
+  <g id="LWPOLYLINE-1670" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2006.72,403.88l8.97-3.84c1.15-.44,1.72-1.74,1.28-2.89l-4.49-10.88"/>
+  </g>
+  <g id="ARC-84" data-name="ARC">
+    <path class="cls-3" d="M2012,386.27c-.44-1.06-1.65-1.56-2.71-1.12,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1671" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2009.6,385.31l-9.28,3.84c-.97.44-1.41,1.58-.97,2.56,0,0,0,0,0,0l4.48,10.88c.39,1.02,1.54,1.52,2.55,1.12,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1672" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1994.23 390.11 2012.16 382.75 2019.2 400.36 2001.6 407.72 1994.23 390.11"/>
+  </g>
+  <g id="LWPOLYLINE-1673" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2018.57 398.11 2018.89 397.79 2018.57 396.83 2017.93 396.83 2018.57 398.11"/>
+  </g>
+  <g id="LWPOLYLINE-1674" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="193" y1="1131.92" x2="204.84" y2="1102.47"/>
+  </g>
+  <g id="ARC-85" data-name="ARC">
+    <path class="cls-3" d="M204.48,1102.11c-2.59-1.02-5.3-1.69-8.07-2"/>
+  </g>
+  <g id="LWPOLYLINE-1675" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="343.16 824.57 339.32 812.4 343.16 811.12 345.08 811.12 346.68 811.76 347.64 812.73 348.92 814.32 349.88 817.2 349.88 819.12 349.57 820.41 348.92 822.01 347.32 822.97 343.16 824.57"/>
+  </g>
+  <g id="LWPOLYLINE-1676" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="355.32 820.41 351.48 808.24 363.33 817.85 359.49 805.68"/>
+  </g>
+  <g id="LWPOLYLINE-1677" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="360.13 793.51 362.69 802.16 363.97 803.76 365.57 804.4 367.49 804.4 368.45 804.08 370.05 803.12 371.01 801.52 371.01 799.6 368.13 790.96"/>
+  </g>
+  <g id="LWPOLYLINE-1678" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="376.77 801.52 372.61 789.35 377.74 787.75 379.66 787.75 380.61 788.07 381.58 789.03 381.9 790.95 381.9 792.23 381.58 792.88 379.98 794.15 374.86 795.76"/>
+  </g>
+  <g id="LWPOLYLINE-1679" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="347.96 783.27 346.36 782.63 344.44 782.31 342.2 783.27 340.6 784.23 339.63 785.83 340.28 787.11 341.24 788.07 341.88 788.39 343.16 788.71 347 788.71 348.28 788.71 349.24 789.35 350.2 790.32 350.52 791.91 349.88 793.52 348.28 794.47 346.04 795.44 344.12 795.44 342.52 794.47"/>
+  </g>
+  <g id="LWPOLYLINE-1680" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="354.68 792.55 350.84 780.39 355.97 778.79 357.88 778.79 358.52 779.11 359.49 780.06 360.13 781.67 359.8 783.27 359.49 783.91 357.88 784.87 352.76 786.79"/>
+  </g>
+  <g id="LWPOLYLINE-1681" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2022.09 395.23 2018.25 383.39 2022.4 382.1 2024.33 382.1 2025.61 382.74 2026.57 383.7 2027.85 385.31 2028.81 388.19 2028.81 390.11 2028.49 391.39 2027.85 392.99 2026.25 393.96 2022.09 395.23"/>
+  </g>
+  <g id="LWPOLYLINE-1682" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2034.25 391.39 2030.41 379.23 2037.78 376.98"/>
+  </g>
+  <g id="LWPOLYLINE-1683" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2032.33" y1="384.99" x2="2036.82" y2="383.71"/>
+  </g>
+  <g id="LWPOLYLINE-1684" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2086.12 390.43 2084.84 389.79 2082.92 389.79 2080.36 390.43 2079.07 391.71 2078.12 393.31 2078.43 394.27 2079.39 395.23 2080.36 395.55 2081.64 395.88 2085.48 395.88 2086.76 396.19 2087.4 396.51 2088.36 397.48 2089 399.07 2088.36 400.68 2086.76 401.96 2084.52 402.6 2082.6 402.6 2081 401.63"/>
+  </g>
+  <g id="LWPOLYLINE-1685" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2093.16 399.71 2089 387.55 2094.44 385.95 2096.36 385.95 2097 386.27 2097.97 387.22 2098.61 389.15 2098.28 390.43 2097.97 391.07 2096.36 392.35 2091.24 393.95"/>
+  </g>
+  <g id="LWPOLYLINE-1686" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="193" y1="1131.92" x2="185.64" y2="1130.96"/>
+  </g>
+  <g id="LWPOLYLINE-1687" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="196.52" y1="1100.23" x2="189.48" y2="1099.59"/>
+  </g>
+  <g id="LWPOLYLINE-1688" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="202.61 1124.24 207.41 1111.44 212.21 1124.24"/>
+  </g>
+  <g id="LWPOLYLINE-1689" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="204.53" y1="1120.08" x2="210.61" y2="1120.08"/>
+  </g>
+  <g id="LWPOLYLINE-1690" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="216.05 1124.24 216.05 1111.44 221.5 1111.44 223.1 1112.08 223.74 1112.71 224.38 1113.99 224.38 1115.6 223.74 1116.88 223.1 1117.52 221.5 1118.16 216.05 1118.16"/>
+  </g>
+  <g id="MTEXT">
+    <text class="cls-2" transform="translate(988.9 1361.6)"><tspan x="0" y="0">Mission Street</tspan></text>
+  </g>
+  <g id="MTEXT-2" data-name="MTEXT">
+    <text class="cls-1" transform="translate(1041.5 490.2) rotate(-18.5)"><tspan x="0" y="0">Otis Street</tspan></text>
+  </g>
+  <g id="LWPOLYLINE-1691" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M216.09,1012.82s0,0,0,0c-.55-.08-.93-.58-.85-1.12.52-2.31.92-4.63,1.22-6.98"/>
+  </g>
+  <g id="LWPOLYLINE-1692" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M224.72,1012.24c1.32-.77,2.46-1.81,3.35-3.06.76-1.08,1.23-2.32,1.38-3.63.15-1.31-.03-2.64-.53-3.86"/>
+  </g>
+  <g id="LWPOLYLINE-1693" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M212.21,1012.15c.14,1.3,1.29,2.26,2.59,2.16,1.79.22,3.61.18,5.38-.14,1.61-.31,3.15-.9,4.56-1.73"/>
+  </g>
+  <g id="LWPOLYLINE-1694" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M218.26,995.22c-.61-.07-1.17.37-1.24.98,0,0,0,0,0,0-.02,2.32-.15,4.64-.39,6.94"/>
+  </g>
+  <g id="LWPOLYLINE-1695" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M214.43,1003.07c-.08.07-.15.15-.2.24-.05.09-.08.19-.1.3,0,.1,0,.21.03.31.03.1.08.2.14.28.07.08.15.15.24.2.09.05.19.08.3.1"/>
+  </g>
+  <g id="LWPOLYLINE-1696" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M229,1001.45c-.6-1.47-1.5-2.8-2.64-3.9-1.2-1.13-2.59-2.05-4.1-2.7-1.63-.75-3.35-1.24-5.13-1.47-1.26-.33-2.55.41-2.91,1.67"/>
+  </g>
+  <g id="LWPOLYLINE-1697" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M229.2,976.71c1.32-.77,2.46-1.82,3.35-3.06.76-1.08,1.23-2.33,1.38-3.63.15-1.31-.03-2.63-.53-3.85"/>
+  </g>
+  <g id="LWPOLYLINE-1698" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M233.48,965.91c-.59-1.44-1.48-2.75-2.61-3.82-1.19-1.16-2.58-2.1-4.09-2.79-1.69-.74-3.49-1.22-5.32-1.42-1.21-.3-2.43.43-2.75,1.63"/>
+  </g>
+  <g id="LWPOLYLINE-1699" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M219.58,976.04c-.14.62.24,1.23.86,1.37,0,0,0,0,0,0,4.76,1.02,9.44-2,10.46-6.76.14-.67.21-1.35.19-2.03"/>
+  </g>
+  <g id="LWPOLYLINE-1700" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M218.92,967.54c-.08.07-.15.15-.2.24-.05.09-.08.2-.1.3"/>
+  </g>
+  <g id="LWPOLYLINE-1701" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M218.65,968.38c.03.1.08.2.15.28.07.08.15.15.24.2.09.05.2.08.3.1"/>
+  </g>
+  <g id="LWPOLYLINE-1702" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M216.7,976.61c.07,1.3,1.16,2.31,2.46,2.28,1.87.17,3.76.07,5.6-.32,1.58-.29,3.09-.85,4.47-1.66"/>
+  </g>
+  <g id="LWPOLYLINE-1703" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M220.58,1077.01c-1.22-.54-2.51-.88-3.83-1.03-1.32-.15-2.65-.1-3.95.15"/>
+  </g>
+  <g id="LWPOLYLINE-1704" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M212.75,1076.39c-1.13.21-2.22.62-3.21,1.19-.65.35-1.25.78-1.79,1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1705" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M206.97,1086.25c.36.59.8,1.13,1.31,1.61.86.8,1.85,1.45,2.93,1.91,1.8.81,3.76,1.2,5.73,1.16"/>
+  </g>
+  <g id="LWPOLYLINE-1706" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M209.7,1084.57c.24.36.52.7.84.98.57.55,1.22,1.01,1.94,1.34.92.4,1.9.67,2.9.78,1,.11,2.02.08,3.01-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1707" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M213.34,1079.54c-.82.15-1.61.43-2.34.83-.35.21-.68.46-.97.75"/>
+  </g>
+  <g id="LWPOLYLINE-1708" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M219.3,1079.94c-.92-.4-1.9-.67-2.9-.78-1-.11-2.02-.08-3.01.11"/>
+  </g>
+  <g id="LWPOLYLINE-1709" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M224.03,1080.71c.06-.15.03-.33-.07-.46-.23-.34-.49-.65-.78-.95-.86-.8-1.85-1.45-2.93-1.92"/>
+  </g>
+  <g id="LWPOLYLINE-1710" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M224.86,1087.2c.6-.74.98-1.63,1.09-2.58.11-.95-.06-1.91-.49-2.76"/>
+  </g>
+  <g id="LWPOLYLINE-1711" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M213.56,1090.83c1.5.19,3.01.18,4.51-.02,1.3-.19,2.57-.59,3.75-1.17"/>
+  </g>
+  <g id="LWPOLYLINE-1712" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M223.62,1086.19c.41-.5.66-1.11.74-1.75.07-.64-.04-1.29-.33-1.87"/>
+  </g>
+  <g id="LWPOLYLINE-1713" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M229.87,1043.99c-.36-.64-.8-1.24-1.31-1.78-.27-.36-.57-.7-.9-1.01-.86-.8-1.85-1.45-2.92-1.92-1.21-.55-2.5-.91-3.82-1.08-1.32-.15-2.65-.1-3.95.15-1.14.19-2.25.57-3.26,1.14-.54.36-1.04.79-1.47,1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1714" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M222.55,1052.71c1.26-.17,2.49-.54,3.64-1.09,1.09-.52,2.05-1.27,2.83-2.19.6-.74.98-1.63,1.09-2.58.11-.95-.06-1.9-.49-2.75"/>
+  </g>
+  <g id="LWPOLYLINE-1715" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M216.65,1048.8c.92.4,1.9.67,2.9.78,1.02.13,2.04.11,3.05-.05.73-.14,1.42-.39,2.07-.74"/>
+  </g>
+  <g id="LWPOLYLINE-1716" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M214.18,1046.48c.24.36.52.7.84.99.57.54,1.23.97,1.95,1.28"/>
+  </g>
+  <g id="LWPOLYLINE-1717" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M225.3,1043.41c-.54-.51-1.17-.93-1.84-1.24-.92-.4-1.9-.67-2.9-.78-1.01-.13-2.04-.11-3.05.05-.72.16-1.4.44-2.02.83-.36.21-.68.46-.97.75"/>
+  </g>
+  <g id="LWPOLYLINE-1718" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M211.46,1048.15c.36.59.81,1.13,1.31,1.61.86.8,1.85,1.45,2.93,1.92"/>
+  </g>
+  <g id="LWPOLYLINE-1719" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M226.65,1049.46c.42-.3.8-.66,1.13-1.05.41-.5.66-1.11.74-1.75.07-.64-.04-1.29-.33-1.87"/>
+  </g>
+  <g id="LWPOLYLINE-1720" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2216.06,226.03c1.22.54,2.51.88,3.83,1.03,1.32.15,2.65.1,3.95-.15"/>
+  </g>
+  <g id="LWPOLYLINE-1721" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2223.89,226.65c1.13-.21,2.22-.61,3.21-1.19.65-.35,1.25-.78,1.79-1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1722" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2224.15,216.15c-.92-.4-1.9-.67-2.9-.78-1-.11-2.02-.08-3.01.11"/>
+  </g>
+  <g id="LWPOLYLINE-1723" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2223.3,223.51c.82-.15,1.61-.43,2.34-.83.35-.21.68-.46.97-.75"/>
+  </g>
+  <g id="LWPOLYLINE-1724" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2217.35,223.1c.92.4,1.9.67,2.9.78,1,.11,2.02.08,3.01-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1725" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2214.15,215.81c-.42.3-.8.66-1.13,1.05-.41.5-.66,1.11-.73,1.75-.06.68.08,1.36.4,1.97.27.54.61,1.05,1,1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1726" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2214.61,213.65c-1.09.52-2.05,1.27-2.82,2.19-.61.73-.99,1.63-1.09,2.58-.09.99.1,1.98.56,2.86.36.64.8,1.24,1.3,1.78.29.38.62.72.97,1.04.84.79,1.8,1.42,2.86,1.89"/>
+  </g>
+  <g id="LWPOLYLINE-1727" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2206.45,261.94c.36.64.8,1.24,1.31,1.78.27.36.57.7.9,1.01.86.8,1.85,1.45,2.93,1.92"/>
+  </g>
+  <g id="LWPOLYLINE-1728" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2211.58,267.01c1.22.53,2.51.88,3.83,1.03,1.32.15,2.65.1,3.95-.15"/>
+  </g>
+  <g id="LWPOLYLINE-1729" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2207.3,256.82c-.6.74-.98,1.63-1.08,2.58-.11.95.06,1.9.48,2.75"/>
+  </g>
+  <g id="LWPOLYLINE-1730" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2213.77,253.22c-1.26.17-2.49.54-3.64,1.09-1.13.56-2.12,1.35-2.92,2.32"/>
+  </g>
+  <g id="LWPOLYLINE-1731" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2221.61,258.47c-.57-.56-1.22-1.01-1.95-1.34-.92-.4-1.9-.67-2.9-.78-1-.11-2.02-.08-3.01.11"/>
+  </g>
+  <g id="LWPOLYLINE-1732" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2218.82,264.49c.72-.16,1.4-.44,2.02-.83.36-.21.68-.46.97-.75"/>
+  </g>
+  <g id="LWPOLYLINE-1733" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2212.86,264.08c.92.4,1.9.66,2.9.78,1,.11,2.02.08,3.01-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1734" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2219.41,267.63c1.13-.21,2.21-.61,3.2-1.19.55-.36,1.04-.79,1.48-1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1735" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2223.8,256.13c-.84-.79-1.81-1.42-2.86-1.89-1.8-.81-3.76-1.2-5.74-1.16"/>
+  </g>
+  <g id="LWPOLYLINE-1736" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2208.54,257.84c-.41.5-.66,1.11-.74,1.75-.07.64.04,1.29.33,1.87"/>
+  </g>
+  <g id="LWPOLYLINE-1737" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2037.26,234.57c-.61.12-1.01.71-.89,1.32,0,0,0,0,0,.01,1.03,4.74,5.7,7.75,10.44,6.72.15-.03.3-.07.45-.11,4.81-.93,7.95-5.59,7.02-10.4-.13-.68-.34-1.34-.62-1.96"/>
+  </g>
+  <g id="LWPOLYLINE-1738" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2040.61,243.11c1.26.9,2.7,1.53,4.22,1.83,1.29.24,2.63.15,3.88-.26,1.25-.41,2.38-1.13,3.28-2.09,1.1-1.15,1.95-2.52,2.48-4.02.58-1.52.89-3.12.91-4.75"/>
+  </g>
+  <g id="LWPOLYLINE-1739" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2034.84,235.2c.54,1.74,1.35,3.39,2.4,4.89.95,1.33,2.13,2.49,3.48,3.42"/>
+  </g>
+  <g id="LWPOLYLINE-1740" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2053.41,230.16c-.19-.59-.82-.91-1.41-.72-2.15.93-4.34,1.75-6.57,2.45"/>
+  </g>
+  <g id="LWPOLYLINE-1741" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2044.42,229.71c-.15-.01-.29,0-.43.05-.14.05-.27.12-.38.21-.11.1-.2.22-.27.35"/>
+  </g>
+  <g id="LWPOLYLINE-1742" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2045.43,231.1c.09-.35,0-.72-.24-1-.1-.11-.22-.21-.35-.28"/>
+  </g>
+  <g id="LWPOLYLINE-1743" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2078.19,221.82c-2.3.73-4.63,1.35-6.99,1.86-.54.23-.79.84-.56,1.38,1.06,4.73,5.77,7.71,10.5,6.64.66-.15,1.3-.37,1.91-.67,4.54-1.75,6.79-6.85,5.04-11.39-.05-.14-.11-.28-.17-.42"/>
+  </g>
+  <g id="LWPOLYLINE-1744" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2079.09,234.06c1.29.24,2.63.15,3.88-.26,1.25-.41,2.38-1.13,3.27-2.09"/>
+  </g>
+  <g id="LWPOLYLINE-1745" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2086.34,231.97c1.06-1.14,1.88-2.49,2.38-3.97.58-1.52.89-3.12.92-4.75-.02-1.85-.33-3.69-.9-5.45"/>
+  </g>
+  <g id="LWPOLYLINE-1746" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2077.93,218.88c-.14.05-.27.12-.38.21-.11.1-.2.22-.27.35"/>
+  </g>
+  <g id="LWPOLYLINE-1747" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2069.8,221.02c-1.15.61-1.61,2.02-1.04,3.19.57,1.78,1.42,3.46,2.5,4.99.93,1.33,2.08,2.49,3.4,3.43"/>
+  </g>
+</svg>

--- a/public/floorplans/Floor 3.svg
+++ b/public/floorplans/Floor 3.svg
@@ -1,0 +1,5657 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="LAYER_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2507.39 1410.79">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 52.94px;
+      }
+
+      .cls-1, .cls-2 {
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-2 {
+        font-size: 52.94px;
+      }
+
+      .cls-3 {
+        fill: none;
+        stroke: #000;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: .71px;
+      }
+    </style>
+  </defs>
+  <g id="LWPOLYLINE">
+    <polygon class="cls-3" points="1080.43 954.59 1080.43 958.43 1081.06 958.43 1081.06 950.11 1080.43 950.11 1080.43 953.95 1073.06 953.95 1073.06 950.11 1072.42 950.11 1072.42 958.43 1073.06 958.43 1073.06 954.59 1080.43 954.59"/>
+  </g>
+  <g id="CIRCLE">
+    <circle class="cls-3" cx="1076.42" cy="954.11" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-2" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="846.71" y="1238.89" width="45.46" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-3" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1911.88" y="1243.37" width="54.11" height="17.93"/>
+  </g>
+  <g id="LWPOLYLINE-4" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2195.55 1243.38 2144 1243.38 2144 1261.31 2201.95 1261.31"/>
+  </g>
+  <g id="LWPOLYLINE-5" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.99" y1="1257.14" x2="2144" y2="1257.14"/>
+  </g>
+  <g id="LWPOLYLINE-6" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="343.73" y1="1192.15" x2="338.29" y2="1192.15"/>
+  </g>
+  <g id="LWPOLYLINE-7" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="343.73" y1="1143.49" x2="338.29" y2="1143.49"/>
+  </g>
+  <g id="LWPOLYLINE-8" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="394.96" y="1243.37" width="54.42" height="17.93"/>
+  </g>
+  <g id="LWPOLYLINE-9" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="185.58 1243.38 216.63 1243.38 216.63 1261.31"/>
+  </g>
+  <g id="LWPOLYLINE-10" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.63" y1="1256.82" x2="394.96" y2="1256.82"/>
+  </g>
+  <g id="LWPOLYLINE-11" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.63" y1="1257.14" x2="394.96" y2="1257.14"/>
+  </g>
+  <g id="LWPOLYLINE-12" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.63" y1="1246.58" x2="394.96" y2="1246.58"/>
+  </g>
+  <g id="LWPOLYLINE-13" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.63" y1="1261.3" x2="162.21" y2="1261.3"/>
+  </g>
+  <g id="LWPOLYLINE-14" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="677.34 653.96 626.12 670.93 631.56 687.9 682.79 670.93 677.34 653.96"/>
+  </g>
+  <g id="LWPOLYLINE-15" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M423.45,742l-152.72,50.26,152.72-50.26Z"/>
+  </g>
+  <g id="CIRCLE-2" data-name="CIRCLE">
+    <circle class="cls-3" cx="1283.88" cy="660.2" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-16" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1287.89 954.59 1287.89 958.43 1288.53 958.43 1288.53 950.11 1287.89 950.11 1287.89 953.95 1280.53 953.95 1280.53 950.11 1279.88 950.11 1279.88 958.43 1280.53 958.43 1280.53 954.59 1287.89 954.59"/>
+  </g>
+  <g id="CIRCLE-3" data-name="CIRCLE">
+    <circle class="cls-3" cx="1283.88" cy="954.11" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-17" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1495.03 954.59 1495.03 958.43 1495.67 958.43 1495.67 950.11 1495.03 950.11 1495.03 953.95 1487.67 953.95 1487.67 950.11 1487.03 950.11 1487.03 958.43 1487.67 958.43 1487.67 954.59 1495.03 954.59"/>
+  </g>
+  <g id="LWPOLYLINE-18" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1704.1 954.59 1704.1 958.43 1704.74 958.43 1704.74 950.11 1704.1 950.11 1704.1 953.95 1696.73 953.95 1696.73 950.11 1696.09 950.11 1696.09 958.43 1696.73 958.43 1696.73 954.59 1704.1 954.59"/>
+  </g>
+  <g id="LWPOLYLINE-19" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1947.42 954.59 1947.42 958.43 1948.06 958.43 1948.06 950.11 1947.42 950.11 1947.42 953.95 1940.06 953.95 1940.06 950.11 1939.41 950.11 1939.41 958.43 1940.06 958.43 1940.06 954.59 1947.42 954.59"/>
+  </g>
+  <g id="CIRCLE-4" data-name="CIRCLE">
+    <circle class="cls-3" cx="1943.74" cy="954.11" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-20" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1947.42 660.68 1947.42 664.84 1948.06 664.84 1948.06 656.2 1947.42 656.2 1947.42 660.36 1940.06 660.36 1940.06 656.2 1939.41 656.2 1939.41 664.84 1940.06 664.84 1940.06 660.68 1947.42 660.68"/>
+  </g>
+  <g id="CIRCLE-5" data-name="CIRCLE">
+    <circle class="cls-3" cx="1943.42" cy="660.2" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-21" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1704.1 660.68 1704.1 664.84 1704.42 664.84 1704.42 656.2 1704.1 656.2 1704.1 660.36 1696.41 660.36 1696.41 656.2 1696.09 656.2 1696.09 664.84 1696.41 664.84 1696.41 660.68 1704.1 660.68"/>
+  </g>
+  <g id="LWPOLYLINE-22" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="873.28 954.59 873.28 958.43 873.6 958.43 873.6 950.11 873.28 950.11 873.28 953.95 865.6 953.95 865.6 950.11 865.27 950.11 865.27 958.43 865.6 958.43 865.6 954.59 873.28 954.59"/>
+  </g>
+  <g id="CIRCLE-6" data-name="CIRCLE">
+    <circle class="cls-3" cx="868.96" cy="954.11" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-23" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="665.18 954.59 665.18 958.43 665.82 958.43 665.82 950.11 665.18 950.11 665.18 953.95 657.81 953.95 657.81 950.11 657.49 950.11 657.49 958.43 657.81 958.43 657.81 954.59 665.18 954.59"/>
+  </g>
+  <g id="LWPOLYLINE-24" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="442.02 953.63 442.02 957.47 442.35 957.47 442.35 949.15 442.02 949.15 442.02 952.99 434.34 952.99 434.34 949.15 434.02 949.15 434.02 957.47 434.34 957.47 434.34 953.63 442.02 953.63"/>
+  </g>
+  <g id="CIRCLE-7" data-name="CIRCLE">
+    <circle class="cls-3" cx="438.02" cy="953.15" r="11.36"/>
+  </g>
+  <g id="LWPOLYLINE-25" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1495.03 660.68 1495.03 664.84 1495.67 664.84 1495.67 656.2 1495.03 656.2 1495.03 660.36 1487.67 660.36 1487.67 656.2 1487.03 656.2 1487.03 664.84 1487.67 664.84 1487.67 660.68 1495.03 660.68"/>
+  </g>
+  <g id="CIRCLE-8" data-name="CIRCLE">
+    <circle class="cls-3" cx="1491.03" cy="660.2" r="8.48"/>
+  </g>
+  <g id="LWPOLYLINE-26" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1287.89 660.68 1287.89 664.84 1288.21 664.84 1288.21 656.2 1287.89 656.2 1287.89 660.36 1280.2 660.36 1280.2 656.2 1279.88 656.2 1279.88 664.84 1280.2 664.84 1280.2 660.68 1287.89 660.68"/>
+  </g>
+  <g id="LWPOLYLINE-27" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1080.43 660.68 1080.43 664.84 1081.06 664.84 1081.06 656.2 1080.43 656.2 1080.43 660.36 1073.06 660.36 1073.06 656.2 1072.42 656.2 1072.42 664.84 1073.06 664.84 1073.06 660.68 1080.43 660.68"/>
+  </g>
+  <g id="CIRCLE-9" data-name="CIRCLE">
+    <circle class="cls-3" cx="1076.42" cy="660.2" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-28" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="873.28 660.68 873.28 664.84 873.6 664.84 873.6 656.2 873.28 656.2 873.28 660.36 865.6 660.36 865.6 656.2 865.27 656.2 865.27 664.84 865.6 664.84 865.6 660.68 873.28 660.68"/>
+  </g>
+  <g id="CIRCLE-10" data-name="CIRCLE">
+    <circle class="cls-3" cx="868.96" cy="660.2" r="8.49"/>
+  </g>
+  <g id="LWPOLYLINE-29" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2172.5 660.68 2172.5 664.84 2173.14 664.84 2173.14 656.2 2172.5 656.2 2172.5 660.36 2165.13 660.36 2165.13 656.2 2164.49 656.2 2164.49 664.84 2165.13 664.84 2165.13 660.68 2172.5 660.68"/>
+  </g>
+  <g id="CIRCLE-11" data-name="CIRCLE">
+    <circle class="cls-3" cx="2168.17" cy="660.2" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-30" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1929.49 460.26 1930.77 463.78 1931.09 463.78 1928.53 455.78 1928.22 455.78 1929.49 459.62 1922.13 461.86 1920.85 458.34 1920.53 458.34 1923.09 466.35 1923.73 466.35 1922.45 462.5 1929.49 460.26"/>
+  </g>
+  <g id="CIRCLE-12" data-name="CIRCLE">
+    <circle class="cls-3" cx="1925.81" cy="460.74" r="8.48"/>
+  </g>
+  <g id="LWPOLYLINE-31" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2104.3 428.57 2105.58 432.4 2104.94 432.73 2102.38 424.73 2102.7 424.4 2103.98 428.24 2111.02 426.01 2109.75 422.16 2110.39 421.84 2112.95 429.84 2112.62 430.17 2111.35 426.33 2104.3 428.57"/>
+  </g>
+  <g id="CIRCLE-13" data-name="CIRCLE">
+    <circle class="cls-3" cx="2107.34" cy="427.12" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-32" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1073.38 533.9 1074.66 537.74 1074.98 537.74 1072.42 529.74 1071.78 529.74 1073.06 533.58 1066.02 535.82 1064.74 531.98 1064.42 532.3 1066.97 540.31 1067.3 540.31 1066.02 536.46 1073.38 533.9"/>
+  </g>
+  <g id="LWPOLYLINE-33" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="658.13 670.61 659.41 674.44 660.05 674.13 657.49 666.12 656.86 666.12 658.13 669.97 651.09 672.53 649.81 668.68 649.17 668.68 652.05 676.69 652.37 676.69 651.09 672.84 658.13 670.61"/>
+  </g>
+  <g id="LWPOLYLINE-34" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="454.51 737.52 455.79 741.36 456.11 741.36 453.55 733.36 452.91 733.36 454.19 737.2 447.15 739.44 445.86 735.6 445.55 735.92 448.1 743.93 448.75 743.93 447.46 740.08 454.51 737.52"/>
+  </g>
+  <g id="LWPOLYLINE-35" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1704.1 1252.02 1704.1 1256.18 1704.42 1256.18 1704.42 1247.54 1704.1 1247.54 1704.1 1251.7 1696.41 1251.7 1696.41 1247.54 1696.09 1247.54 1696.09 1256.18 1696.41 1256.18 1696.41 1252.02 1704.1 1252.02"/>
+  </g>
+  <g id="LWPOLYLINE-36" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1287.89 1247.86 1287.89 1252.02 1288.21 1252.02 1288.21 1243.38 1287.89 1243.38 1287.89 1247.54 1280.2 1247.54 1280.2 1243.38 1279.88 1243.38 1279.88 1252.02 1280.2 1252.02 1280.2 1247.86 1287.89 1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-37" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1080.43 1247.86 1080.43 1252.02 1081.06 1252.02 1081.06 1243.38 1080.43 1243.38 1080.43 1247.54 1073.06 1247.54 1073.06 1243.38 1072.42 1243.38 1072.42 1252.02 1073.06 1252.02 1073.06 1247.86 1080.43 1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-38" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="873.28 1248.18 873.28 1252.02 873.6 1252.02 873.6 1243.7 873.28 1243.7 873.28 1247.54 865.6 1247.54 865.6 1243.7 865.27 1243.7 865.27 1252.02 865.6 1252.02 865.6 1248.18 873.28 1248.18"/>
+  </g>
+  <g id="LWPOLYLINE-39" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="657.49 1250.1 657.49 1254.26 657.82 1254.26 657.82 1245.62 657.49 1245.62 657.49 1249.78 649.81 1249.78 649.81 1245.62 649.49 1245.62 649.49 1254.26 649.81 1254.26 649.81 1250.1 657.49 1250.1"/>
+  </g>
+  <g id="LWPOLYLINE-40" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="426.02 1250.1 426.02 1254.26 426.34 1254.26 426.34 1245.62 426.02 1245.62 426.02 1249.78 418.33 1249.78 418.33 1245.62 418.01 1245.62 418.01 1254.26 418.33 1254.26 418.33 1250.1 426.02 1250.1"/>
+  </g>
+  <g id="LWPOLYLINE-41" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1947.42 1252.02 1947.42 1256.18 1948.06 1256.18 1948.06 1247.54 1947.42 1247.54 1947.42 1251.7 1940.06 1251.7 1940.06 1247.54 1939.41 1247.54 1939.41 1256.18 1940.06 1256.18 1940.06 1252.02 1947.42 1252.02"/>
+  </g>
+  <g id="LWPOLYLINE-42" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="202.86 1038.79 198.7 1038.47 198.7 1039.11 207.02 1040.07 207.35 1039.43 203.19 1039.11 204.14 1031.43 207.99 1032.07 207.99 1031.43 199.66 1030.47 199.66 1031.11 203.5 1031.43 202.86 1038.79"/>
+  </g>
+  <g id="LWPOLYLINE-43" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="228.16 815 224.32 814.68 224.32 815 232.64 815.96 232.64 815.64 228.8 815 229.44 807.64 233.6 808.28 233.6 807.64 225.28 806.68 225.28 807.31 229.12 807.64 228.16 815"/>
+  </g>
+  <g id="LWPOLYLINE-44" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2199.39 1248.5 2203.23 1248.82 2203.23 1248.18 2194.91 1247.22 2194.91 1247.86 2198.75 1248.18 2198.11 1255.86 2193.94 1255.22 2193.94 1255.86 2202.27 1256.82 2202.59 1256.18 2198.43 1255.86 2199.39 1248.5"/>
+  </g>
+  <g id="LWPOLYLINE-45" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2224.04 958.11 2220.21 957.47 2219.88 958.11 2228.52 959.07 2228.52 958.43 2224.68 958.11 2225.32 950.43 2229.17 951.06 2229.49 950.43 2220.84 949.47 2220.84 950.1 2224.68 950.43 2224.04 958.11"/>
+  </g>
+  <g id="LWPOLYLINE-46" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2254.78 663.24 2250.94 662.6 2250.62 663.24 2259.26 664.2 2259.26 663.57 2255.42 663.24 2256.06 655.88 2259.9 656.2 2259.9 655.56 2251.58 654.92 2251.58 655.24 2255.42 655.56 2254.78 663.24"/>
+  </g>
+  <g id="LWPOLYLINE-47" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2282.63 394.95 2278.79 394.62 2278.79 394.95 2287.11 395.91 2287.11 395.27 2283.27 394.95 2283.91 387.58 2288.08 387.9 2288.08 387.26 2279.43 386.62 2279.43 386.94 2283.59 387.58 2282.63 394.95"/>
+  </g>
+  <g id="LWPOLYLINE-48" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2326.81 121.85 2328.09 125.69 2328.41 125.69 2325.85 117.37 2325.54 117.69 2326.81 121.53 2319.45 123.77 2318.17 119.93 2317.85 120.25 2320.41 128.25 2321.05 127.93 2319.77 124.41 2326.81 121.85"/>
+  </g>
+  <g id="LWPOLYLINE-49" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="218.87" y1="1255.54" x2="221.11" y2="1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-50" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="221.11 1253.3 223.99 1255.86 226.87 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-51" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="226.88 1253.3 229.44 1255.86 232.31 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-52" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="232.32 1253.3 235.2 1255.86 238.08 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-53" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="238.08 1253.3 240.64 1255.86 243.52 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-54" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="243.53 1253.3 246.41 1255.86 249.28 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-55" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="249.29 1253.3 252.17 1255.86 254.73 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-56" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="254.73 1253.3 257.61 1255.86 260.49 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-57" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="260.49 1253.3 263.37 1255.86 266.25 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-58" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="266.26 1253.3 268.82 1255.86 271.69 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-59" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="271.7 1253.3 274.58 1255.86 277.46 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-60" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="277.46 1253.3 280.02 1255.86 282.9 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-61" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="282.9 1253.3 285.79 1255.86 288.66 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-62" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="288.67 1253.3 291.55 1255.86 294.11 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-63" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="294.11 1253.3 296.99 1255.86 299.87 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-64" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="299.87 1253.3 302.76 1255.86 304.68 1253.94"/>
+  </g>
+  <g id="LWPOLYLINE-65" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="216.63" y="1251.38" width="2.24" height="5.45"/>
+  </g>
+  <g id="LWPOLYLINE-66" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="304.68" y="1251.38" width="2.24" height="5.45"/>
+  </g>
+  <g id="LWPOLYLINE-67" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="392.72" y="1251.38" width="2.24" height="5.45"/>
+  </g>
+  <g id="LWPOLYLINE-68" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="392.72" y1="1251.38" x2="218.87" y2="1251.38"/>
+  </g>
+  <g id="LWPOLYLINE-69" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="306.92 1254.58 308.2 1255.86 311.08 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-70" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="311.08 1253.3 313.96 1255.86 316.84 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-71" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="316.84 1253.3 319.4 1255.86 322.28 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-72" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="322.29 1253.3 325.17 1255.86 328.04 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-73" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="328.05 1253.3 330.93 1255.86 333.49 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-74" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="333.49 1253.3 336.37 1255.86 339.25 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-75" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="339.25 1253.3 342.13 1255.86 344.69 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-76" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="344.7 1253.3 347.58 1255.86 350.45 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-77" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="350.46 1253.3 353.34 1255.86 356.22 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-78" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="356.22 1253.3 358.78 1255.86 361.66 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-79" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="361.67 1253.3 364.54 1255.86 367.42 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-80" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="367.43 1253.3 369.99 1255.86 372.87 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-81" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="372.87 1253.3 375.75 1255.86 378.63 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-82" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="378.64 1253.3 381.51 1255.86 384.07 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-83" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="384.07 1253.3 386.96 1255.86 389.83 1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-84" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="392.72" y1="1255.86" x2="392.72" y2="1255.86"/>
+  </g>
+  <g id="LWPOLYLINE-85" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="392.72" y1="1255.86" x2="389.84" y2="1253.3"/>
+  </g>
+  <g id="LWPOLYLINE-86" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="680.54 1257.14 685.03 1257.14 685.03 1238.89 662.61 1238.89 662.61 1243.37 626.76 1243.37 626.76 1261.3 680.54 1261.3 680.54 1257.14"/>
+  </g>
+  <g id="LWPOLYLINE-87" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="685.03" y1="1252.98" x2="846.71" y2="1252.98"/>
+  </g>
+  <g id="LWPOLYLINE-88" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="685.03" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-89" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="688.23" y1="1244.66" x2="763.79" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-90" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="688.23" y1="1243.69" x2="763.79" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-91" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="685.99" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-92" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="845.43" y="1243.37" width="1.28" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-93" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="843.51" y="1243.37" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-94" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="767.63" y1="1244.66" x2="843.51" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-95" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="767.63" y1="1243.69" x2="843.51" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-96" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1053.85" y="1238.89" width="45.79" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-97" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1053.85" y1="1252.98" x2="892.17" y2="1252.98"/>
+  </g>
+  <g id="LWPOLYLINE-98" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1261.31,1252.98h-161.68,161.68Z"/>
+  </g>
+  <g id="LWPOLYLINE-99" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1468.46" y1="1252.98" x2="1306.78" y2="1252.98"/>
+  </g>
+  <g id="LWPOLYLINE-100" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1733.87 1243.38 1696.73 1243.38 1696.73 1238.89 1675.93 1238.89 1675.93 1257.14 1680.09 1257.14 1680.09 1261.31 1733.87 1261.31 1733.87 1243.38"/>
+  </g>
+  <g id="LWPOLYLINE-101" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1514.25" y1="1252.98" x2="1675.92" y2="1252.98"/>
+  </g>
+  <g id="LWPOLYLINE-102" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="207.99 859.5 214.07 806.35 269.46 788.11 275.22 805.4"/>
+  </g>
+  <g id="LWPOLYLINE-103" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.66" y1="798.35" x2="425.37" y2="748.09"/>
+  </g>
+  <g id="LWPOLYLINE-104" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="273.94" y1="794.83" x2="275.22" y2="792.27"/>
+  </g>
+  <g id="LWPOLYLINE-105" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="275.22 792.27 278.74 793.87 280.66 790.35"/>
+  </g>
+  <g id="LWPOLYLINE-106" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="280.66 790.35 284.19 792.27 286.11 788.75"/>
+  </g>
+  <g id="LWPOLYLINE-107" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="286.11 788.75 289.63 790.35 291.23 786.83"/>
+  </g>
+  <g id="LWPOLYLINE-108" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="291.23 786.82 294.75 788.75 296.67 785.23"/>
+  </g>
+  <g id="LWPOLYLINE-109" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="296.67 785.22 300.19 786.82 302.11 783.3"/>
+  </g>
+  <g id="LWPOLYLINE-110" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="302.12 783.3 305.64 785.22 307.24 781.7"/>
+  </g>
+  <g id="LWPOLYLINE-111" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="307.24 781.7 311.08 783.3 312.68 779.78"/>
+  </g>
+  <g id="LWPOLYLINE-112" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="312.68 779.78 316.2 781.7 318.12 778.18"/>
+  </g>
+  <g id="LWPOLYLINE-113" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="318.12 778.18 321.64 779.78 323.24 776.26"/>
+  </g>
+  <g id="LWPOLYLINE-114" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="323.25 776.26 327.09 778.18 328.69 774.66"/>
+  </g>
+  <g id="LWPOLYLINE-115" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="328.69 774.66 332.21 776.26 334.13 772.74"/>
+  </g>
+  <g id="LWPOLYLINE-116" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="334.13 772.74 337.65 774.66 339.57 771.14"/>
+  </g>
+  <g id="LWPOLYLINE-117" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="339.57 771.13 343.09 772.74 344.69 769.22"/>
+  </g>
+  <g id="LWPOLYLINE-118" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="346.94" y1="770.5" x2="344.7" y2="769.22"/>
+  </g>
+  <g id="LWPOLYLINE-119" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="271.49" y="791.82" width="2.03" height="5.06" transform="translate(-236.72 126.56) rotate(-18.39)"/>
+  </g>
+  <g id="LWPOLYLINE-120" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="347.58 772.42 349.82 771.78 348.22 766.65 345.98 767.3 347.58 772.42"/>
+  </g>
+  <g id="LWPOLYLINE-121" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="423.13 747.77 425.06 747.13 423.46 742 421.21 742.64 423.13 747.77"/>
+  </g>
+  <g id="LWPOLYLINE-122" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.26" y1="796.43" x2="425.05" y2="747.12"/>
+  </g>
+  <g id="LWPOLYLINE-123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.66" y1="791.63" x2="423.45" y2="742"/>
+  </g>
+  <g id="LWPOLYLINE-124" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="349.18" y1="769.86" x2="350.14" y2="767.62"/>
+  </g>
+  <g id="LWPOLYLINE-125" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="350.14 767.62 353.66 769.22 355.58 765.7"/>
+  </g>
+  <g id="LWPOLYLINE-126" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="355.58 765.69 359.1 767.62 360.7 764.1"/>
+  </g>
+  <g id="LWPOLYLINE-127" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="360.7 764.09 364.22 765.69 366.15 762.17"/>
+  </g>
+  <g id="LWPOLYLINE-128" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="366.15 762.17 369.67 764.09 371.59 760.57"/>
+  </g>
+  <g id="LWPOLYLINE-129" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="371.59 760.57 375.11 762.49 376.71 758.66"/>
+  </g>
+  <g id="LWPOLYLINE-130" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="376.71 758.65 380.23 760.57 382.15 757.05"/>
+  </g>
+  <g id="LWPOLYLINE-131" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="382.15 757.05 385.68 758.97 387.6 755.13"/>
+  </g>
+  <g id="LWPOLYLINE-132" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="387.6 755.12 391.12 757.05 392.72 753.53"/>
+  </g>
+  <g id="LWPOLYLINE-133" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="392.72 753.53 396.24 755.45 398.16 751.61"/>
+  </g>
+  <g id="LWPOLYLINE-134" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="398.16 751.61 401.68 753.53 403.61 750.01"/>
+  </g>
+  <g id="LWPOLYLINE-135" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="403.61 750 407.13 751.93 408.73 748.41"/>
+  </g>
+  <g id="LWPOLYLINE-136" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="408.73 748.41 412.57 750.01 414.17 746.49"/>
+  </g>
+  <g id="LWPOLYLINE-137" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="414.17 746.49 417.69 748.41 419.61 744.89"/>
+  </g>
+  <g id="LWPOLYLINE-138" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="422.5" y1="746.17" x2="419.61" y2="744.89"/>
+  </g>
+  <g id="LWPOLYLINE-139" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="884.81 585.76 833.58 602.73 839.02 619.7 890.57 602.73 884.81 585.76"/>
+  </g>
+  <g id="LWPOLYLINE-140" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1092.27 517.57 1041.05 534.54 1046.49 551.51 1098.04 534.54 1092.27 517.57"/>
+  </g>
+  <g id="LWPOLYLINE-141" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2331.3 110.32 2279.75 127.29 2285.2 144.26"/>
+  </g>
+  <g id="LWPOLYLINE-142" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2331.3" y1="110.32" x2="2332.26" y2="113.85"/>
+  </g>
+  <g id="LWPOLYLINE-143" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2128.31,181.4l152.72-49.95-152.72,49.95Z"/>
+  </g>
+  <g id="LWPOLYLINE-144" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2285.19" y1="144.26" x2="2132.48" y2="194.52"/>
+  </g>
+  <g id="LWPOLYLINE-145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2206.43" y1="158.03" x2="2206.75" y2="157.39"/>
+  </g>
+  <g id="LWPOLYLINE-146" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2206.75 157.38 2210.28 158.99 2212.2 155.47"/>
+  </g>
+  <g id="LWPOLYLINE-147" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2212.2 155.47 2215.72 157.39 2217.32 153.87"/>
+  </g>
+  <g id="LWPOLYLINE-148" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2217.32 153.87 2220.84 155.47 2222.76 151.95"/>
+  </g>
+  <g id="LWPOLYLINE-149" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2222.76 151.94 2226.28 153.87 2228.2 150.35"/>
+  </g>
+  <g id="LWPOLYLINE-150" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2228.21 150.34 2231.73 151.94 2233.33 148.42"/>
+  </g>
+  <g id="LWPOLYLINE-151" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2233.33 148.42 2236.85 150.34 2238.77 146.82"/>
+  </g>
+  <g id="LWPOLYLINE-152" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2238.77 146.82 2242.29 148.42 2244.21 144.9"/>
+  </g>
+  <g id="LWPOLYLINE-153" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2244.21 144.9 2247.73 146.82 2249.33 143.3"/>
+  </g>
+  <g id="LWPOLYLINE-154" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2249.34 143.3 2252.86 144.9 2254.78 141.38"/>
+  </g>
+  <g id="LWPOLYLINE-155" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2254.78 141.38 2258.3 143.3 2260.22 139.78"/>
+  </g>
+  <g id="LWPOLYLINE-156" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2260.22 139.78 2263.74 141.38 2265.34 137.86"/>
+  </g>
+  <g id="LWPOLYLINE-157" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2265.35 137.86 2269.18 139.78 2270.78 136.26"/>
+  </g>
+  <g id="LWPOLYLINE-158" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2270.79 136.26 2274.31 137.86 2276.23 134.34"/>
+  </g>
+  <g id="LWPOLYLINE-159" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2276.23 134.34 2279.75 136.26 2280.07 135.62"/>
+  </g>
+  <g id="LWPOLYLINE-160" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2282.63 136.26 2280.71 136.9 2278.79 132.1 2281.03 131.46 2282.63 136.26"/>
+  </g>
+  <g id="LWPOLYLINE-161" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2207.39 161.23 2205.16 161.87 2203.56 156.75 2205.79 156.11 2207.39 161.23"/>
+  </g>
+  <g id="LWPOLYLINE-162" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2131.83 185.88 2129.91 186.52 2128.31 181.4 2130.23 180.76 2131.83 185.88"/>
+  </g>
+  <g id="LWPOLYLINE-163" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2280.71" y1="136.9" x2="2129.92" y2="186.52"/>
+  </g>
+  <g id="LWPOLYLINE-164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2278.79" y1="132.1" x2="2128.31" y2="181.4"/>
+  </g>
+  <g id="LWPOLYLINE-165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2131.19" y1="183.32" x2="2131.83" y2="181.72"/>
+  </g>
+  <g id="LWPOLYLINE-166" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2131.84 181.72 2135.36 183.64 2137.28 180.12"/>
+  </g>
+  <g id="LWPOLYLINE-167" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2137.28 180.12 2140.8 181.72 2142.72 178.2"/>
+  </g>
+  <g id="LWPOLYLINE-168" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2142.72 178.2 2146.24 180.12 2147.84 176.6"/>
+  </g>
+  <g id="LWPOLYLINE-169" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2147.84 176.6 2151.37 178.2 2153.29 174.68"/>
+  </g>
+  <g id="LWPOLYLINE-170" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2153.29 174.68 2156.81 176.6 2158.73 173.08"/>
+  </g>
+  <g id="LWPOLYLINE-171" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2158.73 173.07 2162.25 175 2163.85 171.16"/>
+  </g>
+  <g id="LWPOLYLINE-172" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2163.86 171.15 2167.69 173.07 2169.29 169.55"/>
+  </g>
+  <g id="LWPOLYLINE-173" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2169.3 169.55 2172.82 171.48 2174.74 167.64"/>
+  </g>
+  <g id="LWPOLYLINE-174" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2174.74 167.63 2178.26 169.55 2179.86 166.03"/>
+  </g>
+  <g id="LWPOLYLINE-175" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2179.86 166.03 2183.7 167.95 2185.3 164.11"/>
+  </g>
+  <g id="LWPOLYLINE-176" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2185.3 164.11 2188.82 166.03 2190.75 162.51"/>
+  </g>
+  <g id="LWPOLYLINE-177" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2190.75 162.51 2194.27 164.43 2196.19 160.91"/>
+  </g>
+  <g id="LWPOLYLINE-178" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2196.19 160.91 2199.71 162.51 2201.31 158.99"/>
+  </g>
+  <g id="LWPOLYLINE-179" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2201.31 158.99 2204.83 160.91 2204.83 160.59"/>
+  </g>
+  <g id="LWPOLYLINE-180" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="685.03" y1="1238.89" x2="846.71" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-181" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1083.63" y1="711.59" x2="1083.63" y2="667.08"/>
+  </g>
+  <g id="LWPOLYLINE-182" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1083.63" y1="653.96" x2="1083.63" y2="539.34"/>
+  </g>
+  <g id="LWPOLYLINE-183" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1280.85" y1="651.4" x2="1280.85" y2="474.35"/>
+  </g>
+  <g id="LWPOLYLINE-184" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1083.63 711.59 1056.41 711.59 1056.41 707.42"/>
+  </g>
+  <g id="LWPOLYLINE-185" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1079.47" y1="707.42" x2="1079.47" y2="669.65"/>
+  </g>
+  <g id="LWPOLYLINE-186" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1079.47" y1="651.4" x2="1079.47" y2="540.94"/>
+  </g>
+  <g id="LWPOLYLINE-187" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="344.05" y1="1246.58" x2="344.05" y2="1192.15"/>
+  </g>
+  <g id="LWPOLYLINE-188" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="344.05" y1="1143.49" x2="344.05" y2="1127.8"/>
+  </g>
+  <g id="LWPOLYLINE-189" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="338.29" y1="1246.58" x2="338.29" y2="1192.15"/>
+  </g>
+  <g id="LWPOLYLINE-190" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="338.29" y1="1143.49" x2="338.29" y2="1134.2"/>
+  </g>
+  <g id="LWPOLYLINE-191" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="333.17" y="1188.95" width="12.48" height="3.2"/>
+  </g>
+  <g id="LWPOLYLINE-192" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="333.17 1188.95 333.17 1146.69 345.65 1146.69 345.65 1143.48 333.17 1143.48 333.17 1146.69"/>
+  </g>
+  <g id="LWPOLYLINE-193" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="319.72 1146.69 251.21 1146.69 251.21 1220.32 319.72 1220.32 319.72 1188.95 331.89 1188.95 331.89 1223.53 248.33 1223.53 248.33 1143.49 331.89 1143.49 331.89 1146.69 319.72 1146.69"/>
+  </g>
+  <g id="LWPOLYLINE-194" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="265.3 1177.42 256.01 1177.42 256.01 1162.7 265.3 1162.7"/>
+  </g>
+  <g id="LWPOLYLINE-195" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="256.01" y1="1169.74" x2="261.77" y2="1169.74"/>
+  </g>
+  <g id="LWPOLYLINE-196" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="269.46 1162.69 269.46 1177.42 277.78 1177.42"/>
+  </g>
+  <g id="LWPOLYLINE-197" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="290.59 1177.42 281.3 1177.42 281.3 1162.7 290.59 1162.7"/>
+  </g>
+  <g id="LWPOLYLINE-198" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="281.3" y1="1169.74" x2="287.07" y2="1169.74"/>
+  </g>
+  <g id="LWPOLYLINE-199" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="294.75 1162.69 300.52 1177.42 306.27 1162.69"/>
+  </g>
+  <g id="LWPOLYLINE-200" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="309.8 1176.14 309.16 1176.78 309.8 1177.42 310.44 1176.78"/>
+  </g>
+  <g id="LWPOLYLINE-201" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="316.2 1165.58 317.48 1164.61 319.72 1162.7 319.72 1177.42"/>
+  </g>
+  <g id="LWPOLYLINE-202" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="198.06" y1="1134.2" x2="338.29" y2="1134.2"/>
+  </g>
+  <g id="LWPOLYLINE-203" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="344.05" y1="1127.8" x2="198.71" y2="1127.8"/>
+  </g>
+  <g id="LWPOLYLINE-204" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.58" y1="803.79" x2="426.97" y2="753.53"/>
+  </g>
+  <g id="LWPOLYLINE-205" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="434.34 752.89 454.19 813.4 524.31 790.35"/>
+  </g>
+  <g id="LWPOLYLINE-206" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="528.15" y1="787.79" x2="651.41" y2="747.12"/>
+  </g>
+  <g id="LWPOLYLINE-207" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="528.15 787.78 528.79 789.71 652.05 749.04"/>
+  </g>
+  <g id="CIRCLE-14" data-name="CIRCLE">
+    <circle class="cls-3" cx="1700.09" cy="660.2" r="9.44"/>
+  </g>
+  <g id="CIRCLE-15" data-name="CIRCLE">
+    <circle class="cls-3" cx="1700.09" cy="953.79" r="9.44"/>
+  </g>
+  <g id="CIRCLE-16" data-name="CIRCLE">
+    <circle class="cls-3" cx="1491.03" cy="954.11" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-208" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="876.8 788.75 725.69 788.75 682.79 670.93"/>
+  </g>
+  <g id="LWPOLYLINE-209" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="718" y1="779.78" x2="678.94" y2="672.21"/>
+  </g>
+  <g id="LWPOLYLINE-210" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="865.92 602.41 866.88 605.93 867.52 605.93 864.96 597.93 864.32 597.93 865.6 601.77 858.55 604.01 857.27 600.17 856.95 600.49 859.51 608.49 859.83 608.49 858.55 604.65 865.92 602.41"/>
+  </g>
+  <g id="LWPOLYLINE-211" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="882.57" y1="711.59" x2="1016.39" y2="711.59"/>
+  </g>
+  <g id="LWPOLYLINE-212" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1085.87" y1="663.56" x2="1219.05" y2="663.56"/>
+  </g>
+  <g id="LWPOLYLINE-213" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.61" y1="574.88" x2="1419.79" y2="574.88"/>
+  </g>
+  <g id="LWPOLYLINE-214" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1459.5 570.71 1459.5 574.88 1486.71 574.88"/>
+  </g>
+  <g id="LWPOLYLINE-215" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1472.3" y1="642.75" x2="1474.86" y2="642.75"/>
+  </g>
+  <g id="LWPOLYLINE-216" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1506.88" y1="642.75" x2="1509.44" y2="642.75"/>
+  </g>
+  <g id="LWPOLYLINE-217" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1472.3 642.76 1472.3 671.89 1509.44 671.89"/>
+  </g>
+  <g id="LWPOLYLINE-218" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1476.15 651.39 1476.15 667.73 1487.03 667.73"/>
+  </g>
+  <g id="LWPOLYLINE-219" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1495.68" y1="667.73" x2="1505.6" y2="667.73"/>
+  </g>
+  <g id="LWPOLYLINE-220" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1488.31" y1="513.09" x2="1621.49" y2="513.09"/>
+  </g>
+  <g id="LWPOLYLINE-221" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1661.2 508.61 1661.2 513.09 1688.09 513.09"/>
+  </g>
+  <g id="LWPOLYLINE-222" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1488.31" y1="508.61" x2="1621.49" y2="508.61"/>
+  </g>
+  <g id="LWPOLYLINE-223" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1661.2" y1="508.61" x2="1683.93" y2="508.61"/>
+  </g>
+  <g id="LWPOLYLINE-224" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.61" y1="570.72" x2="1419.79" y2="570.72"/>
+  </g>
+  <g id="LWPOLYLINE-225" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1459.5" y1="570.72" x2="1482.55" y2="570.72"/>
+  </g>
+  <g id="LWPOLYLINE-226" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1086.19" y1="659.4" x2="1219.05" y2="659.4"/>
+  </g>
+  <g id="LWPOLYLINE-227" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="882.57" y1="707.42" x2="1016.39" y2="707.42"/>
+  </g>
+  <g id="LWPOLYLINE-228" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1056.41" y1="707.42" x2="1079.46" y2="707.42"/>
+  </g>
+  <g id="LWPOLYLINE-229" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1052.89" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-230" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1050.65" y1="1244.66" x2="974.77" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1050.65" y1="1243.69" x2="974.77" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-232" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1050.65" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-233" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="892.17" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-234" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="893.13" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-235" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="895.37" y1="1244.66" x2="971.25" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-236" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="895.37" y1="1243.69" x2="971.25" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-237" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1053.85" y1="1238.89" x2="892.17" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-238" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="886.09" y1="589.93" x2="1042.33" y2="538.38"/>
+  </g>
+  <g id="LWPOLYLINE-239" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="890.57" y1="602.73" x2="1046.49" y2="551.19"/>
+  </g>
+  <g id="LWPOLYLINE-240" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1029.2 680.53 1056.42 707.43 1054.82 708.71 1027.92 681.81"/>
+  </g>
+  <g id="LWPOLYLINE-241" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1030.16 679.57 1026.96 682.77 1024.4 686.3 1022.15 690.13 1020.55 694.29 1019.28 698.78 1018.31 702.94 1018 707.42"/>
+  </g>
+  <g id="LWPOLYLINE-242" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1285.01" y1="651.08" x2="1285.01" y2="473.06"/>
+  </g>
+  <g id="LWPOLYLINE-243" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1509.44" y1="671.89" x2="1509.44" y2="642.76"/>
+  </g>
+  <g id="LWPOLYLINE-244" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1505.6" y1="667.73" x2="1505.6" y2="651.39"/>
+  </g>
+  <g id="LWPOLYLINE-245" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1231.86 632.51 1258.76 659.4 1257.48 660.68 1230.58 633.78"/>
+  </g>
+  <g id="LWPOLYLINE-246" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1232.82 631.55 1229.62 634.75 1227.06 638.59 1224.81 642.43 1222.9 646.27 1221.62 650.75 1220.98 654.92 1220.66 659.4"/>
+  </g>
+  <g id="LWPOLYLINE-247" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1248.51 466.34 1300.06 449.37 1305.5 466.34 1253.96 482.99 1248.51 466.34"/>
+  </g>
+  <g id="LWPOLYLINE-248" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1273.8 468.27 1275.08 472.1 1274.44 472.1 1271.88 464.1 1272.2 463.78 1273.48 467.63 1280.53 465.38 1279.25 461.54 1279.89 461.54 1282.45 469.54 1282.13 469.54 1280.85 465.71 1273.8 468.27"/>
+  </g>
+  <g id="LWPOLYLINE-249" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.79" y1="470.19" x2="1093.87" y2="521.73"/>
+  </g>
+  <g id="LWPOLYLINE-250" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1253.95" y1="482.99" x2="1098.03" y2="534.54"/>
+  </g>
+  <g id="LWPOLYLINE-251" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1432.6 543.82 1459.5 570.71 1458.22 572 1431 545.11"/>
+  </g>
+  <g id="LWPOLYLINE-252" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1433.24 542.86 1430.36 546.38 1427.48 549.91 1425.24 553.75 1423.64 557.58 1422.36 562.07 1421.4 566.23 1421.4 570.71"/>
+  </g>
+  <g id="LWPOLYLINE-253" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1486.71" y1="574.88" x2="1486.71" y2="406.79"/>
+  </g>
+  <g id="LWPOLYLINE-254" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1482.55" y1="570.72" x2="1482.55" y2="408.4"/>
+  </g>
+  <g id="LWPOLYLINE-255" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2062.68 489.08 2038.35 459.3 2037.06 460.58 2061.08 490.36"/>
+  </g>
+  <g id="LWPOLYLINE-256" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2063.32 488.43 2059.8 490.99 2055.96 493.23 2052.11 495.16 2047.63 496.44 2043.47 497.4 2038.99 497.72 2034.51 497.4"/>
+  </g>
+  <g id="LWPOLYLINE-257" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1261.32" y="1238.89" width="45.46" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-258" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1487.67 1247.86 1487.67 1252.02 1487.03 1252.02 1487.03 1243.38 1487.67 1243.38 1487.67 1247.54 1495.04 1247.54 1495.04 1243.38 1495.68 1243.38 1495.68 1252.02 1495.04 1252.02 1495.04 1247.86 1487.67 1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-259" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1468.46" y="1238.89" width="45.79" height="18.25"/>
+  </g>
+  <g id="LWPOLYLINE-260" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1306.78 1252.98 1468.46 1252.98 1306.78 1252.98"/>
+  </g>
+  <g id="LWPOLYLINE-261" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2075.49 194.53 2127.03 177.56 2132.47 194.53 2081.25 211.17 2075.49 194.53"/>
+  </g>
+  <g id="LWPOLYLINE-262" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2096.94 197.41 2098.21 201.25 2097.9 201.57 2095.02 193.25 2095.66 193.25 2096.94 197.09 2103.98 194.85 2102.7 191.01 2103.34 190.68 2105.9 198.69 2105.26 199.01 2104.3 195.17 2096.94 197.41"/>
+  </g>
+  <g id="LWPOLYLINE-263" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="189.42 1060.88 172.45 1207.84 168.29 1207.52 162.2 1261.3"/>
+  </g>
+  <g id="LWPOLYLINE-264" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="185.57" y1="1243.38" x2="233.92" y2="818.84"/>
+  </g>
+  <g id="LWPOLYLINE-265" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="184.94" y1="1060.56" x2="191.34" y2="1006.46"/>
+  </g>
+  <g id="LWPOLYLINE-266" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="195.5" y1="1007.1" x2="212.15" y2="860.14"/>
+  </g>
+  <g id="LWPOLYLINE-267" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M474.68,725.03l152.72-49.95-152.72,49.95Z"/>
+  </g>
+  <g id="LWPOLYLINE-268" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="629.32" y1="680.85" x2="476.6" y2="731.11"/>
+  </g>
+  <g id="LWPOLYLINE-269" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="552.8" y1="701.98" x2="553.12" y2="701.02"/>
+  </g>
+  <g id="LWPOLYLINE-270" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="553.12 701.02 556.64 702.94 558.56 699.42"/>
+  </g>
+  <g id="LWPOLYLINE-271" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="558.56 699.42 562.08 701.02 564.01 697.5"/>
+  </g>
+  <g id="LWPOLYLINE-272" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="564.01 697.5 567.53 699.42 569.13 695.9"/>
+  </g>
+  <g id="LWPOLYLINE-273" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="569.13 695.9 572.65 697.5 574.57 693.98"/>
+  </g>
+  <g id="LWPOLYLINE-274" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="574.57 693.97 578.09 695.9 580.01 692.38"/>
+  </g>
+  <g id="LWPOLYLINE-275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="580.01 692.38 583.54 693.98 585.14 690.46"/>
+  </g>
+  <g id="LWPOLYLINE-276" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="585.14 690.46 588.66 692.38 590.58 688.86"/>
+  </g>
+  <g id="LWPOLYLINE-277" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="590.58 688.85 594.1 690.78 596.02 687.25"/>
+  </g>
+  <g id="LWPOLYLINE-278" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="596.02 687.26 599.54 688.86 601.14 685.33"/>
+  </g>
+  <g id="LWPOLYLINE-279" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="601.15 685.33 604.99 687.26 606.59 683.73"/>
+  </g>
+  <g id="LWPOLYLINE-280" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="606.59 683.73 610.11 685.33 612.03 681.81"/>
+  </g>
+  <g id="LWPOLYLINE-281" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="612.03 681.81 615.55 683.73 617.47 680.21"/>
+  </g>
+  <g id="LWPOLYLINE-282" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="617.47 680.21 620.99 681.81 622.59 678.29"/>
+  </g>
+  <g id="LWPOLYLINE-283" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="622.6 678.29 626.12 680.21 626.44 679.57"/>
+  </g>
+  <g id="LWPOLYLINE-284" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="626.23" y="675.28" width="2.02" height="5.06" transform="translate(-181.83 232.54) rotate(-18.39)"/>
+  </g>
+  <g id="LWPOLYLINE-285" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="553.76 704.86 551.84 705.5 549.92 700.38 552.16 699.74 553.76 704.86"/>
+  </g>
+  <g id="LWPOLYLINE-286" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="478.52 729.52 476.28 730.16 474.69 725.03 476.6 724.4 478.52 729.52"/>
+  </g>
+  <g id="LWPOLYLINE-287" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="627.08" y1="680.53" x2="476.28" y2="730.16"/>
+  </g>
+  <g id="LWPOLYLINE-288" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="625.48" y1="675.73" x2="474.68" y2="725.04"/>
+  </g>
+  <g id="LWPOLYLINE-289" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="477.56" y1="726.96" x2="478.2" y2="725.35"/>
+  </g>
+  <g id="LWPOLYLINE-290" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="478.21 725.35 482.04 727.28 483.64 723.76"/>
+  </g>
+  <g id="LWPOLYLINE-291" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="483.65 723.75 487.17 725.67 489.09 722.15"/>
+  </g>
+  <g id="LWPOLYLINE-292" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="489.09 722.15 492.61 723.75 494.53 720.23"/>
+  </g>
+  <g id="LWPOLYLINE-293" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="494.53 720.23 498.05 722.15 499.65 718.63"/>
+  </g>
+  <g id="LWPOLYLINE-294" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="499.65 718.63 503.17 720.23 505.1 716.71"/>
+  </g>
+  <g id="LWPOLYLINE-295" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="505.1 716.71 508.62 718.63 510.54 715.11"/>
+  </g>
+  <g id="LWPOLYLINE-296" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="510.54 715.11 514.06 716.71 515.66 713.19"/>
+  </g>
+  <g id="LWPOLYLINE-297" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="515.66 713.19 519.18 715.11 521.1 711.59"/>
+  </g>
+  <g id="LWPOLYLINE-298" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="521.1 711.59 524.63 713.19 526.55 709.67"/>
+  </g>
+  <g id="LWPOLYLINE-299" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="526.55 709.66 530.07 711.59 531.67 708.07"/>
+  </g>
+  <g id="LWPOLYLINE-300" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="531.67 708.07 535.19 709.99 537.11 706.15"/>
+  </g>
+  <g id="LWPOLYLINE-301" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="537.11 706.14 540.63 708.07 542.55 704.54"/>
+  </g>
+  <g id="LWPOLYLINE-302" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="542.56 704.54 546.08 706.47 547.68 702.94"/>
+  </g>
+  <g id="LWPOLYLINE-303" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="551.52" y1="704.54" x2="551.52" y2="704.54"/>
+  </g>
+  <g id="LWPOLYLINE-304" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="551.52" y1="704.54" x2="547.68" y2="702.94"/>
+  </g>
+  <g id="LWPOLYLINE-305" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1480.31 400.39 1481.58 403.91 1480.95 404.23 1478.38 396.23 1479.03 395.91 1479.98 399.75 1487.35 397.51 1486.07 393.67 1486.39 393.34 1488.95 401.67 1488.63 401.67 1487.35 397.83 1480.31 400.39"/>
+  </g>
+  <g id="LWPOLYLINE-306" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1455.97 398.15 1507.52 381.18 1512.97 398.15 1461.74 414.8 1455.97 398.15"/>
+  </g>
+  <g id="LWPOLYLINE-307" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1301.34" y1="453.54" x2="1457.26" y2="401.99"/>
+  </g>
+  <g id="LWPOLYLINE-308" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1305.5" y1="466.34" x2="1461.74" y2="414.8"/>
+  </g>
+  <g id="LWPOLYLINE-309" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1714.98 312.99 1663.44 329.96 1669.2 346.6 1720.43 329.96 1714.98 312.99"/>
+  </g>
+  <g id="LWPOLYLINE-310" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1695.78 329.32 1697.05 333.15 1697.7 333.15 1694.82 324.83 1694.5 325.15 1695.78 328.99 1688.41 331.24 1687.45 327.39 1686.81 327.72 1689.37 335.72 1690.01 335.4 1688.73 331.88 1695.78 329.32"/>
+  </g>
+  <g id="LWPOLYLINE-311" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1665.04" y1="333.8" x2="1508.8" y2="385.34"/>
+  </g>
+  <g id="LWPOLYLINE-312" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1669.2" y1="346.6" x2="1512.96" y2="398.15"/>
+  </g>
+  <g id="LWPOLYLINE-313" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1903.24 261.12 1904.52 264.96 1905.16 264.96 1902.28 256.64 1901.96 256.96 1903.24 260.8 1896.19 263.04 1894.92 259.2 1894.28 259.52 1897.15 267.53 1897.48 267.2 1896.19 263.37 1903.24 261.12"/>
+  </g>
+  <g id="LWPOLYLINE-314" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1922.45 244.79 1871.23 261.76 1876.66 278.41 1927.9 261.76 1922.45 244.79"/>
+  </g>
+  <g id="LWPOLYLINE-315" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1716.27" y1="316.83" x2="1872.51" y2="265.61"/>
+  </g>
+  <g id="LWPOLYLINE-316" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1720.43" y1="329.96" x2="1876.67" y2="278.41"/>
+  </g>
+  <g id="LWPOLYLINE-317" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="178.21 1253.62 174.37 1253.3 174.37 1253.62 182.69 1254.58 182.69 1254.26 178.85 1253.62 179.49 1246.26 183.66 1246.57 183.66 1246.26 175.33 1245.3 175.01 1245.61 179.17 1246.26 178.21 1253.62"/>
+  </g>
+  <g id="LWPOLYLINE-318" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="233.92" y1="818.84" x2="275.22" y2="805.4"/>
+  </g>
+  <g id="LWPOLYLINE-319" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="473.4 721.19 422.18 738.16 427.61 755.13 479.16 738.16 473.4 721.19"/>
+  </g>
+  <g id="LWPOLYLINE-320" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1442.85" y1="425.68" x2="1439.33" y2="426.65"/>
+  </g>
+  <g id="LWPOLYLINE-321" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1436.45" y1="427.6" x2="1430.36" y2="429.53"/>
+  </g>
+  <g id="LWPOLYLINE-322" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1427.48" y1="430.81" x2="1421.39" y2="432.73"/>
+  </g>
+  <g id="LWPOLYLINE-323" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1418.2" y1="433.69" x2="1412.43" y2="435.61"/>
+  </g>
+  <g id="LWPOLYLINE-324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1409.23" y1="436.57" x2="1403.15" y2="438.49"/>
+  </g>
+  <g id="LWPOLYLINE-325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1400.27" y1="439.45" x2="1394.18" y2="441.69"/>
+  </g>
+  <g id="LWPOLYLINE-326" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1390.98" y1="442.65" x2="1385.22" y2="444.58"/>
+  </g>
+  <g id="LWPOLYLINE-327" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1382.02" y1="445.53" x2="1375.93" y2="447.46"/>
+  </g>
+  <g id="LWPOLYLINE-328" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1373.05" y1="448.41" x2="1366.97" y2="450.65"/>
+  </g>
+  <g id="LWPOLYLINE-329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1364.09" y1="451.62" x2="1358" y2="453.54"/>
+  </g>
+  <g id="LWPOLYLINE-330" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1354.8" y1="454.5" x2="1348.72" y2="456.42"/>
+  </g>
+  <g id="LWPOLYLINE-331" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1345.84" y1="457.38" x2="1339.75" y2="459.3"/>
+  </g>
+  <g id="LWPOLYLINE-332" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1336.87" y1="460.58" x2="1330.79" y2="462.5"/>
+  </g>
+  <g id="LWPOLYLINE-333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1327.59" y1="463.46" x2="1321.5" y2="465.39"/>
+  </g>
+  <g id="LWPOLYLINE-334" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1318.63" y1="466.34" x2="1312.54" y2="468.27"/>
+  </g>
+  <g id="LWPOLYLINE-335" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1309.66" y1="469.54" x2="1303.58" y2="471.47"/>
+  </g>
+  <g id="LWPOLYLINE-336" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1300.38" y1="472.43" x2="1297.18" y2="473.39"/>
+  </g>
+  <g id="LWPOLYLINE-337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1262.92" y1="484.59" x2="1257.15" y2="486.52"/>
+  </g>
+  <g id="LWPOLYLINE-338" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1254.27" y1="487.48" x2="1248.19" y2="489.71"/>
+  </g>
+  <g id="LWPOLYLINE-339" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1244.99" y1="490.67" x2="1239.22" y2="492.6"/>
+  </g>
+  <g id="LWPOLYLINE-340" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1236.02" y1="493.56" x2="1229.94" y2="495.48"/>
+  </g>
+  <g id="LWPOLYLINE-341" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1227.06" y1="496.44" x2="1220.97" y2="498.36"/>
+  </g>
+  <g id="LWPOLYLINE-342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1217.78" y1="499.64" x2="1212.01" y2="501.56"/>
+  </g>
+  <g id="LWPOLYLINE-343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1208.81" y1="502.52" x2="1202.72" y2="504.44"/>
+  </g>
+  <g id="LWPOLYLINE-344" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1199.85" y1="505.4" x2="1193.76" y2="507.33"/>
+  </g>
+  <g id="LWPOLYLINE-345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1190.56" y1="508.29" x2="1184.8" y2="510.52"/>
+  </g>
+  <g id="LWPOLYLINE-346" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1181.6" y1="511.49" x2="1175.51" y2="513.41"/>
+  </g>
+  <g id="LWPOLYLINE-347" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1172.63" y1="514.37" x2="1166.55" y2="516.29"/>
+  </g>
+  <g id="LWPOLYLINE-348" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1163.67" y1="517.25" x2="1157.58" y2="519.5"/>
+  </g>
+  <g id="LWPOLYLINE-349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1154.38" y1="520.45" x2="1148.3" y2="522.38"/>
+  </g>
+  <g id="LWPOLYLINE-350" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1145.42" y1="523.33" x2="1139.33" y2="525.25"/>
+  </g>
+  <g id="LWPOLYLINE-351" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1136.45" y1="526.21" x2="1130.37" y2="528.45"/>
+  </g>
+  <g id="LWPOLYLINE-352" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1127.17" y1="529.42" x2="1121.08" y2="531.34"/>
+  </g>
+  <g id="LWPOLYLINE-353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1118.2" y1="532.3" x2="1112.44" y2="534.22"/>
+  </g>
+  <g id="LWPOLYLINE-354" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1442.85 425.69 1444.45 430.49 1441.25 431.76"/>
+  </g>
+  <g id="LWPOLYLINE-355" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1438.05" y1="432.73" x2="1431.96" y2="434.65"/>
+  </g>
+  <g id="LWPOLYLINE-356" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1429.08" y1="435.61" x2="1423" y2="437.53"/>
+  </g>
+  <g id="LWPOLYLINE-357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1420.12" y1="438.81" x2="1414.03" y2="440.73"/>
+  </g>
+  <g id="LWPOLYLINE-358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1410.83" y1="441.69" x2="1404.75" y2="443.61"/>
+  </g>
+  <g id="LWPOLYLINE-359" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1401.87" y1="444.57" x2="1395.78" y2="446.49"/>
+  </g>
+  <g id="LWPOLYLINE-360" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1392.9" y1="447.46" x2="1386.82" y2="449.69"/>
+  </g>
+  <g id="LWPOLYLINE-361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1383.62" y1="450.66" x2="1377.53" y2="452.58"/>
+  </g>
+  <g id="LWPOLYLINE-362" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1374.65" y1="453.54" x2="1368.57" y2="455.46"/>
+  </g>
+  <g id="LWPOLYLINE-363" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1365.69" y1="456.42" x2="1359.6" y2="458.66"/>
+  </g>
+  <g id="LWPOLYLINE-364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1356.41" y1="459.62" x2="1350.32" y2="461.54"/>
+  </g>
+  <g id="LWPOLYLINE-365" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1347.44" y1="462.5" x2="1341.35" y2="464.42"/>
+  </g>
+  <g id="LWPOLYLINE-366" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1338.48" y1="465.38" x2="1332.39" y2="467.62"/>
+  </g>
+  <g id="LWPOLYLINE-367" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1329.19" y1="468.59" x2="1323.43" y2="470.51"/>
+  </g>
+  <g id="LWPOLYLINE-368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1320.23" y1="471.47" x2="1314.14" y2="473.39"/>
+  </g>
+  <g id="LWPOLYLINE-369" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.26" y1="474.35" x2="1305.18" y2="476.27"/>
+  </g>
+  <g id="LWPOLYLINE-370" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1301.98" y1="477.55" x2="1298.78" y2="478.51"/>
+  </g>
+  <g id="LWPOLYLINE-371" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1262.92 484.59 1264.52 489.72 1258.75 491.64"/>
+  </g>
+  <g id="LWPOLYLINE-372" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1255.87" y1="492.6" x2="1249.79" y2="494.52"/>
+  </g>
+  <g id="LWPOLYLINE-373" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1246.91" y1="495.48" x2="1240.82" y2="497.72"/>
+  </g>
+  <g id="LWPOLYLINE-374" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1237.62" y1="498.68" x2="1231.54" y2="500.61"/>
+  </g>
+  <g id="LWPOLYLINE-375" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1228.66" y1="501.56" x2="1222.57" y2="503.49"/>
+  </g>
+  <g id="LWPOLYLINE-376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1219.7" y1="504.44" x2="1213.61" y2="506.68"/>
+  </g>
+  <g id="LWPOLYLINE-377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1210.41" y1="507.64" x2="1204.33" y2="509.57"/>
+  </g>
+  <g id="LWPOLYLINE-378" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1201.45" y1="510.53" x2="1195.36" y2="512.45"/>
+  </g>
+  <g id="LWPOLYLINE-379" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1192.48" y1="513.41" x2="1186.4" y2="515.33"/>
+  </g>
+  <g id="LWPOLYLINE-380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1183.2" y1="516.61" x2="1177.11" y2="518.53"/>
+  </g>
+  <g id="LWPOLYLINE-381" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1174.23" y1="519.49" x2="1168.15" y2="521.41"/>
+  </g>
+  <g id="LWPOLYLINE-382" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1165.27" y1="522.37" x2="1159.18" y2="524.29"/>
+  </g>
+  <g id="LWPOLYLINE-383" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1155.98" y1="525.25" x2="1150.22" y2="527.5"/>
+  </g>
+  <g id="LWPOLYLINE-384" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1147.02" y1="528.45" x2="1140.93" y2="530.38"/>
+  </g>
+  <g id="LWPOLYLINE-385" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1138.05" y1="531.34" x2="1131.97" y2="533.26"/>
+  </g>
+  <g id="LWPOLYLINE-386" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1128.77" y1="534.22" x2="1123.01" y2="536.46"/>
+  </g>
+  <g id="LWPOLYLINE-387" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1119.81" y1="537.42" x2="1114.36" y2="539.02"/>
+  </g>
+  <g id="LWPOLYLINE-388" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2146.24 636.99 2149.76 607.22 2155.21 607.85"/>
+  </g>
+  <g id="LWPOLYLINE-389" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2155.53" y1="558.55" x2="2160.01" y2="559.19"/>
+  </g>
+  <g id="LWPOLYLINE-390" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2163.21" y1="605.29" x2="2165.77" y2="584.48"/>
+  </g>
+  <g id="LWPOLYLINE-391" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2160.33 604.97 2148.48 603.7 2148.16 606.9 2159.69 608.17 2160.33 604.97"/>
+  </g>
+  <g id="LWPOLYLINE-392" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2165.13 563.03 2153.29 561.75 2153.61 558.55 2165.45 559.83 2165.13 563.03"/>
+  </g>
+  <g id="LWPOLYLINE-393" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2165.13 563.03 2169.61 563.35 2167.37 584.48 2165.77 584.48"/>
+  </g>
+  <g id="LWPOLYLINE-394" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2183.06 564.95 2240.05 571.35 2233.65 629.95 2176.34 623.54 2178.26 607.22 2166.09 605.62 2163.85 625.15 2236.21 633.47 2243.57 568.79 2171.22 560.47 2170.89 563.68 2183.06 564.95"/>
+  </g>
+  <g id="LWPOLYLINE-395" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2176.33 593.77 2167.37 592.81 2168.97 578.08 2178.26 579.04"/>
+  </g>
+  <g id="LWPOLYLINE-396" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2168.33" y1="585.12" x2="2173.78" y2="585.76"/>
+  </g>
+  <g id="LWPOLYLINE-397" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2182.42 579.68 2180.5 594.41 2189.14 595.37"/>
+  </g>
+  <g id="LWPOLYLINE-398" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2201.63 596.65 2192.66 595.69 2194.27 580.97 2203.55 581.92"/>
+  </g>
+  <g id="LWPOLYLINE-399" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2193.63" y1="588" x2="2199.07" y2="588.64"/>
+  </g>
+  <g id="LWPOLYLINE-400" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2207.71 582.56 2211.55 597.93 2218.92 583.84"/>
+  </g>
+  <g id="LWPOLYLINE-401" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2220.84 597.61 2220.2 598.25 2220.84 598.89 2221.48 598.25"/>
+  </g>
+  <g id="LWPOLYLINE-402" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2228.84 588.33 2229.17 587.69 2229.81 586.4 2230.77 585.77 2232.04 585.13 2234.93 585.45 2236.21 586.4 2236.85 587.37 2237.49 588.65 2237.49 590.25 2236.53 591.52 2234.93 593.45 2226.92 599.53 2236.85 600.81"/>
+  </g>
+  <g id="LWPOLYLINE-403" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2169.61" y1="504.76" x2="2223.4" y2="510.85"/>
+  </g>
+  <g id="LWPOLYLINE-404" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2170.9" y1="494.52" x2="2224.68" y2="500.6"/>
+  </g>
+  <g id="LWPOLYLINE-405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2172.18" y1="484.27" x2="2225.64" y2="490.36"/>
+  </g>
+  <g id="LWPOLYLINE-406" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2190.74" y1="475.95" x2="2195.87" y2="476.59"/>
+  </g>
+  <g id="LWPOLYLINE-407" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2199.39" y1="476.91" x2="2226.92" y2="480.11"/>
+  </g>
+  <g id="LWPOLYLINE-408" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2174.42" y1="463.78" x2="2200.99" y2="466.67"/>
+  </g>
+  <g id="LWPOLYLINE-409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2175.7" y1="453.54" x2="2229.16" y2="459.62"/>
+  </g>
+  <g id="LWPOLYLINE-410" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2176.66" y1="443.29" x2="2230.44" y2="449.38"/>
+  </g>
+  <g id="LWPOLYLINE-411" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2177.3" y1="437.21" x2="2231.08" y2="443.29"/>
+  </g>
+  <g id="LWPOLYLINE-412" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2178.58" y1="426.96" x2="2232.36" y2="433.05"/>
+  </g>
+  <g id="LWPOLYLINE-413" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2179.86" y1="416.72" x2="2233.64" y2="422.8"/>
+  </g>
+  <g id="LWPOLYLINE-414" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2152.01" y1="633.47" x2="2263.42" y2="646.27"/>
+  </g>
+  <g id="LWPOLYLINE-415" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2160.97" y1="550.55" x2="2272.7" y2="563.03"/>
+  </g>
+  <g id="LWPOLYLINE-416" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2185.3" y1="368.05" x2="2184.98" y2="370.61"/>
+  </g>
+  <g id="LWPOLYLINE-417" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2172.17 352.69 2177.3 368.37 2176.98 369.65"/>
+  </g>
+  <g id="LWPOLYLINE-418" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2180.82 408.4 2172.82 407.44 2155.52 558.55"/>
+  </g>
+  <g id="LWPOLYLINE-419" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2180.82" y1="408.39" x2="2165.45" y2="543.18"/>
+  </g>
+  <g id="LWPOLYLINE-420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2177.3" y1="408.07" x2="2160.02" y2="559.19"/>
+  </g>
+  <g id="LWPOLYLINE-421" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2285.19 144.26 2321.69 132.1 2293.51 380.54"/>
+  </g>
+  <g id="LWPOLYLINE-422" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2291.59" y1="396.87" x2="2262.46" y2="652.68"/>
+  </g>
+  <g id="LWPOLYLINE-423" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2293.52 380.54 2278.79 378.62 2276.87 395.27"/>
+  </g>
+  <g id="LWPOLYLINE-424" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2287.75 431.12 2278.15 429.84 2264.06 554.39"/>
+  </g>
+  <g id="LWPOLYLINE-425" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2262.46 652.68 2247.73 650.76 2246.13 665.49"/>
+  </g>
+  <g id="LWPOLYLINE-426" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2260.86" y1="667.4" x2="2229.17" y2="947.22"/>
+  </g>
+  <g id="LWPOLYLINE-427" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2212.52 960.35 2227.24 961.95 2195.55 1243.37"/>
+  </g>
+  <g id="LWPOLYLINE-428" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2214.44" y1="945.63" x2="2212.52" y2="960.35"/>
+  </g>
+  <g id="LWPOLYLINE-429" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2332.26" y1="113.85" x2="2201.95" y2="1261.31"/>
+  </g>
+  <g id="LWPOLYLINE-430" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2148.49 604.33 2144.32 603.69 2140.48 636.35"/>
+  </g>
+  <g id="LWPOLYLINE-431" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2155.21" y1="607.86" x2="2152.01" y2="633.47"/>
+  </g>
+  <g id="LWPOLYLINE-432" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2208.67 400.39 2184.98 370.61 2183.38 371.57 2207.39 401.35"/>
+  </g>
+  <g id="LWPOLYLINE-433" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2209.63 399.75 2206.11 402.31 2202.27 404.55 2198.11 406.15 2193.94 407.76 2189.46 408.39 2184.98 408.71 2180.82 408.39"/>
+  </g>
+  <g id="LWPOLYLINE-434" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2097.9 313.63 2131.83 330.59 2131.19 332.52 2096.94 315.23"/>
+  </g>
+  <g id="LWPOLYLINE-435" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2098.54 312.67 2096.61 316.5 2095.02 320.67 2094.05 325.15 2093.74 329.64 2094.05 334.12 2094.7 338.28 2095.66 342.76"/>
+  </g>
+  <g id="LWPOLYLINE-436" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2165.45" y1="543.18" x2="2273.67" y2="555.67"/>
+  </g>
+  <g id="LWPOLYLINE-437" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2222.44" y1="519.49" x2="2233.65" y2="422.8"/>
+  </g>
+  <g id="LWPOLYLINE-438" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2208.67 419.6 2208.03 418 2206.75 417.68 2205.15 418 2204.51 419.6 2205.15 421.2 2206.75 421.84 2208.03 421.2 2208.67 419.6"/>
+  </g>
+  <g id="LWPOLYLINE-439" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2190.74 493.24 2199.07 487.48 2204.83 495.48"/>
+  </g>
+  <g id="LWPOLYLINE-440" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2173.78 469.22 2195.87 466.99 2199.07 470.83 2203.23 461.54 2206.11 465.7 2228.85 463.46"/>
+  </g>
+  <g id="LWPOLYLINE-441" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2210.6 403.91 2209.63 412.88 2209.96 414.8 2211.23 416.08 2212.83 416.72 2214.12 417.04 2216.04 416.72 2217.32 415.44 2217.96 413.84 2218.92 404.87"/>
+  </g>
+  <g id="LWPOLYLINE-442" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2222.44 418 2223.72 405.19 2229.17 405.83 2231.09 406.48 2231.4 407.12 2232.05 408.39 2231.73 410.32 2231.09 411.59 2230.45 411.91 2228.53 412.55 2223.08 411.91"/>
+  </g>
+  <g id="LWPOLYLINE-443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2223.08" y1="965.15" x2="2187.86" y2="1243.37"/>
+  </g>
+  <g id="LWPOLYLINE-444" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2245.81" y1="652.36" x2="2210.28" y2="963.87"/>
+  </g>
+  <g id="LWPOLYLINE-445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2233.97" y1="683.73" x2="2232.05" y2="700.07"/>
+  </g>
+  <g id="LWPOLYLINE-446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2238.77" y1="679.89" x2="2236.85" y2="696.21"/>
+  </g>
+  <g id="LWPOLYLINE-447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2248.37" y1="665.8" x2="2216.68" y2="945.62"/>
+  </g>
+  <g id="LWPOLYLINE-448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2152.32" y1="674.45" x2="2151.36" y2="681.81"/>
+  </g>
+  <g id="LWPOLYLINE-449" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.04" y1="685.01" x2="2150.41" y2="691.1"/>
+  </g>
+  <g id="LWPOLYLINE-450" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2150.08" y1="694.3" x2="2149.44" y2="700.71"/>
+  </g>
+  <g id="LWPOLYLINE-451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2149.12" y1="703.9" x2="2148.16" y2="710.3"/>
+  </g>
+  <g id="LWPOLYLINE-452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.84" y1="713.19" x2="2147.2" y2="719.6"/>
+  </g>
+  <g id="LWPOLYLINE-453" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2146.88" y1="722.79" x2="2146.25" y2="729.2"/>
+  </g>
+  <g id="LWPOLYLINE-454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2145.6" y1="732.4" x2="2144.96" y2="738.48"/>
+  </g>
+  <g id="LWPOLYLINE-455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2144.64" y1="741.68" x2="2144" y2="748.09"/>
+  </g>
+  <g id="LWPOLYLINE-456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2143.68" y1="751.29" x2="2143.04" y2="757.69"/>
+  </g>
+  <g id="LWPOLYLINE-457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2142.4" y1="760.89" x2="2141.76" y2="766.98"/>
+  </g>
+  <g id="LWPOLYLINE-458" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2141.44" y1="770.18" x2="2140.8" y2="776.58"/>
+  </g>
+  <g id="LWPOLYLINE-459" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.48" y1="779.78" x2="2139.52" y2="786.19"/>
+  </g>
+  <g id="LWPOLYLINE-460" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2139.2" y1="789.07" x2="2138.56" y2="795.47"/>
+  </g>
+  <g id="LWPOLYLINE-461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2138.24" y1="798.67" x2="2137.28" y2="806.04"/>
+  </g>
+  <g id="LWPOLYLINE-462" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="409.05 1178.06 399.76 1178.06 399.76 1163.34 409.05 1163.34"/>
+  </g>
+  <g id="LWPOLYLINE-463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="399.76" y1="1170.38" x2="405.53" y2="1170.38"/>
+  </g>
+  <g id="LWPOLYLINE-464" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="413.21 1163.34 413.21 1178.06 421.86 1178.06"/>
+  </g>
+  <g id="LWPOLYLINE-465" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="434.34 1178.06 425.38 1178.06 425.38 1163.34 434.34 1163.34"/>
+  </g>
+  <g id="LWPOLYLINE-466" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="425.38" y1="1170.38" x2="430.82" y2="1170.38"/>
+  </g>
+  <g id="LWPOLYLINE-467" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="438.82 1163.34 444.27 1178.06 450.03 1163.34"/>
+  </g>
+  <g id="LWPOLYLINE-468" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="453.55 1176.78 452.91 1177.42 453.55 1178.06 454.19 1177.42"/>
+  </g>
+  <g id="LWPOLYLINE-469" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="512.78 819.48 511.18 818.52 508.94 818.52 506.06 819.48 504.46 820.76 503.49 822.68 503.82 823.96 505.09 824.93 506.06 825.57 507.65 825.89 512.14 825.89 513.42 825.89 514.38 826.53 515.66 827.49 516.3 829.73 515.34 831.33 513.42 832.6 510.86 833.56 508.62 833.56 506.69 832.6"/>
+  </g>
+  <g id="LWPOLYLINE-470" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="521.1" y1="814.68" x2="525.59" y2="828.76"/>
+  </g>
+  <g id="LWPOLYLINE-471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="516.3" y1="816.28" x2="525.59" y2="813.08"/>
+  </g>
+  <g id="LWPOLYLINE-472" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="532.95 826.2 533.91 810.52 543.84 822.68"/>
+  </g>
+  <g id="LWPOLYLINE-473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="533.59" y1="821.08" x2="540.32" y2="818.84"/>
+  </g>
+  <g id="LWPOLYLINE-474" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="547.68" y1="821.4" x2="543.2" y2="807.32"/>
+  </g>
+  <g id="LWPOLYLINE-475" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="553.12 819.8 548.64 805.72 554.72 803.79 556.96 803.79 557.6 804.11 558.89 805.08 559.21 806.68 558.89 808.28 558.57 808.92 556.64 810.52 550.88 812.44"/>
+  </g>
+  <g id="LWPOLYLINE-476" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="555.36" y1="810.84" x2="562.41" y2="816.6"/>
+  </g>
+  <g id="LWPOLYLINE-477" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="565.29" y1="808.92" x2="577.45" y2="805.08"/>
+  </g>
+  <g id="LWPOLYLINE-478" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="580.97 798.03 582.25 796.75 583.53 794.19 588.02 808.28"/>
+  </g>
+  <g id="LWPOLYLINE-479" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2293.2 539.34 2291.59 540.3 2290.64 542.54 2290.32 545.43 2290.64 547.35 2291.92 548.95 2293.52 549.26 2294.8 548.62 2295.76 547.99 2296.4 546.7 2298.32 542.54 2299.28 541.26 2299.92 540.62 2301.52 540.3 2303.76 540.3 2305.04 541.9 2305.36 544.14 2305.04 547.03 2304.08 548.95 2302.48 550.22"/>
+  </g>
+  <g id="LWPOLYLINE-480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2291.92" y1="529.74" x2="2306.65" y2="531.66"/>
+  </g>
+  <g id="LWPOLYLINE-481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2291.59" y1="534.86" x2="2292.56" y2="524.93"/>
+  </g>
+  <g id="LWPOLYLINE-482" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2307.6 523.65 2293.52 516.61 2308.88 512.45"/>
+  </g>
+  <g id="LWPOLYLINE-483" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2303.12" y1="521.09" x2="2303.76" y2="514.04"/>
+  </g>
+  <g id="LWPOLYLINE-484" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2309.53" y1="508.29" x2="2294.79" y2="506.68"/>
+  </g>
+  <g id="LWPOLYLINE-485" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2310.16 502.84 2295.44 500.92 2296.08 494.84 2297.04 492.6 2297.68 491.96 2299.28 491.64 2300.56 491.64 2301.84 492.6 2302.48 493.24 2303.12 495.48 2302.48 501.88"/>
+  </g>
+  <g id="LWPOLYLINE-486" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2302.8" y1="496.76" x2="2311.12" y2="492.92"/>
+  </g>
+  <g id="LWPOLYLINE-487" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2305.36" y1="487.15" x2="2306.97" y2="474.67"/>
+  </g>
+  <g id="LWPOLYLINE-488" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2302.8 467.62 2301.84 467.62 2300.56 466.66 2299.92 466.03 2299.6 464.43 2299.92 461.86 2300.56 460.26 2301.52 459.62 2302.8 459.3 2304.4 459.3 2305.68 460.26 2307.61 461.86 2313.69 469.55 2314.97 459.94"/>
+  </g>
+  <g id="LWPOLYLINE-489" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1081.07 1229.93 1081.07 1235.05 1088.11 1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-490" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1091.31" y1="1235.05" x2="1097.72" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-491" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1100.92" y1="1235.05" x2="1107.32" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-492" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1110.52" y1="1235.05" x2="1116.61" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-493" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1119.81" y1="1235.05" x2="1126.21" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-494" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1129.41" y1="1235.05" x2="1135.82" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-495" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1139.02" y1="1235.05" x2="1145.42" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1148.62" y1="1235.05" x2="1155.02" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1158.22" y1="1235.05" x2="1164.63" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-498" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1167.51" y1="1235.05" x2="1173.91" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-499" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1177.11" y1="1235.05" x2="1183.52" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-500" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1186.72" y1="1235.05" x2="1193.12" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-501" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1196.32" y1="1235.05" x2="1202.73" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-502" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1205.93" y1="1235.05" x2="1212.33" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-503" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1215.21" y1="1235.05" x2="1221.62" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-504" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1224.82" y1="1235.05" x2="1231.22" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-505" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1234.42" y1="1235.05" x2="1240.83" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1244.03" y1="1235.05" x2="1250.43" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-507" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1253.63" y1="1235.05" x2="1260.04" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-508" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1263.24" y1="1235.05" x2="1269.32" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1272.52" y1="1235.05" x2="1279.89" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1081.07" y1="1229.93" x2="1088.11" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1091.31" y1="1229.93" x2="1097.72" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-512" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1100.92" y1="1229.93" x2="1107.32" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1110.52" y1="1229.93" x2="1116.61" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-514" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1119.81" y1="1229.93" x2="1126.21" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-515" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1129.41" y1="1229.93" x2="1135.82" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-516" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1139.02" y1="1229.93" x2="1145.42" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1148.62" y1="1229.93" x2="1155.02" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1158.22" y1="1229.93" x2="1164.63" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-519" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1167.51" y1="1229.93" x2="1173.91" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-520" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1177.11" y1="1229.93" x2="1183.52" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1186.72" y1="1229.93" x2="1193.12" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-522" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1196.32" y1="1229.93" x2="1202.73" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-523" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1205.93" y1="1229.93" x2="1212.33" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-524" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1215.21" y1="1229.93" x2="1221.62" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-525" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1224.82" y1="1229.93" x2="1231.22" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-526" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1234.42" y1="1229.93" x2="1240.83" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-527" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1244.03" y1="1229.93" x2="1250.43" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1253.63" y1="1229.93" x2="1260.04" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-529" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1263.24" y1="1229.93" x2="1269.32" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1272.52" y1="1229.93" x2="1279.89" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-531" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1279.89" y1="1235.05" x2="1279.89" y2="1229.93"/>
+  </g>
+  <g id="CIRCLE-17" data-name="CIRCLE">
+    <circle class="cls-3" cx="661.17" cy="954.11" r="9.44"/>
+  </g>
+  <g id="LWPOLYLINE-532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2229.17" y1="947.23" x2="2214.43" y2="945.63"/>
+  </g>
+  <g id="LWPOLYLINE-533" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2246.13" y1="665.48" x2="2260.86" y2="667.41"/>
+  </g>
+  <g id="LWPOLYLINE-534" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="446.19 1097.7 419.29 1124.6 420.57 1125.88 447.46 1098.98"/>
+  </g>
+  <g id="LWPOLYLINE-535" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="445.55 1096.74 448.42 1099.94 451.31 1103.47 453.55 1107.3 455.15 1111.46 456.43 1115.63 457.07 1120.11 457.39 1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-536" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="429.22" y1="874.87" x2="430.82" y2="879.67"/>
+  </g>
+  <g id="LWPOLYLINE-537" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="415.13 876.15 406.17 879.35 408.73 887.04"/>
+  </g>
+  <g id="LWPOLYLINE-538" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="369.99" y1="891.2" x2="372.55" y2="898.88"/>
+  </g>
+  <g id="LWPOLYLINE-539" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="718 779.79 465.4 863.02 467 867.83"/>
+  </g>
+  <g id="LWPOLYLINE-540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="275.22" y1="805.39" x2="631.56" y2="687.89"/>
+  </g>
+  <g id="LWPOLYLINE-541" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="502.53 730.16 520.14 783.62 649.49 741.05"/>
+  </g>
+  <g id="LWPOLYLINE-542" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="415.13 1020.55 360.06 903.04 372.55 898.88"/>
+  </g>
+  <g id="LWPOLYLINE-543" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="408.73" y1="887.04" x2="430.82" y2="879.67"/>
+  </g>
+  <g id="LWPOLYLINE-544" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="352.7" y1="896.96" x2="369.99" y2="891.2"/>
+  </g>
+  <g id="LWPOLYLINE-545" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="421.53" y1="877.43" x2="429.22" y2="874.87"/>
+  </g>
+  <g id="LWPOLYLINE-546" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="467" y1="867.83" x2="693.67" y2="792.91"/>
+  </g>
+  <g id="LWPOLYLINE-547" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="232.32" y1="833.89" x2="246.4" y2="835.49"/>
+  </g>
+  <g id="LWPOLYLINE-548" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="446.19 840.93 429.22 874.87 430.82 875.83 448.11 841.89"/>
+  </g>
+  <g id="LWPOLYLINE-549" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="445.23 840.29 449.06 842.53 452.91 845.09 456.11 847.98 458.99 851.5 461.56 855.01 463.8 858.86 465.4 863.02"/>
+  </g>
+  <g id="LWPOLYLINE-550" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="399.76 1185.11 399.76 1199.83 408.41 1199.83"/>
+  </g>
+  <g id="LWPOLYLINE-551" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="416.09 1185.11 414.81 1185.74 413.21 1187.34 412.57 1188.63 411.93 1190.87 411.93 1194.39 412.57 1196.31 413.21 1197.91 414.81 1199.19 416.09 1199.83 418.97 1199.83 420.25 1199.19 421.85 1197.91 422.5 1196.31 423.14 1194.39 423.14 1190.87 422.5 1188.63 421.85 1187.34 420.25 1185.74 418.97 1185.11 416.09 1185.11"/>
+  </g>
+  <g id="LWPOLYLINE-552" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="433.7 1192.15 435.94 1192.79 436.58 1193.75 437.22 1195.03 437.22 1197.27 436.58 1198.56 435.94 1199.2 433.7 1199.83 427.29 1199.83 427.29 1185.1 433.7 1185.1 435.94 1185.75 436.58 1186.39 437.22 1187.99 437.22 1189.27 436.58 1190.87 435.94 1191.51 433.7 1192.15 427.29 1192.15"/>
+  </g>
+  <g id="LWPOLYLINE-553" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="448.75 1192.15 450.67 1192.79 451.31 1193.75 452.27 1195.03 452.27 1197.27 451.31 1198.56 450.67 1199.2 448.75 1199.83 442.34 1199.83 442.34 1185.1 448.75 1185.1 450.67 1185.75 451.31 1186.39 452.27 1187.99 452.27 1189.27 451.31 1190.87 450.67 1191.51 448.75 1192.15 442.34 1192.15"/>
+  </g>
+  <g id="LWPOLYLINE-554" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="457.07 1185.11 462.84 1192.15 468.28 1185.11"/>
+  </g>
+  <g id="LWPOLYLINE-555" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="462.84" y1="1192.15" x2="462.84" y2="1199.83"/>
+  </g>
+  <g id="LWPOLYLINE-556" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="449.39" y1="1257.14" x2="626.76" y2="1257.14"/>
+  </g>
+  <g id="LWPOLYLINE-557" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="449.39" y="1248.18" width="1.28" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-558" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="452.59" y1="1249.46" x2="536.15" y2="1249.46"/>
+  </g>
+  <g id="LWPOLYLINE-559" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="452.59" y1="1248.5" x2="536.15" y2="1248.5"/>
+  </g>
+  <g id="LWPOLYLINE-560" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="450.67" y="1248.18" width="1.92" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-561" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="536.16" y="1243.38" width="3.84" height="6.4"/>
+  </g>
+  <g id="LWPOLYLINE-562" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="449.39" y1="1243.38" x2="626.76" y2="1243.38"/>
+  </g>
+  <g id="LWPOLYLINE-563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="505.42" y1="1238.89" x2="540" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-564" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="625.48" y="1248.18" width="1.28" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-565" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="623.56" y1="1249.46" x2="540" y2="1249.46"/>
+  </g>
+  <g id="LWPOLYLINE-566" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="623.56" y1="1248.5" x2="540" y2="1248.5"/>
+  </g>
+  <g id="LWPOLYLINE-567" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="623.56" y="1248.18" width="1.92" height="1.6"/>
+  </g>
+  <g id="LWPOLYLINE-568" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1683.93" y1="508.61" x2="1683.93" y2="341.8"/>
+  </g>
+  <g id="LWPOLYLINE-569" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1688.09" y1="513.09" x2="1688.09" y2="340.52"/>
+  </g>
+  <g id="LWPOLYLINE-570" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1634.31 481.71 1661.2 508.61 1659.92 510.21 1633.03 483.31"/>
+  </g>
+  <g id="LWPOLYLINE-571" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1634.94 481.07 1632.06 484.27 1629.18 487.8 1626.94 491.63 1625.34 495.8 1624.06 499.96 1623.42 504.44 1623.1 508.6"/>
+  </g>
+  <g id="LWPOLYLINE-572" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2034.51 458.98 2034.83 455.46 1974.63 455.46"/>
+  </g>
+  <g id="LWPOLYLINE-573" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1936.54 451.29 1936.54 455.46 1932.38 455.46"/>
+  </g>
+  <g id="LWPOLYLINE-574" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2035.15" y1="451.3" x2="1974.64" y2="451.3"/>
+  </g>
+  <g id="LWPOLYLINE-575" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1936.54" y1="451.3" x2="1917.97" y2="451.3"/>
+  </g>
+  <g id="LWPOLYLINE-576" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1735.8 473.71 1713.39 504.76 1714.98 505.72 1737.07 474.99"/>
+  </g>
+  <g id="LWPOLYLINE-577" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1734.84 473.07 1738.36 475.95 1741.56 478.83 1744.44 482.35 1746.68 486.19 1748.6 490.04 1750.21 494.52 1751.17 498.68"/>
+  </g>
+  <g id="LWPOLYLINE-578" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2076.77" y1="198.37" x2="1923.74" y2="248.63"/>
+  </g>
+  <g id="LWPOLYLINE-579" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2081.25" y1="211.18" x2="1927.9" y2="261.76"/>
+  </g>
+  <g id="LWPOLYLINE-580" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2286.15 333.48 2165.45 319.71 2131.83 330.6"/>
+  </g>
+  <g id="LWPOLYLINE-581" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2153.61" y1="193.57" x2="2087.33" y2="215.34"/>
+  </g>
+  <g id="LWPOLYLINE-582" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2095.66" y1="342.76" x2="2050.83" y2="357.48"/>
+  </g>
+  <g id="LWPOLYLINE-583" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2005.05 377.02 2041.55 364.85 1999.93 238.07"/>
+  </g>
+  <g id="LWPOLYLINE-584" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2006.33 380.86 2046.99 367.74 2003.77 236.79"/>
+  </g>
+  <g id="LWPOLYLINE-585" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2006.33" y1="380.86" x2="2005.05" y2="377.02"/>
+  </g>
+  <g id="LWPOLYLINE-586" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1917.97 410 1970.15 392.71 1968.88 388.87"/>
+  </g>
+  <g id="LWPOLYLINE-587" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2050.84" y1="357.49" x2="2010.5" y2="234.55"/>
+  </g>
+  <g id="LWPOLYLINE-588" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2047.95" y1="362.61" x2="2006.33" y2="235.82"/>
+  </g>
+  <g id="LWPOLYLINE-589" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2091.81" y1="243.19" x2="2081.25" y2="211.18"/>
+  </g>
+  <g id="LWPOLYLINE-590" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2091.81 243.19 2095.98 241.59 2085.42 209.9"/>
+  </g>
+  <g id="LWPOLYLINE-591" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2165.77 218.22 2162.25 219.18 2152.01 188.13"/>
+  </g>
+  <g id="LWPOLYLINE-592" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2165.13 183.64 2162.57 207.01 2155.85 186.52"/>
+  </g>
+  <g id="LWPOLYLINE-593" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2247.41" y1="333.16" x2="2243.25" y2="369.66"/>
+  </g>
+  <g id="LWPOLYLINE-594" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2251.57" y1="333.8" x2="2247.74" y2="370.3"/>
+  </g>
+  <g id="LWPOLYLINE-595" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.05 324.2 2168.01 327.39 2164.18 328.36"/>
+  </g>
+  <g id="LWPOLYLINE-596" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2176.02" y1="351.41" x2="2172.18" y2="352.69"/>
+  </g>
+  <g id="LWPOLYLINE-597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2162.89" y1="324.83" x2="2133.12" y2="334.76"/>
+  </g>
+  <g id="LWPOLYLINE-598" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2095.66 342.76 2096.94 346.6 2047.96 362.61"/>
+  </g>
+  <g id="LWPOLYLINE-599" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1968.87" y1="388.87" x2="1913.48" y2="407.11"/>
+  </g>
+  <g id="LWPOLYLINE-600" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2055.96 599.53 2026.18 623.54 2027.14 624.82 2056.92 601.13"/>
+  </g>
+  <g id="LWPOLYLINE-601" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2055.32 598.89 2057.88 602.41 2060.12 606.26 2061.72 610.41 2063 614.58 2063.96 618.74 2064.28 623.22 2063.96 627.71"/>
+  </g>
+  <g id="LWPOLYLINE-602" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1911.89" y1="1257.14" x2="1733.87" y2="1257.14"/>
+  </g>
+  <g id="LWPOLYLINE-603" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1910.92" y="1247.54" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-604" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909" y1="1249.14" x2="1824.8" y2="1249.14"/>
+  </g>
+  <g id="LWPOLYLINE-605" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909" y1="1247.86" x2="1824.8" y2="1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-606" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1909" y="1247.54" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-607" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1733.87" y="1247.54" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-608" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1734.84" y="1247.54" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-609" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1737.08" y1="1249.14" x2="1820.95" y2="1249.14"/>
+  </g>
+  <g id="LWPOLYLINE-610" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1737.08" y1="1247.86" x2="1820.95" y2="1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-611" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="834.86" y1="606.57" x2="678.62" y2="658.12"/>
+  </g>
+  <g id="LWPOLYLINE-612" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="837.1 613.3 837.43 614.9 836.46 615.22 836.14 613.62 837.1 613.3"/>
+  </g>
+  <g id="LWPOLYLINE-613" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="834.22" y1="614.58" x2="760.91" y2="638.59"/>
+  </g>
+  <g id="LWPOLYLINE-614" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="834.54" y1="615.54" x2="761.23" y2="639.87"/>
+  </g>
+  <g id="LWPOLYLINE-615" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="836.14 613.62 836.47 615.22 834.54 615.86 833.91 614.26 836.14 613.62"/>
+  </g>
+  <g id="LWPOLYLINE-616" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="680.86 664.52 681.5 666.45 682.46 666.13 681.83 664.2 680.86 664.52"/>
+  </g>
+  <g id="LWPOLYLINE-617" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="681.82 664.2 682.46 666.13 684.38 665.48 683.75 663.56 681.82 664.2"/>
+  </g>
+  <g id="LWPOLYLINE-618" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="760.58 638.27 762.82 644.68 759.31 645.96 757.06 639.55 760.58 638.27"/>
+  </g>
+  <g id="LWPOLYLINE-619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="684.07" y1="663.88" x2="757.38" y2="639.88"/>
+  </g>
+  <g id="LWPOLYLINE-620" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="684.39" y1="664.84" x2="757.7" y2="640.84"/>
+  </g>
+  <g id="LWPOLYLINE-621" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="763.79" y="1238.89" width="3.84" height="6.4"/>
+  </g>
+  <g id="LWPOLYLINE-622" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="971.25" y="1238.89" width="3.52" height="6.4"/>
+  </g>
+  <g id="LWPOLYLINE-623" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1099.64" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-624" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1102.84" y1="1244.66" x2="1178.4" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-625" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1102.84" y1="1243.69" x2="1178.4" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-626" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1100.6" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-627" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1260.04" y="1243.37" width="1.28" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-628" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1258.12" y="1243.37" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-629" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1258.11" y1="1244.66" x2="1182.23" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-630" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1258.11" y1="1243.69" x2="1182.23" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-631" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1099.64" y1="1238.89" x2="1261.31" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-632" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1178.4" y="1238.89" width="3.84" height="6.4"/>
+  </g>
+  <g id="LWPOLYLINE-633" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1467.5" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-634" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1465.26" y1="1244.66" x2="1389.38" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1465.26" y1="1243.69" x2="1389.38" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-636" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1465.26" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-637" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1306.78" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-638" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1307.74" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-639" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1309.98" y1="1244.66" x2="1385.86" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-640" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1309.98" y1="1243.69" x2="1385.86" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-641" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1468.46" y1="1238.89" x2="1306.78" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-642" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1385.86" y="1238.89" width="3.52" height="6.4"/>
+  </g>
+  <g id="LWPOLYLINE-643" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1514.24" y="1243.37" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-644" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1517.44" y1="1244.66" x2="1593.01" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-645" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1517.44" y1="1243.69" x2="1593.01" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-646" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1515.2" y="1243.37" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-647" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1674.65" y="1243.37" width="1.28" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-648" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1672.72" y="1243.37" width="1.93" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-649" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1672.72" y1="1244.66" x2="1596.85" y2="1244.66"/>
+  </g>
+  <g id="LWPOLYLINE-650" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1672.72" y1="1243.69" x2="1596.85" y2="1243.69"/>
+  </g>
+  <g id="LWPOLYLINE-651" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1514.25" y1="1238.89" x2="1675.92" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-652" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1593" y="1238.89" width="3.84" height="6.4"/>
+  </g>
+  <g id="LWPOLYLINE-653" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1911.89" y1="1243.38" x2="1733.87" y2="1243.38"/>
+  </g>
+  <g id="LWPOLYLINE-654" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1487.03 1229.93 1487.03 1235.05 1479.98 1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-655" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1476.79" y1="1235.05" x2="1470.38" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-656" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1467.18" y1="1235.05" x2="1460.78" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-657" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1457.58" y1="1235.05" x2="1451.17" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-658" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1447.97" y1="1235.05" x2="1441.89" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-659" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1438.69" y1="1235.05" x2="1432.28" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-660" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1429.08" y1="1235.05" x2="1422.67" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-661" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1419.48" y1="1235.05" x2="1413.08" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-662" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1409.87" y1="1235.05" x2="1403.46" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-663" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1400.27" y1="1235.05" x2="1394.18" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-664" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1390.98" y1="1235.05" x2="1384.57" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-665" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1381.38" y1="1235.05" x2="1374.97" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-666" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.77" y1="1235.05" x2="1365.37" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-667" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1362.17" y1="1235.05" x2="1355.76" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-668" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1352.56" y1="1235.05" x2="1346.48" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-669" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1343.28" y1="1235.05" x2="1336.87" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-670" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1333.67" y1="1235.05" x2="1327.27" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-671" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1324.07" y1="1235.05" x2="1317.66" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-672" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1314.46" y1="1235.05" x2="1308.06" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-673" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1304.86" y1="1235.05" x2="1298.45" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-674" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1295.57" y1="1235.05" x2="1288.21" y2="1235.05"/>
+  </g>
+  <g id="LWPOLYLINE-675" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1487.03" y1="1229.93" x2="1479.98" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-676" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1476.79" y1="1229.93" x2="1470.38" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-677" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1467.18" y1="1229.93" x2="1460.78" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-678" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1457.58" y1="1229.93" x2="1451.17" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-679" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1447.97" y1="1229.93" x2="1441.89" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-680" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1438.69" y1="1229.93" x2="1432.28" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-681" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1429.08" y1="1229.93" x2="1422.67" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-682" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1419.48" y1="1229.93" x2="1413.08" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-683" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1409.87" y1="1229.93" x2="1403.46" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-684" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1400.27" y1="1229.93" x2="1394.18" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-685" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1390.98" y1="1229.93" x2="1384.57" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-686" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1381.38" y1="1229.93" x2="1374.97" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-687" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.77" y1="1229.93" x2="1365.37" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-688" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1362.17" y1="1229.93" x2="1355.76" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-689" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1352.56" y1="1229.93" x2="1346.48" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-690" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1343.28" y1="1229.93" x2="1336.87" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-691" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1333.67" y1="1229.93" x2="1327.27" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-692" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1324.07" y1="1229.93" x2="1317.66" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-693" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1314.46" y1="1229.93" x2="1308.06" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-694" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1304.86" y1="1229.93" x2="1298.45" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-695" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1295.57" y1="1229.93" x2="1288.21" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-696" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1288.21" y1="1235.05" x2="1288.21" y2="1229.93"/>
+  </g>
+  <g id="LWPOLYLINE-697" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1820.96" y="1243.37" width="3.84" height="6.09"/>
+  </g>
+  <g id="LWPOLYLINE-698" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1965.99" y="1247.54" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-699" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1968.87" y1="1249.14" x2="2053.08" y2="1249.14"/>
+  </g>
+  <g id="LWPOLYLINE-700" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1968.87" y1="1247.86" x2="2053.08" y2="1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-701" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1966.95" y="1247.54" width="1.92" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-702" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2143.04" y="1247.54" width=".96" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-703" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2140.8" y="1247.54" width="2.24" height="1.92"/>
+  </g>
+  <g id="LWPOLYLINE-704" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.8" y1="1249.14" x2="2056.92" y2="1249.14"/>
+  </g>
+  <g id="LWPOLYLINE-705" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.8" y1="1247.86" x2="2056.92" y2="1247.86"/>
+  </g>
+  <g id="LWPOLYLINE-706" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.99" y1="1243.38" x2="2144" y2="1243.38"/>
+  </g>
+  <g id="LWPOLYLINE-707" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2053.08" y="1243.37" width="3.84" height="6.09"/>
+  </g>
+  <g id="LWPOLYLINE-708" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="559.52 950.75 505.42 950.75 505.42 855.02"/>
+  </g>
+  <g id="LWPOLYLINE-709" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="662.62" y1="944.98" x2="662.62" y2="803.15"/>
+  </g>
+  <g id="LWPOLYLINE-710" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="666.78" y1="946.59" x2="666.78" y2="801.87"/>
+  </g>
+  <g id="LWPOLYLINE-711" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="559.53 954.91 501.26 954.91 501.26 856.62"/>
+  </g>
+  <g id="LWPOLYLINE-712" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.13" y1="1020.54" x2="415.13" y2="1041.03"/>
+  </g>
+  <g id="LWPOLYLINE-713" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.13" y1="1079.13" x2="415.13" y2="1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-714" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="419.29" y1="1124.6" x2="419.29" y2="1128.76"/>
+  </g>
+  <g id="LWPOLYLINE-715" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="410.97" y1="1021.5" x2="410.97" y2="1041.03"/>
+  </g>
+  <g id="LWPOLYLINE-716" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="415.13 1079.13 410.97 1079.13 410.97 1128.76"/>
+  </g>
+  <g id="LWPOLYLINE-717" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="315.88" y1="1118.83" x2="315.88" y2="1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-718" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="315.88 1118.51 314.92 1119.15 314.92 1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-719" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="248.65 814.04 251.52 824.92 246.41 835.49"/>
+  </g>
+  <g id="LWPOLYLINE-720" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="648.21 719.59 644.37 707.75 648.21 706.15 650.13 706.15 651.73 707.1 652.69 708.07 653.97 709.67 654.93 712.55 654.93 714.47 654.61 715.75 653.97 717.34 652.37 718.31 648.21 719.59"/>
+  </g>
+  <g id="LWPOLYLINE-721" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="660.37 715.75 656.54 703.59 668.38 713.19 664.53 701.03"/>
+  </g>
+  <g id="LWPOLYLINE-722" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="464.76" y1="809.88" x2="444.91" y2="749.36"/>
+  </g>
+  <g id="LWPOLYLINE-723" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="475.32" y1="806.35" x2="455.47" y2="745.85"/>
+  </g>
+  <g id="LWPOLYLINE-724" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="485.89" y1="802.83" x2="466.04" y2="742.32"/>
+  </g>
+  <g id="LWPOLYLINE-725" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="496.45" y1="799.31" x2="476.6" y2="738.79"/>
+  </g>
+  <g id="LWPOLYLINE-726" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="507.02" y1="795.79" x2="488.12" y2="739.12"/>
+  </g>
+  <g id="LWPOLYLINE-727" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="517.58" y1="792.27" x2="510.22" y2="770.5"/>
+  </g>
+  <g id="LWPOLYLINE-728" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="508.94" y1="766.33" x2="507.98" y2="763.46"/>
+  </g>
+  <g id="LWPOLYLINE-729" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="446.19 782.98 445.55 781.71 444.26 781.06 442.67 781.71 442.03 782.98 442.67 784.58 444.26 785.22 445.55 784.58 446.19 782.98"/>
+  </g>
+  <g id="LWPOLYLINE-730" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="417.05 785.55 419.61 794.19 420.89 795.79 422.5 796.43 424.42 796.43 425.38 796.11 426.98 795.15 427.94 793.55 427.94 791.63 425.06 782.98"/>
+  </g>
+  <g id="LWPOLYLINE-731" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="433.38 793.55 429.54 781.38 434.66 779.78 436.58 779.78 437.54 780.1 438.51 781.06 438.83 782.99 438.83 784.26 438.51 784.9 436.9 786.19 431.78 787.78"/>
+  </g>
+  <g id="LWPOLYLINE-732" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="444.27 782.98 497.09 765.69 492.61 774.98"/>
+  </g>
+  <g id="LWPOLYLINE-733" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="497.09" y1="765.69" x2="487.81" y2="761.21"/>
+  </g>
+  <g id="LWPOLYLINE-734" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="524.31 790.35 508.3 767.62 510.54 763.13 500.3 764.09 502.54 759.29 485.89 735.92"/>
+  </g>
+  <g id="LWPOLYLINE-735" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1016.39" y="707.43" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-736" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1016.39" y1="709.67" x2="950.44" y2="709.67"/>
+  </g>
+  <g id="LWPOLYLINE-737" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1016.39" y1="709.35" x2="950.44" y2="709.35"/>
+  </g>
+  <g id="LWPOLYLINE-738" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="948.84" y="707.43" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-739" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="880.97" y="707.43" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-740" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="882.57" y1="709.67" x2="948.84" y2="709.67"/>
+  </g>
+  <g id="LWPOLYLINE-741" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="882.57" y1="709.35" x2="948.84" y2="709.35"/>
+  </g>
+  <g id="LWPOLYLINE-742" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1419.8" y="570.72" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-743" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1419.8" y1="572.96" x2="1353.84" y2="572.96"/>
+  </g>
+  <g id="LWPOLYLINE-744" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1419.8" y1="572.64" x2="1353.84" y2="572.64"/>
+  </g>
+  <g id="LWPOLYLINE-745" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1352.24" y="570.72" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-746" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1285.01" y="570.72" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-747" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.61" y1="572.96" x2="1352.24" y2="572.96"/>
+  </g>
+  <g id="LWPOLYLINE-748" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.61" y1="572.64" x2="1352.24" y2="572.64"/>
+  </g>
+  <g id="LWPOLYLINE-749" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1621.5" y="508.61" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-750" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1553.94" y="508.61" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-751" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1486.71" y="508.61" width="1.6" height="4.48"/>
+  </g>
+  <g id="LWPOLYLINE-752" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1488.31" y1="511.17" x2="1553.94" y2="511.17"/>
+  </g>
+  <g id="LWPOLYLINE-753" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1488.31" y1="510.85" x2="1553.94" y2="510.85"/>
+  </g>
+  <g id="LWPOLYLINE-754" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1963.43 482.67 1936.54 455.46 1937.81 454.18 1964.71 481.07"/>
+  </g>
+  <g id="LWPOLYLINE-755" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1962.79 483.31 1965.67 480.11 1968.23 476.59 1970.48 472.75 1972.4 468.59 1973.68 464.42 1974.32 459.94 1974.64 455.46"/>
+  </g>
+  <g id="LWPOLYLINE-756" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.07" y1="1062.8" x2="184.94" y2="1060.57"/>
+  </g>
+  <g id="LWPOLYLINE-757" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="195.82" y1="1107.63" x2="200.95" y2="1062.16"/>
+  </g>
+  <g id="LWPOLYLINE-758" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="190.38" y1="1064.73" x2="191.98" y2="1063.45"/>
+  </g>
+  <g id="LWPOLYLINE-759" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="190.06" y1="1068.25" x2="191.98" y2="1066.65"/>
+  </g>
+  <g id="LWPOLYLINE-760" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="189.42" y1="1072.09" x2="191.66" y2="1070.49"/>
+  </g>
+  <g id="LWPOLYLINE-761" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="189.1" y1="1075.93" x2="191.34" y2="1074.01"/>
+  </g>
+  <g id="LWPOLYLINE-762" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="188.78" y1="1079.45" x2="190.7" y2="1077.85"/>
+  </g>
+  <g id="LWPOLYLINE-763" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="188.46" y1="1083.3" x2="190.38" y2="1081.7"/>
+  </g>
+  <g id="LWPOLYLINE-764" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="187.82" y1="1087.14" x2="190.05" y2="1085.22"/>
+  </g>
+  <g id="LWPOLYLINE-765" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="187.5" y1="1090.66" x2="189.42" y2="1089.06"/>
+  </g>
+  <g id="LWPOLYLINE-766" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="187.18" y1="1094.5" x2="189.1" y2="1092.9"/>
+  </g>
+  <g id="LWPOLYLINE-767" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="186.53" y1="1098.02" x2="188.77" y2="1096.42"/>
+  </g>
+  <g id="LWPOLYLINE-768" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="187.18 1104.43 187.81 1104.1 186.22 1101.86 188.14 1100.27 186.54 1098.02"/>
+  </g>
+  <g id="LWPOLYLINE-769" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="188.78" y1="1096.42" x2="187.18" y2="1094.5"/>
+  </g>
+  <g id="LWPOLYLINE-770" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="189.1" y1="1092.9" x2="187.5" y2="1090.66"/>
+  </g>
+  <g id="LWPOLYLINE-771" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="189.42" y1="1089.06" x2="187.82" y2="1087.14"/>
+  </g>
+  <g id="LWPOLYLINE-772" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="190.06" y1="1085.22" x2="188.46" y2="1083.29"/>
+  </g>
+  <g id="LWPOLYLINE-773" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="190.38" y1="1081.69" x2="188.78" y2="1079.46"/>
+  </g>
+  <g id="LWPOLYLINE-774" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="190.7" y1="1077.85" x2="189.1" y2="1075.93"/>
+  </g>
+  <g id="LWPOLYLINE-775" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="191.34" y1="1074.01" x2="189.42" y2="1072.09"/>
+  </g>
+  <g id="LWPOLYLINE-776" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="191.66" y1="1070.49" x2="190.06" y2="1068.25"/>
+  </g>
+  <g id="LWPOLYLINE-777" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="191.98" y1="1066.65" x2="190.38" y2="1064.72"/>
+  </g>
+  <g id="LWPOLYLINE-778" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="189.42" y1="1060.88" x2="183.97" y2="1106.35"/>
+  </g>
+  <g id="LWPOLYLINE-779" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="194.54 1061.52 194.22 1063.76 189.09 1063.12 189.42 1060.88 194.54 1061.52"/>
+  </g>
+  <g id="LWPOLYLINE-780" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="189.74 1104.75 189.41 1106.98 183.97 1106.35 184.3 1104.11 189.74 1104.75"/>
+  </g>
+  <g id="LWPOLYLINE-781" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="194.22" y1="1063.76" x2="189.42" y2="1106.99"/>
+  </g>
+  <g id="LWPOLYLINE-782" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="183.97" y1="1106.35" x2="200.94" y2="1108.27"/>
+  </g>
+  <g id="LWPOLYLINE-783" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.15" y1="1009.02" x2="191.34" y2="1006.46"/>
+  </g>
+  <g id="LWPOLYLINE-784" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.03" y1="1008.38" x2="223.67" y2="861.42"/>
+  </g>
+  <g id="LWPOLYLINE-785" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="229.12 862.06 212.15 860.14 207.99 859.5"/>
+  </g>
+  <g id="LWPOLYLINE-786" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.43" y1="863.66" x2="215.03" y2="862.39"/>
+  </g>
+  <g id="LWPOLYLINE-787" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.11" y1="867.51" x2="215.35" y2="865.91"/>
+  </g>
+  <g id="LWPOLYLINE-788" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.79" y1="871.03" x2="214.71" y2="869.43"/>
+  </g>
+  <g id="LWPOLYLINE-789" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.15" y1="874.87" x2="214.39" y2="873.27"/>
+  </g>
+  <g id="LWPOLYLINE-790" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.83" y1="878.71" x2="214.07" y2="877.11"/>
+  </g>
+  <g id="LWPOLYLINE-791" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.51" y1="882.23" x2="213.43" y2="880.63"/>
+  </g>
+  <g id="LWPOLYLINE-792" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="210.87" y1="886.07" x2="213.11" y2="884.48"/>
+  </g>
+  <g id="LWPOLYLINE-793" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="210.55" y1="889.92" x2="212.79" y2="888"/>
+  </g>
+  <g id="LWPOLYLINE-794" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="210.23" y1="893.44" x2="212.15" y2="891.84"/>
+  </g>
+  <g id="LWPOLYLINE-795" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="209.59" y1="897.28" x2="211.83" y2="895.68"/>
+  </g>
+  <g id="LWPOLYLINE-796" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="209.27" y1="900.8" x2="211.51" y2="899.2"/>
+  </g>
+  <g id="LWPOLYLINE-797" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="208.95" y1="904.65" x2="210.87" y2="903.05"/>
+  </g>
+  <g id="LWPOLYLINE-798" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="208.31" y1="908.49" x2="210.54" y2="906.89"/>
+  </g>
+  <g id="LWPOLYLINE-799" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.99" y1="912.01" x2="210.22" y2="910.41"/>
+  </g>
+  <g id="LWPOLYLINE-800" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.67" y1="915.85" x2="209.59" y2="914.25"/>
+  </g>
+  <g id="LWPOLYLINE-801" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.03" y1="919.69" x2="209.26" y2="917.77"/>
+  </g>
+  <g id="LWPOLYLINE-802" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.71" y1="923.21" x2="208.95" y2="921.61"/>
+  </g>
+  <g id="LWPOLYLINE-803" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.39" y1="927.06" x2="208.31" y2="925.46"/>
+  </g>
+  <g id="LWPOLYLINE-804" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.07" y1="930.9" x2="207.99" y2="928.98"/>
+  </g>
+  <g id="LWPOLYLINE-805" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.67" y1="932.82" x2="207.67" y2="932.82"/>
+  </g>
+  <g id="LWPOLYLINE-806" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="205.11" y1="938.26" x2="207.03" y2="936.66"/>
+  </g>
+  <g id="LWPOLYLINE-807" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="204.78" y1="941.78" x2="206.71" y2="940.18"/>
+  </g>
+  <g id="LWPOLYLINE-808" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="204.15" y1="945.63" x2="206.38" y2="944.03"/>
+  </g>
+  <g id="LWPOLYLINE-809" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="203.83" y1="949.47" x2="205.75" y2="947.87"/>
+  </g>
+  <g id="LWPOLYLINE-810" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="203.5" y1="952.99" x2="205.43" y2="951.39"/>
+  </g>
+  <g id="LWPOLYLINE-811" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="202.86" y1="956.83" x2="205.1" y2="955.23"/>
+  </g>
+  <g id="LWPOLYLINE-812" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="202.54" y1="960.67" x2="204.46" y2="958.75"/>
+  </g>
+  <g id="LWPOLYLINE-813" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="202.22" y1="964.19" x2="204.15" y2="962.59"/>
+  </g>
+  <g id="LWPOLYLINE-814" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.58" y1="968.04" x2="203.82" y2="966.44"/>
+  </g>
+  <g id="LWPOLYLINE-815" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.26" y1="971.56" x2="203.18" y2="969.96"/>
+  </g>
+  <g id="LWPOLYLINE-816" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="200.94" y1="975.4" x2="202.86" y2="973.8"/>
+  </g>
+  <g id="LWPOLYLINE-817" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="200.3" y1="979.24" x2="202.54" y2="977.64"/>
+  </g>
+  <g id="LWPOLYLINE-818" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="199.98" y1="982.76" x2="201.9" y2="981.16"/>
+  </g>
+  <g id="LWPOLYLINE-819" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="199.66" y1="986.61" x2="201.58" y2="985.01"/>
+  </g>
+  <g id="LWPOLYLINE-820" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="199.02" y1="990.45" x2="201.26" y2="988.85"/>
+  </g>
+  <g id="LWPOLYLINE-821" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="198.7" y1="993.97" x2="200.62" y2="992.37"/>
+  </g>
+  <g id="LWPOLYLINE-822" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="198.38" y1="997.81" x2="200.3" y2="996.21"/>
+  </g>
+  <g id="LWPOLYLINE-823" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="197.74 1005.17 199.34 1003.58 197.74 1001.65 199.98 999.73 198.38 997.81"/>
+  </g>
+  <g id="LWPOLYLINE-824" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="200.3" y1="996.21" x2="198.7" y2="993.97"/>
+  </g>
+  <g id="LWPOLYLINE-825" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="200.62" y1="992.37" x2="199.02" y2="990.45"/>
+  </g>
+  <g id="LWPOLYLINE-826" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.26" y1="988.85" x2="199.66" y2="986.61"/>
+  </g>
+  <g id="LWPOLYLINE-827" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.58" y1="985" x2="199.98" y2="982.77"/>
+  </g>
+  <g id="LWPOLYLINE-828" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="201.9" y1="981.16" x2="200.3" y2="979.24"/>
+  </g>
+  <g id="LWPOLYLINE-829" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="202.54" y1="977.64" x2="200.94" y2="975.4"/>
+  </g>
+  <g id="LWPOLYLINE-830" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="202.86" y1="973.8" x2="201.26" y2="971.56"/>
+  </g>
+  <g id="LWPOLYLINE-831" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="203.18" y1="969.96" x2="201.58" y2="968.04"/>
+  </g>
+  <g id="LWPOLYLINE-832" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="203.83" y1="966.43" x2="202.23" y2="964.2"/>
+  </g>
+  <g id="LWPOLYLINE-833" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="204.15" y1="962.59" x2="202.54" y2="960.67"/>
+  </g>
+  <g id="LWPOLYLINE-834" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="204.46" y1="958.75" x2="202.86" y2="956.83"/>
+  </g>
+  <g id="LWPOLYLINE-835" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="205.11" y1="955.23" x2="203.51" y2="952.99"/>
+  </g>
+  <g id="LWPOLYLINE-836" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="205.42" y1="951.39" x2="203.83" y2="949.47"/>
+  </g>
+  <g id="LWPOLYLINE-837" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="205.75" y1="947.87" x2="204.15" y2="945.63"/>
+  </g>
+  <g id="LWPOLYLINE-838" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.39" y1="944.02" x2="204.79" y2="941.79"/>
+  </g>
+  <g id="LWPOLYLINE-839" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="206.71" y1="940.18" x2="205.11" y2="938.26"/>
+  </g>
+  <g id="LWPOLYLINE-840" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.03" y1="936.66" x2="205.75" y2="934.74"/>
+  </g>
+  <g id="LWPOLYLINE-841" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.67" y1="932.82" x2="206.07" y2="930.9"/>
+  </g>
+  <g id="LWPOLYLINE-842" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.99" y1="928.98" x2="206.39" y2="927.06"/>
+  </g>
+  <g id="LWPOLYLINE-843" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="208.31" y1="925.46" x2="206.71" y2="923.22"/>
+  </g>
+  <g id="LWPOLYLINE-844" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="208.95" y1="921.61" x2="207.03" y2="919.69"/>
+  </g>
+  <g id="LWPOLYLINE-845" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="209.27" y1="917.77" x2="207.67" y2="915.85"/>
+  </g>
+  <g id="LWPOLYLINE-846" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="209.59" y1="914.25" x2="207.99" y2="912.01"/>
+  </g>
+  <g id="LWPOLYLINE-847" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="210.23" y1="910.41" x2="208.31" y2="908.49"/>
+  </g>
+  <g id="LWPOLYLINE-848" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="210.55" y1="906.89" x2="208.95" y2="904.65"/>
+  </g>
+  <g id="LWPOLYLINE-849" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="210.87" y1="903.04" x2="209.27" y2="900.81"/>
+  </g>
+  <g id="LWPOLYLINE-850" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.51" y1="899.2" x2="209.59" y2="897.28"/>
+  </g>
+  <g id="LWPOLYLINE-851" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.83" y1="895.68" x2="210.23" y2="893.44"/>
+  </g>
+  <g id="LWPOLYLINE-852" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.15" y1="891.84" x2="210.55" y2="889.92"/>
+  </g>
+  <g id="LWPOLYLINE-853" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.79" y1="888" x2="210.87" y2="886.08"/>
+  </g>
+  <g id="LWPOLYLINE-854" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.11" y1="884.48" x2="211.51" y2="882.24"/>
+  </g>
+  <g id="LWPOLYLINE-855" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="213.43" y1="880.63" x2="211.83" y2="878.71"/>
+  </g>
+  <g id="LWPOLYLINE-856" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="214.07" y1="877.11" x2="212.15" y2="874.87"/>
+  </g>
+  <g id="LWPOLYLINE-857" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="214.39" y1="873.27" x2="212.79" y2="871.03"/>
+  </g>
+  <g id="LWPOLYLINE-858" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="214.71" y1="869.43" x2="213.11" y2="867.51"/>
+  </g>
+  <g id="LWPOLYLINE-859" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="215.35" y1="865.91" x2="213.43" y2="863.67"/>
+  </g>
+  <g id="LWPOLYLINE-860" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.15" y1="860.14" x2="195.5" y2="1007.1"/>
+  </g>
+  <g id="LWPOLYLINE-861" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="217.59 860.46 217.27 862.7 211.83 862.06 212.14 860.14 217.59 860.46"/>
+  </g>
+  <g id="LWPOLYLINE-862" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="200.94 1005.5 200.62 1007.73 195.5 1007.09 195.82 1004.86 200.94 1005.5"/>
+  </g>
+  <g id="LWPOLYLINE-863" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="217.27" y1="862.7" x2="200.94" y2="1006.45"/>
+  </g>
+  <g id="LWPOLYLINE-864" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="209.27 933.14 208.95 935.06 203.83 934.42 203.83 932.5 209.27 933.14"/>
+  </g>
+  <g id="LWPOLYLINE-865" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="344.05 1128.76 410.97 1128.76 419.3 1128.76"/>
+  </g>
+  <g id="LWPOLYLINE-866" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="495.49 1124.6 495.49 1128.76 501.26 1128.76"/>
+  </g>
+  <g id="LWPOLYLINE-867" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M344.05,1218.56c.04,10.57,8.64,19.09,19.21,19.05h0s82.28,0,82.28,0v5.76"/>
+  </g>
+  <g id="LWPOLYLINE-868" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M343.94,1231.08c4.28,6.5,11.54,10.4,19.33,10.37h78.44v1.92"/>
+  </g>
+  <g id="LWPOLYLINE-869" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.13" y1="1124.6" x2="419.29" y2="1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-870" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="410.97" y1="1041.03" x2="415.13" y2="1041.03"/>
+  </g>
+  <g id="LWPOLYLINE-871" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="495.49" y1="1124.6" x2="501.26" y2="1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-872" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="199.02" y1="1124.6" x2="410.97" y2="1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-873" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.13" y1="874.23" x2="264.65" y2="877.11"/>
+  </g>
+  <g id="LWPOLYLINE-874" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="267.22" y1="879.03" x2="272.34" y2="882.55"/>
+  </g>
+  <g id="LWPOLYLINE-875" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.9" y1="884.48" x2="280.02" y2="888.31"/>
+  </g>
+  <g id="LWPOLYLINE-876" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.58" y1="890.24" x2="287.71" y2="894.07"/>
+  </g>
+  <g id="LWPOLYLINE-877" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="290.27" y1="896" x2="295.39" y2="899.52"/>
+  </g>
+  <g id="LWPOLYLINE-878" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="298.27" y1="901.44" x2="303.4" y2="905.28"/>
+  </g>
+  <g id="LWPOLYLINE-879" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="305.96" y1="907.21" x2="311.08" y2="911.04"/>
+  </g>
+  <g id="LWPOLYLINE-880" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="313.64" y1="912.65" x2="318.76" y2="916.49"/>
+  </g>
+  <g id="LWPOLYLINE-881" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="321.32" y1="918.41" x2="326.45" y2="922.25"/>
+  </g>
+  <g id="LWPOLYLINE-882" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="329.01" y1="924.17" x2="334.13" y2="927.7"/>
+  </g>
+  <g id="LWPOLYLINE-883" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="336.69" y1="929.62" x2="341.82" y2="933.46"/>
+  </g>
+  <g id="LWPOLYLINE-884" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="344.37" y1="935.38" x2="347.9" y2="937.94"/>
+  </g>
+  <g id="LWPOLYLINE-885" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="251.85" y1="937.3" x2="254.41" y2="935.38"/>
+  </g>
+  <g id="LWPOLYLINE-886" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="256.97" y1="933.14" x2="261.77" y2="929.3"/>
+  </g>
+  <g id="LWPOLYLINE-887" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="264.33" y1="927.38" x2="269.46" y2="923.22"/>
+  </g>
+  <g id="LWPOLYLINE-888" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="271.7" y1="921.29" x2="276.82" y2="917.45"/>
+  </g>
+  <g id="LWPOLYLINE-889" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="279.38" y1="915.53" x2="284.19" y2="911.37"/>
+  </g>
+  <g id="LWPOLYLINE-890" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="286.75" y1="909.45" x2="291.87" y2="905.61"/>
+  </g>
+  <g id="LWPOLYLINE-891" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="294.11" y1="903.36" x2="299.24" y2="899.53"/>
+  </g>
+  <g id="LWPOLYLINE-892" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="301.79" y1="897.6" x2="306.6" y2="893.44"/>
+  </g>
+  <g id="LWPOLYLINE-893" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="309.16" y1="891.52" x2="313.96" y2="887.68"/>
+  </g>
+  <g id="LWPOLYLINE-894" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="316.52" y1="885.76" x2="321.65" y2="881.6"/>
+  </g>
+  <g id="LWPOLYLINE-895" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="324.2" y1="879.67" x2="329.01" y2="875.83"/>
+  </g>
+  <g id="LWPOLYLINE-896" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="331.57" y1="873.59" x2="336.37" y2="869.75"/>
+  </g>
+  <g id="LWPOLYLINE-897" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="338.93" y1="867.83" x2="344.06" y2="863.67"/>
+  </g>
+  <g id="LWPOLYLINE-898" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="346.3" y1="861.74" x2="348.86" y2="859.82"/>
+  </g>
+  <g id="LWPOLYLINE-899" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="311.4 1060.24 314.92 1074.97 318.45 1060.24 321.96 1074.97 325.48 1060.24"/>
+  </g>
+  <g id="LWPOLYLINE-900" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="332.53 1060.24 330.93 1060.88 329.65 1062.48 329.01 1063.76 328.37 1066.01 328.37 1069.53 329.01 1071.45 329.65 1073.05 330.93 1074.33 332.53 1074.97 335.41 1074.97 336.69 1074.33 337.98 1073.05 338.94 1071.45 339.58 1069.53 339.58 1066.01 338.94 1063.76 337.98 1062.48 336.69 1060.88 335.41 1060.24 332.53 1060.24"/>
+  </g>
+  <g id="LWPOLYLINE-901" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="343.73 1074.97 343.73 1060.25 349.5 1074.97 354.94 1060.25 354.94 1074.97"/>
+  </g>
+  <g id="LWPOLYLINE-902" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="369.99 1074.97 360.7 1074.97 360.7 1060.25 369.99 1060.25"/>
+  </g>
+  <g id="LWPOLYLINE-903" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="360.7" y1="1067.29" x2="366.47" y2="1067.29"/>
+  </g>
+  <g id="LWPOLYLINE-904" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="374.15 1074.97 374.15 1060.25 384.07 1074.97 384.07 1060.25"/>
+  </g>
+  <g id="LWPOLYLINE-905" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1762.37 375.42 1761.73 373.82 1760.44 372.54 1758.85 371.9 1756.28 371.9 1754.68 372.54 1753.41 373.82 1752.76 375.42 1751.81 377.34 1751.81 380.87 1752.76 383.1 1753.41 384.38 1754.68 385.98 1756.28 386.63 1758.85 386.63 1760.44 385.98 1761.73 384.38 1762.37 383.1"/>
+  </g>
+  <g id="LWPOLYLINE-906" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1771.01 371.9 1769.74 372.53 1768.13 373.82 1767.49 375.42 1766.85 377.34 1766.85 380.86 1767.49 383.1 1768.13 384.38 1769.74 385.98 1771.01 386.62 1773.89 386.62 1775.18 385.98 1776.78 384.38 1777.42 383.1 1778.06 380.86 1778.06 377.34 1777.42 375.42 1776.78 373.82 1775.18 372.53 1773.89 371.9 1771.01 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-907" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1782.22 386.62 1782.22 371.9 1792.14 386.62 1792.14 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-908" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1797.91 386.62 1797.91 371.9 1807.19 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-909" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1797.91" y1="378.94" x2="1803.67" y2="378.94"/>
+  </g>
+  <g id="LWPOLYLINE-910" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1819.67 386.62 1810.71 386.62 1810.71 371.9 1819.67 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-911" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1810.71" y1="378.94" x2="1816.15" y2="378.94"/>
+  </g>
+  <g id="LWPOLYLINE-912" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1824.16 386.62 1824.16 371.9 1830.24 371.9 1832.48 372.54 1833.12 373.18 1833.77 374.46 1833.77 376.06 1833.12 377.34 1832.48 377.99 1830.24 378.94 1824.16 378.94"/>
+  </g>
+  <g id="LWPOLYLINE-913" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1828.96" y1="378.94" x2="1833.77" y2="386.62"/>
+  </g>
+  <g id="LWPOLYLINE-914" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1848.17 386.62 1838.89 386.62 1838.89 371.9 1848.17 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-915" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1838.89" y1="378.94" x2="1844.65" y2="378.94"/>
+  </g>
+  <g id="LWPOLYLINE-916" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1852.33 386.62 1852.33 371.9 1862.26 386.62 1862.26 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-917" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1878.59 375.42 1877.63 373.82 1876.35 372.54 1875.07 371.9 1872.18 371.9 1870.58 372.54 1869.31 373.82 1868.66 375.42 1867.7 377.34 1867.7 380.87 1868.66 383.1 1869.31 384.38 1870.58 385.98 1872.18 386.63 1875.07 386.63 1876.35 385.98 1877.63 384.38 1878.59 383.1"/>
+  </g>
+  <g id="LWPOLYLINE-918" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1892.03 386.62 1882.75 386.62 1882.75 371.9 1892.03 371.9"/>
+  </g>
+  <g id="LWPOLYLINE-919" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1882.75" y1="378.94" x2="1888.51" y2="378.94"/>
+  </g>
+  <g id="LWPOLYLINE-920" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1275.09 663.56 1258.76 663.56 1258.76 659.4"/>
+  </g>
+  <g id="LWPOLYLINE-921" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1219.06" y="659.4" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-922" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1219.06" y1="661.64" x2="1155.67" y2="661.64"/>
+  </g>
+  <g id="LWPOLYLINE-923" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1219.06" y1="661.32" x2="1155.67" y2="661.32"/>
+  </g>
+  <g id="LWPOLYLINE-924" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1154.06" y="659.4" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-925" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1089.07" y="659.4" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-926" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1090.67" y1="661.64" x2="1154.06" y2="661.64"/>
+  </g>
+  <g id="LWPOLYLINE-927" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1090.67" y1="661.32" x2="1154.06" y2="661.32"/>
+  </g>
+  <g id="LWPOLYLINE-928" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1258.76" y1="659.4" x2="1274.44" y2="659.4"/>
+  </g>
+  <g id="LWPOLYLINE-929" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1114.36" y1="539.02" x2="1112.44" y2="534.21"/>
+  </g>
+  <g id="LWPOLYLINE-930" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1506.88 642.75 1507.2 642.75 1507.2 651.4 1474.54 651.4 1474.54 642.75 1474.86 642.75 1502.4 627.06 1504.32 630.59 1505.6 634.74 1506.56 638.59 1506.88 642.75"/>
+  </g>
+  <g id="LWPOLYLINE-931" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1511.36 641.47 1511.36 628.67 1519.37 628.67"/>
+  </g>
+  <g id="LWPOLYLINE-932" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1511.36" y1="634.75" x2="1516.49" y2="634.75"/>
+  </g>
+  <g id="LWPOLYLINE-933" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1522.25" y1="641.47" x2="1522.25" y2="628.67"/>
+  </g>
+  <g id="LWPOLYLINE-934" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1530.89" y1="628.67" x2="1530.89" y2="641.47"/>
+  </g>
+  <g id="LWPOLYLINE-935" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1522.25" y1="634.75" x2="1530.89" y2="634.75"/>
+  </g>
+  <g id="LWPOLYLINE-936" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1544.66 631.87 1544.34 630.59 1543.06 629.3 1541.78 628.67 1539.21 628.67 1538.26 629.3 1536.97 630.59 1536.33 631.87 1535.7 633.47 1535.7 636.67 1536.33 638.59 1536.97 639.55 1538.26 640.83 1539.21 641.48 1541.78 641.48 1543.06 640.83 1544.34 639.55 1544.66 638.59"/>
+  </g>
+  <g id="LWPOLYLINE-937" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="682.79" y1="670.93" x2="839.03" y2="619.7"/>
+  </g>
+  <g id="LWPOLYLINE-938" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2005.05 229.42 2006.97 235.51 2003.45 236.79 2001.53 230.38 2005.05 229.42"/>
+  </g>
+  <g id="LWPOLYLINE-939" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1931.09 446.81 1921.81 446.81 1921.81 432.08 1931.09 432.08"/>
+  </g>
+  <g id="LWPOLYLINE-940" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1921.81" y1="439.13" x2="1927.57" y2="439.13"/>
+  </g>
+  <g id="LWPOLYLINE-941" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1935.26 432.09 1935.26 446.82 1943.9 446.82"/>
+  </g>
+  <g id="LWPOLYLINE-942" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1956.38 446.81 1947.42 446.81 1947.42 432.08 1956.38 432.08"/>
+  </g>
+  <g id="LWPOLYLINE-943" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1947.42" y1="439.13" x2="1952.87" y2="439.13"/>
+  </g>
+  <g id="LWPOLYLINE-944" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1971.43 435.61 1970.79 434.01 1969.2 432.73 1967.91 432.09 1965.04 432.09 1963.43 432.73 1962.15 434.01 1961.51 435.61 1960.87 437.53 1960.87 441.05 1961.51 443.29 1962.15 444.57 1963.43 446.17 1965.04 446.81 1967.91 446.81 1969.2 446.17 1970.79 444.57 1971.43 443.29"/>
+  </g>
+  <g id="LWPOLYLINE-945" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1976.24 445.53 1975.6 446.17 1976.24 446.81 1976.87 446.17"/>
+  </g>
+  <g id="LWPOLYLINE-946" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2021.7" y1="622.9" x2="2026.18" y2="623.54"/>
+  </g>
+  <g id="LWPOLYLINE-947" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2063.64 631.87 2063.96 627.7 2262.78 650.44"/>
+  </g>
+  <g id="LWPOLYLINE-948" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2017.22" y1="626.43" x2="2025.54" y2="627.39"/>
+  </g>
+  <g id="LWPOLYLINE-949" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2063.64" y1="631.87" x2="2245.81" y2="652.36"/>
+  </g>
+  <g id="LWPOLYLINE-950" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2077.73" y1="799.31" x2="2147.52" y2="807.32"/>
+  </g>
+  <g id="LWPOLYLINE-951" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2136.64" y1="672.53" x2="2233.97" y2="683.73"/>
+  </g>
+  <g id="LWPOLYLINE-952" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2232.05" y1="700.06" x2="2240.05" y2="701.02"/>
+  </g>
+  <g id="LWPOLYLINE-953" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2210.28" y1="963.87" x2="2223.08" y2="965.15"/>
+  </g>
+  <g id="LWPOLYLINE-954" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2236.85" y1="696.22" x2="2240.69" y2="696.54"/>
+  </g>
+  <g id="LWPOLYLINE-955" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2136.96" y1="668.37" x2="2238.77" y2="679.89"/>
+  </g>
+  <g id="LWPOLYLINE-956" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2077.73 799.31 2077.41 803.47 2147.2 811.48"/>
+  </g>
+  <g id="LWPOLYLINE-957" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2160.33" y1="604.97" x2="2163.21" y2="605.3"/>
+  </g>
+  <g id="LWPOLYLINE-958" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2153.61 561.11 2149.12 560.47 2152.33 532.3 2158.4 533.26"/>
+  </g>
+  <g id="LWPOLYLINE-959" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2161.61 506.37 2155.53 505.73 2153.93 519.81 2160.01 520.45"/>
+  </g>
+  <g id="LWPOLYLINE-960" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2278.15" y1="429.84" x2="2233.32" y2="424.72"/>
+  </g>
+  <g id="LWPOLYLINE-961" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2277.19" y1="439.45" x2="2232.04" y2="434.33"/>
+  </g>
+  <g id="LWPOLYLINE-962" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2276.23" y1="448.73" x2="2231.08" y2="443.61"/>
+  </g>
+  <g id="LWPOLYLINE-963" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2274.95" y1="458.34" x2="2230.12" y2="453.22"/>
+  </g>
+  <g id="LWPOLYLINE-964" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2273.99" y1="467.94" x2="2228.84" y2="462.82"/>
+  </g>
+  <g id="LWPOLYLINE-965" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2273.03" y1="477.23" x2="2227.88" y2="472.11"/>
+  </g>
+  <g id="LWPOLYLINE-966" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2271.75" y1="486.83" x2="2226.92" y2="481.71"/>
+  </g>
+  <g id="LWPOLYLINE-967" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2270.79" y1="496.44" x2="2225.64" y2="491.31"/>
+  </g>
+  <g id="LWPOLYLINE-968" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2269.51" y1="505.72" x2="2224.68" y2="500.6"/>
+  </g>
+  <g id="LWPOLYLINE-969" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2268.54" y1="515.33" x2="2223.4" y2="510.2"/>
+  </g>
+  <g id="LWPOLYLINE-970" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2267.58" y1="524.61" x2="2222.44" y2="519.49"/>
+  </g>
+  <g id="LWPOLYLINE-971" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2172.82 477.87 2194.91 475.63 2198.11 479.8 2202.27 470.51 2205.15 474.35 2227.89 472.11"/>
+  </g>
+  <g id="LWPOLYLINE-972" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2193.95" y1="531.34" x2="2199.07" y2="487.48"/>
+  </g>
+  <g id="LWPOLYLINE-973" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2202.59" y1="456.42" x2="2206.75" y2="419.6"/>
+  </g>
+  <g id="LWPOLYLINE-974" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2255.74" y1="427.28" x2="2243.25" y2="537.1"/>
+  </g>
+  <g id="LWPOLYLINE-975" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2257.98 427.28 2257.34 426.01 2255.74 425.36 2254.14 426.01 2253.5 427.28 2254.14 428.89 2255.74 429.52 2257.34 428.89 2257.98 427.28"/>
+  </g>
+  <g id="LWPOLYLINE-976" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2195.87 448.73 2202.59 456.42 2210.27 449.7"/>
+  </g>
+  <g id="LWPOLYLINE-977" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2247.09 421.2 2248.37 408.72 2252.86 409.04 2254.46 409.99 2255.42 411.28 2256.06 412.56 2256.38 414.48 2256.06 417.36 2255.42 418.96 2254.46 420.24 2253.18 421.2 2251.25 421.84 2247.09 421.2"/>
+  </g>
+  <g id="LWPOLYLINE-978" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2259.9 422.48 2261.18 410 2268.22 423.44 2269.51 410.96"/>
+  </g>
+  <g id="LWPOLYLINE-979" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2164.17" y1="328.35" x2="2162.89" y2="324.83"/>
+  </g>
+  <g id="LWPOLYLINE-980" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2294.16 375.42 2179.54 362.29 2176.02 351.41"/>
+  </g>
+  <g id="LWPOLYLINE-981" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2152.64 351.09 2164.17 328.35 2165.13 328.99 2153.92 351.72"/>
+  </g>
+  <g id="LWPOLYLINE-982" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2152.01 350.77 2154.57 352.04 2157.45 353 2160.33 353.65 2163.21 353.97 2166.41 353.97 2169.29 353.33 2172.18 352.69"/>
+  </g>
+  <g id="LWPOLYLINE-983" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2308.56" y1="136.58" x2="2286.16" y2="333.48"/>
+  </g>
+  <g id="LWPOLYLINE-984" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2290 298.26 2264.7 295.38 2264.7 296.66"/>
+  </g>
+  <g id="LWPOLYLINE-985" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2237.17" y1="220.14" x2="2236.21" y2="226.54"/>
+  </g>
+  <g id="LWPOLYLINE-986" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2234.6 251.84 2233.33 251.84 2232.69 257.6"/>
+  </g>
+  <g id="LWPOLYLINE-987" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2238.13" y1="220.14" x2="2237.49" y2="226.54"/>
+  </g>
+  <g id="LWPOLYLINE-988" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2237.21,226.37c6.77.74,12.98,4.14,17.24,9.45l-19.85,16.01-.64,4.8,60.19,6.72"/>
+  </g>
+  <g id="LWPOLYLINE-989" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2313.05" y1="134.98" x2="2289.68" y2="338.28"/>
+  </g>
+  <g id="LWPOLYLINE-990" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2232.68" y1="257.6" x2="2293.84" y2="264.32"/>
+  </g>
+  <g id="LWPOLYLINE-991" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2236.21" y1="226.54" x2="2237.49" y2="226.54"/>
+  </g>
+  <g id="LWPOLYLINE-992" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2166.09" y1="212.14" x2="2177.94" y2="213.41"/>
+  </g>
+  <g id="LWPOLYLINE-993" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2216.04 216.62 2215.72 217.58 2298.32 227.19"/>
+  </g>
+  <g id="LWPOLYLINE-994" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2166.41" y1="210.85" x2="2177.94" y2="212.13"/>
+  </g>
+  <g id="LWPOLYLINE-995" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2216.04" y1="216.62" x2="2298.32" y2="225.9"/>
+  </g>
+  <g id="LWPOLYLINE-996" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2176.98" y1="367.09" x2="2278.79" y2="378.62"/>
+  </g>
+  <g id="LWPOLYLINE-997" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2276.87" y1="395.27" x2="2291.59" y2="396.87"/>
+  </g>
+  <g id="LWPOLYLINE-998" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2176.98" y1="369.66" x2="2184.98" y2="370.62"/>
+  </g>
+  <g id="LWPOLYLINE-999" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2305.68 161.88 2256.7 156.43 2256.06 153.87"/>
+  </g>
+  <g id="LWPOLYLINE-1000" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2165.77" y1="218.22" x2="2169.29" y2="182.36"/>
+  </g>
+  <g id="LWPOLYLINE-1001" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2215.8,217.49c-1.12,10.11-6.22,19.35-14.17,25.7l-23.69-29.78v-1.28"/>
+  </g>
+  <g id="LWPOLYLINE-1002" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2153.61 517.25 2148.81 560.47 2146.56 560.15 2151.37 517.25"/>
+  </g>
+  <g id="LWPOLYLINE-1003" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2154.89 517.57 2149.76 517.25 2144.96 517.25 2139.84 517.89 2135.04 519.17 2130.24 521.09 2125.76 523.65 2121.6 526.53"/>
+  </g>
+  <g id="ARC">
+    <path class="cls-3" d="M2121.48,526.23c-18.82,14.82-22.06,42.09-7.24,60.9,7.33,9.31,18.14,15.21,29.94,16.34"/>
+  </g>
+  <g id="LWPOLYLINE-1004" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2193.31" y1="812.12" x2="2178.58" y2="810.2"/>
+  </g>
+  <g id="LWPOLYLINE-1005" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2179.54" y1="800.59" x2="2188.5" y2="811.48"/>
+  </g>
+  <g id="LWPOLYLINE-1006" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2185.3" y1="807.64" x2="2194.59" y2="802.19"/>
+  </g>
+  <g id="LWPOLYLINE-1007" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2194.91" y1="797.07" x2="2180.18" y2="795.47"/>
+  </g>
+  <g id="LWPOLYLINE-1008" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2181.46" y1="784.9" x2="2196.18" y2="786.83"/>
+  </g>
+  <g id="LWPOLYLINE-1009" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2180.82" y1="790.03" x2="2182.1" y2="780.1"/>
+  </g>
+  <g id="LWPOLYLINE-1010" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2186.9 767.3 2185.63 767.62 2184.02 768.9 2183.07 770.18 2182.74 773.06 2183.38 774.66 2184.66 776.25 2185.94 776.9 2187.87 777.86 2191.39 778.18 2193.63 777.86 2195.22 777.22 2196.83 775.94 2197.47 774.66 2197.79 771.78 2197.47 770.49 2196.18 768.9 2194.91 767.93"/>
+  </g>
+  <g id="LWPOLYLINE-1011" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2198.75" y1="764.09" x2="2184.03" y2="762.49"/>
+  </g>
+  <g id="LWPOLYLINE-1012" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2184.98" y1="752.57" x2="2199.71" y2="754.49"/>
+  </g>
+  <g id="LWPOLYLINE-1013" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2191.07" y1="763.45" x2="2192.03" y2="753.53"/>
+  </g>
+  <g id="LWPOLYLINE-1014" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2201.63 739.76 2200.35 748.73 2185.63 747.12 2186.9 737.84"/>
+  </g>
+  <g id="LWPOLYLINE-1015" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2192.66" y1="747.77" x2="2193.3" y2="742.32"/>
+  </g>
+  <g id="LWPOLYLINE-1016" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2201.95 735.28 2187.22 733.68 2203.23 725.67 2188.51 723.76"/>
+  </g>
+  <g id="LWPOLYLINE-1017" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2134.72" y1="739.44" x2="2134.08" y2="745.53"/>
+  </g>
+  <g id="CIRCLE-18" data-name="CIRCLE">
+    <circle class="cls-3" cx="2141.27" cy="739.29" r="1.45"/>
+  </g>
+  <g id="LWPOLYLINE-1018" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2133.12" y1="737.2" x2="2132.8" y2="739.44"/>
+  </g>
+  <g id="CIRCLE-19" data-name="CIRCLE">
+    <circle class="cls-3" cx="2132.96" cy="740.24" r=".8"/>
+  </g>
+  <g id="SPLINE">
+    <path class="cls-3" d="M2134.39,736.17c.05-.44-.27-.84-.7-.88"/>
+  </g>
+  <g id="ARC-2" data-name="ARC">
+    <path class="cls-3" d="M2133.69,735.29c-.43-.05-.83.26-.88.69s.26.83.69.88.83-.26.88-.69c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1019" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2134.08 737.2 2138.88 738.48 2138.88 739.44 2133.75 739.76"/>
+  </g>
+  <g id="ARC-3" data-name="ARC">
+    <path class="cls-3" d="M2129.92,747.44c-.09.79.48,1.5,1.27,1.59,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1020" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2130.24" y1="747.77" x2="2132.47" y2="728.56"/>
+  </g>
+  <g id="LWPOLYLINE-1021" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.52" y1="750.97" x2="2131.51" y2="749.05"/>
+  </g>
+  <g id="SPLINE-2" data-name="SPLINE">
+    <path class="cls-3" d="M2147.2,750.96c.79.09,1.5-.48,1.59-1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1022" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.04" y1="730.8" x2="2148.81" y2="749.69"/>
+  </g>
+  <g id="ARC-4" data-name="ARC">
+    <path class="cls-3" d="M2151.03,730.48c.09-.79-.48-1.5-1.27-1.59"/>
+  </g>
+  <g id="LWPOLYLINE-1023" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2133.75" y1="727.6" x2="2150.09" y2="729.2"/>
+  </g>
+  <g id="ARC-5" data-name="ARC">
+    <path class="cls-3" d="M2133.76,727.28c-.79-.08-1.5.48-1.59,1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1024" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2133.77,745.38c-.13,1.54,1.01,2.89,2.54,3.03l8.65.96c1.41.17,2.7-.83,2.88-2.24l1.6-14.08c.21-1.55-.87-2.97-2.41-3.19"/>
+  </g>
+  <g id="LWPOLYLINE-1025" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.2" y1="730.16" x2="2138.24" y2="729.2"/>
+  </g>
+  <g id="LWPOLYLINE-1026" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2135.36" y1="731.44" x2="2134.72" y2="737.52"/>
+  </g>
+  <g id="ARC-6" data-name="ARC">
+    <path class="cls-3" d="M2138.06,728.89c-1.49-.17-2.84.9-3.01,2.39"/>
+  </g>
+  <g id="LWPOLYLINE-1027" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2241.97,353.01l-.96,5.76c-.14,1.54-1.49,2.67-3.03,2.54"/>
+  </g>
+  <g id="CIRCLE-20" data-name="CIRCLE">
+    <circle class="cls-3" cx="2235.1" cy="350.92" r="1.43"/>
+  </g>
+  <g id="LWPOLYLINE-1028" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2243.89" y1="350.77" x2="2243.57" y2="353.33"/>
+  </g>
+  <g id="SPLINE-3" data-name="SPLINE">
+    <path class="cls-3" d="M2243.57,354.22c.05-.44-.27-.84-.7-.88"/>
+  </g>
+  <g id="ARC-7" data-name="ARC">
+    <path class="cls-3" d="M2242.87,353.33c-.44-.05-.84.26-.89.7s.26.84.7.89.84-.26.89-.7c0,0,0,0,0,0"/>
+  </g>
+  <g id="SPLINE-4" data-name="SPLINE">
+    <path class="cls-3" d="M2244.21,350.05c.05-.44-.27-.84-.7-.88"/>
+  </g>
+  <g id="ARC-8" data-name="ARC">
+    <path class="cls-3" d="M2243.51,349.17c-.43-.05-.83.26-.88.69s.26.83.69.88.83-.26.88-.69c0,0,0,0,0-.01"/>
+  </g>
+  <g id="LWPOLYLINE-1029" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2242.93 350.77 2237.81 351.09 2237.49 352.04 2242.61 353.33"/>
+  </g>
+  <g id="ARC-9" data-name="ARC">
+    <path class="cls-3" d="M2242.61,362.92c.79.08,1.5-.48,1.59-1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1030" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2244.21,361.97l2.24-19.21c.09-.79-.48-1.5-1.27-1.59,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1031" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2226.6" y1="361.01" x2="2242.94" y2="362.93"/>
+  </g>
+  <g id="SPLINE-5" data-name="SPLINE">
+    <path class="cls-3" d="M2225.33,359.41c-.09.79.48,1.5,1.27,1.59"/>
+  </g>
+  <g id="LWPOLYLINE-1032" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2227.56" y1="340.84" x2="2225.64" y2="359.73"/>
+  </g>
+  <g id="ARC-10" data-name="ARC">
+    <path class="cls-3" d="M2228.85,339.25c-.79-.09-1.5.47-1.59,1.26,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1033" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2245.17" y1="341.48" x2="2229.16" y2="339.56"/>
+  </g>
+  <g id="LWPOLYLINE-1034" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2238.45,361.33l-8.96-1.28c-1.54-.14-2.68-1.49-2.55-3.03"/>
+  </g>
+  <g id="LWPOLYLINE-1035" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2227.24" y1="357.17" x2="2228.85" y2="343.4"/>
+  </g>
+  <g id="ARC-11" data-name="ARC">
+    <path class="cls-3" d="M2231.55,340.86c-1.49-.17-2.84.9-3.01,2.39"/>
+  </g>
+  <g id="LWPOLYLINE-1036" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2231.41" y1="341.16" x2="2240.36" y2="342.12"/>
+  </g>
+  <g id="LWPOLYLINE-1037" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2240.2,341.82c1.54.22,2.62,1.64,2.41,3.19l-.64,5.76"/>
+  </g>
+  <g id="LWPOLYLINE-1038" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2186.26 335.4 2184.98 346.61 2184.02 348.52 2183.06 349.17 2181.78 349.8 2180.18 349.48 2178.9 348.84 2178.26 347.88 2177.94 345.64 2177.94 344.36"/>
+  </g>
+  <g id="LWPOLYLINE-1039" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2188.82 350.45 2196.19 336.36 2200.03 351.72"/>
+  </g>
+  <g id="LWPOLYLINE-1040" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2191.39" y1="345.96" x2="2198.43" y2="346.6"/>
+  </g>
+  <g id="LWPOLYLINE-1041" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2204.19 352.37 2205.79 337.64 2214.12 353.33 2215.72 338.6"/>
+  </g>
+  <g id="LWPOLYLINE-1042" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2220.52 352.69 2219.88 353.32 2220.2 354.29 2221.16 353.65"/>
+  </g>
+  <g id="LWPOLYLINE-1043" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2264.7" y1="296.66" x2="2290" y2="299.54"/>
+  </g>
+  <g id="LWPOLYLINE-1044" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2257.02" y1="219.82" x2="2289.03" y2="223.34"/>
+  </g>
+  <g id="LWPOLYLINE-1045" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2289.35" y1="221.74" x2="2257.34" y2="218.22"/>
+  </g>
+  <g id="LWPOLYLINE-1046" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2286.26,211.96c1.18-.21,2.32-.62,3.36-1.21.6-.32,1.16-.71,1.66-1.18l1.6.32.96-7.37-1.6-.32"/>
+  </g>
+  <g id="SPLINE-6" data-name="SPLINE">
+    <path class="cls-3" d="M2275.77,199.75c-.13.1-.2.27-.18.44"/>
+  </g>
+  <g id="SPLINE-7" data-name="SPLINE">
+    <path class="cls-3" d="M2275.59,200.18c.02.17.12.31.27.38"/>
+  </g>
+  <g id="LWPOLYLINE-1047" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2275.91" y1="200.93" x2="2278.15" y2="201.89"/>
+  </g>
+  <g id="SPLINE-8" data-name="SPLINE">
+    <path class="cls-3" d="M2278.11,201.53c.14.06.3.06.43-.02"/>
+  </g>
+  <g id="ARC-12" data-name="ARC">
+    <path class="cls-3" d="M2280.88,201.05c-.72.14-1.42.39-2.07.74"/>
+  </g>
+  <g id="ARC-13" data-name="ARC">
+    <path class="cls-3" d="M2278.18,206.84c.55.5,1.17.9,1.85,1.19"/>
+  </g>
+  <g id="ARC-14" data-name="ARC">
+    <path class="cls-3" d="M2277.99,207.14c-.11-.1-.27-.14-.42-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1048" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2277.83" y1="207.01" x2="2275.27" y2="207.65"/>
+  </g>
+  <g id="SPLINE-9" data-name="SPLINE">
+    <path class="cls-3" d="M2275.01,207.34c-.16.03-.29.15-.35.3"/>
+  </g>
+  <g id="SPLINE-10" data-name="SPLINE">
+    <path class="cls-3" d="M2274.66,207.65c-.06.15-.03.32.07.45"/>
+  </g>
+  <g id="ARC-15" data-name="ARC">
+    <path class="cls-3" d="M2276.97,198.64c-1.13.56-2.13,1.35-2.92,2.32"/>
+  </g>
+  <g id="ARC-16" data-name="ARC">
+    <path class="cls-3" d="M2280.93,197.55c-1.3.19-2.56.59-3.74,1.17"/>
+  </g>
+  <g id="ARC-17" data-name="ARC">
+    <path class="cls-3" d="M2275.89,209.09c.84.78,1.8,1.42,2.85,1.88"/>
+  </g>
+  <g id="LWPOLYLINE-1049" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2277.83" y1="207.01" x2="2277.83" y2="207.01"/>
+  </g>
+  <g id="LWPOLYLINE-1050" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2274.95" y1="207.97" x2="2274.95" y2="207.97"/>
+  </g>
+  <g id="ARC-18" data-name="ARC">
+    <path class="cls-3" d="M2276.52,200.79c-.45.34-.87.74-1.23,1.18"/>
+  </g>
+  <g id="LWPOLYLINE-1051" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2254.78" y1="220.14" x2="2256.38" y2="220.46"/>
+  </g>
+  <g id="LWPOLYLINE-1052" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2254.14 220.14 2254.14 220.46 2253.81 220.78 2257.01 221.42 2257.01 220.78 2257.01 220.46 2256.37 220.46 2256.37 220.14"/>
+  </g>
+  <g id="SPLINE-11" data-name="SPLINE">
+    <path class="cls-3" d="M2256.91,219.5c-.27-.03-.51.16-.53.43"/>
+  </g>
+  <g id="LWPOLYLINE-1053" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2257.09,217.91c-1.16-.11-2.2.74-2.32,1.9,0,0,0,0,0,0v.32h-.64"/>
+  </g>
+  <g id="LWPOLYLINE-1054" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2298" y1="215.66" x2="2301.52" y2="183.64"/>
+  </g>
+  <g id="LWPOLYLINE-1055" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2302.24,181.41c-1.17-.11-2.2.74-2.32,1.91l-3.52,32.34"/>
+  </g>
+  <g id="LWPOLYLINE-1056" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2302.16 183.32 2302.48 183.32 2302.16 183.64 2302.48 183.96 2303.12 183.96 2303.44 180.76 2302.8 180.76 2302.48 181.07 2302.48 181.72 2302.16 181.72"/>
+  </g>
+  <g id="SPLINE-12" data-name="SPLINE">
+    <path class="cls-3" d="M2302.06,183c-.27-.03-.51.16-.53.43"/>
+  </g>
+  <g id="LWPOLYLINE-1057" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2302.48" y1="183.32" x2="2302.48" y2="181.72"/>
+  </g>
+  <g id="ARC-19" data-name="ARC">
+    <path class="cls-3" d="M2282.07,212.09c.52.11,1.05.2,1.59.26"/>
+  </g>
+  <g id="LWPOLYLINE-1058" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2283.91" y1="212.46" x2="2296.4" y2="214.06"/>
+  </g>
+  <g id="LWPOLYLINE-1059" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2298,199.33l-12.48-1.6c-1.57-.14-3.14-.07-4.69.2"/>
+  </g>
+  <g id="LWPOLYLINE-1060" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2298 214.06 2299.6 214.38 2300.24 210.22 2300.56 207.01 2300.88 203.81 2301.2 199.65 2299.6 199.33"/>
+  </g>
+  <g id="LWPOLYLINE-1061" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2298.32" y1="217.9" x2="2298.64" y2="216.3"/>
+  </g>
+  <g id="LWPOLYLINE-1062" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2298.32 218.54 2298.64 218.86 2298.96 218.86"/>
+  </g>
+  <g id="LWPOLYLINE-1063" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2298.64" y1="216.3" x2="2298.32" y2="216.3"/>
+  </g>
+  <g id="LWPOLYLINE-1064" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2298 217.9 2298.32 217.9 2298.32 218.54"/>
+  </g>
+  <g id="LWPOLYLINE-1065" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2298.96 218.86 2299.6 215.66 2298.96 215.66 2298.64 215.98 2298.64 216.3"/>
+  </g>
+  <g id="SPLINE-13" data-name="SPLINE">
+    <path class="cls-3" d="M2297.68,215.44c-.03.27.16.51.43.53"/>
+  </g>
+  <g id="ARC-20" data-name="ARC">
+    <path class="cls-3" d="M2296.09,215.26c-.13,1.14.69,2.17,1.83,2.3,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1066" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2289.67 223.98 2289.67 224.3 2289.04 223.98 2288.71 224.3 2288.71 224.94 2291.91 225.26 2291.91 224.62 2291.6 224.3 2291.27 224.3 2291.27 223.98"/>
+  </g>
+  <g id="SPLINE-14" data-name="SPLINE">
+    <path class="cls-3" d="M2289.35,223.88c.03-.27-.16-.51-.43-.53"/>
+  </g>
+  <g id="LWPOLYLINE-1067" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2289.67" y1="224.3" x2="2291.27" y2="224.3"/>
+  </g>
+  <g id="ARC-21" data-name="ARC">
+    <path class="cls-3" d="M2290.94,224.06c.13-1.14-.69-2.17-1.83-2.3,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-22" data-name="ARC">
+    <path class="cls-3" d="M2277.59,252.11c.52.1,1.05.19,1.59.25"/>
+  </g>
+  <g id="LWPOLYLINE-1068" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2279.43 252.8 2295.12 254.4 2295.44 250.24 2295.76 247.03 2296.4 243.83 2296.71 239.67 2281.03 238.07"/>
+  </g>
+  <g id="LWPOLYLINE-1069" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2270.46" y1="247.99" x2="2270.46" y2="247.99"/>
+  </g>
+  <g id="ARC-23" data-name="ARC">
+    <path class="cls-3" d="M2270.44,248.39c.27.36.57.7.9,1.01"/>
+  </g>
+  <g id="LWPOLYLINE-1070" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2273.35" y1="247.03" x2="2273.35" y2="247.03"/>
+  </g>
+  <g id="ARC-24" data-name="ARC">
+    <path class="cls-3" d="M2276.13,237.57c-1.3.19-2.56.59-3.74,1.17"/>
+  </g>
+  <g id="ARC-25" data-name="ARC">
+    <path class="cls-3" d="M2280.96,237.86c-1.54-.17-3.09-.15-4.61.08"/>
+  </g>
+  <g id="SPLINE-15" data-name="SPLINE">
+    <path class="cls-3" d="M2271.11,240.21c.02.17.12.31.27.38"/>
+  </g>
+  <g id="ARC-26" data-name="ARC">
+    <path class="cls-3" d="M2271.29,239.77c-.14.1-.2.27-.18.44"/>
+  </g>
+  <g id="LWPOLYLINE-1071" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2271.43" y1="240.95" x2="2273.66" y2="241.91"/>
+  </g>
+  <g id="SPLINE-16" data-name="SPLINE">
+    <path class="cls-3" d="M2273.62,241.87c.14.06.3.06.44-.02"/>
+  </g>
+  <g id="ARC-27" data-name="ARC">
+    <path class="cls-3" d="M2276.08,241.07c-.72.14-1.42.39-2.07.74"/>
+  </g>
+  <g id="ARC-28" data-name="ARC">
+    <path class="cls-3" d="M2284.37,247.35c.92-.98,1.08-2.44.41-3.6"/>
+  </g>
+  <g id="SPLINE-17" data-name="SPLINE">
+    <path class="cls-3" d="M2273.51,247.16c-.12-.1-.27-.14-.42-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1072" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2273.03" y1="247.03" x2="2270.79" y2="247.67"/>
+  </g>
+  <g id="SPLINE-18" data-name="SPLINE">
+    <path class="cls-3" d="M2270.53,247.68c-.16.04-.29.15-.35.3"/>
+  </g>
+  <g id="SPLINE-19" data-name="SPLINE">
+    <path class="cls-3" d="M2270.18,247.99c-.06.15-.04.33.07.46"/>
+  </g>
+  <g id="LWPOLYLINE-1073" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2286.79 249.92 2288.39 249.92 2289.35 242.55 2287.75 242.55"/>
+  </g>
+  <g id="ARC-29" data-name="ARC">
+    <path class="cls-3" d="M2283.31,238.54c-1.81-.79-3.77-1.17-5.74-1.11"/>
+  </g>
+  <g id="ARC-30" data-name="ARC">
+    <path class="cls-3" d="M2270.25,245.9c.27.54.61,1.05,1,1.51"/>
+  </g>
+  <g id="ARC-31" data-name="ARC">
+    <path class="cls-3" d="M2268.81,246.61c.32.64.71,1.24,1.17,1.78"/>
+  </g>
+  <g id="LWPOLYLINE-1074" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2161.93" y1="218.54" x2="2095.34" y2="240.31"/>
+  </g>
+  <g id="LWPOLYLINE-1075" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2103.66" y1="218.54" x2="2105.26" y2="217.9"/>
+  </g>
+  <g id="LWPOLYLINE-1076" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2103.02" y1="216.62" x2="2107.82" y2="215.02"/>
+  </g>
+  <g id="LWPOLYLINE-1077" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.27 212.78 2105.26 215.34 2097.25 218.22"/>
+  </g>
+  <g id="SPLINE-20" data-name="SPLINE">
+    <path class="cls-3" d="M2103.03,218.43c.03.08.12.13.2.1"/>
+  </g>
+  <g id="SPLINE-21" data-name="SPLINE">
+    <path class="cls-3" d="M2102.81,216.63c-.08.03-.13.12-.1.2"/>
+  </g>
+  <g id="LWPOLYLINE-1078" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2103.34" y1="218.54" x2="2102.7" y2="216.94"/>
+  </g>
+  <g id="ARC-32" data-name="ARC">
+    <path class="cls-3" d="M2096.95,217.85c-1.15.6-1.61,2.01-1.05,3.18"/>
+  </g>
+  <g id="LWPOLYLINE-1079" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2106.54" y1="220.78" x2="2104.94" y2="217.26"/>
+  </g>
+  <g id="LWPOLYLINE-1080" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2106.86" y1="217.58" x2="2108.46" y2="216.94"/>
+  </g>
+  <g id="SPLINE-22" data-name="SPLINE">
+    <path class="cls-3" d="M2107.81,215.13c-.03-.08-.12-.13-.2-.1"/>
+  </g>
+  <g id="ARC-33" data-name="ARC">
+    <path class="cls-3" d="M2108.35,216.61c.08-.03.13-.12.1-.2"/>
+  </g>
+  <g id="LWPOLYLINE-1081" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2108.78" y1="216.62" x2="2108.15" y2="215.02"/>
+  </g>
+  <g id="ARC-34" data-name="ARC">
+    <path class="cls-3" d="M2104.66,217.03c.02.06.04.11.08.17"/>
+  </g>
+  <g id="SPLINE-23" data-name="SPLINE">
+    <path class="cls-3" d="M2104.62,216.72c0,.1,0,.21.04.31"/>
+  </g>
+  <g id="ARC-35" data-name="ARC">
+    <path class="cls-3" d="M2104.71,216.42c-.05.09-.07.2-.08.3"/>
+  </g>
+  <g id="SPLINE-24" data-name="SPLINE">
+    <path class="cls-3" d="M2104.9,216.17c-.08.07-.14.16-.19.25"/>
+  </g>
+  <g id="ARC-36" data-name="ARC">
+    <path class="cls-3" d="M2105.17,216.02c-.1.03-.2.09-.28.16"/>
+  </g>
+  <g id="SPLINE-25" data-name="SPLINE">
+    <path class="cls-3" d="M2105.48,215.98c-.1,0-.21,0-.31.04"/>
+  </g>
+  <g id="ARC-37" data-name="ARC">
+    <path class="cls-3" d="M2105.78,216.06c-.09-.05-.2-.07-.3-.08"/>
+  </g>
+  <g id="SPLINE-26" data-name="SPLINE">
+    <path class="cls-3" d="M2106.03,216.26c-.07-.08-.16-.14-.25-.19"/>
+  </g>
+  <g id="ARC-38" data-name="ARC">
+    <path class="cls-3" d="M2106.18,216.53c-.03-.1-.09-.19-.16-.27"/>
+  </g>
+  <g id="SPLINE-27" data-name="SPLINE">
+    <path class="cls-3" d="M2104.42,216.27c-.07.13-.1.28-.12.42"/>
+  </g>
+  <g id="SPLINE-28" data-name="SPLINE">
+    <path class="cls-3" d="M2104.69,215.93c-.11.09-.2.21-.27.35"/>
+  </g>
+  <g id="SPLINE-29" data-name="SPLINE">
+    <path class="cls-3" d="M2105.07,215.71c-.14.05-.27.12-.38.21"/>
+  </g>
+  <g id="ARC-39" data-name="ARC">
+    <path class="cls-3" d="M2105.51,215.66c-.15-.01-.3,0-.44.06"/>
+  </g>
+  <g id="SPLINE-30" data-name="SPLINE">
+    <path class="cls-3" d="M2105.93,215.78c-.13-.07-.28-.1-.42-.12"/>
+  </g>
+  <g id="SPLINE-31" data-name="SPLINE">
+    <path class="cls-3" d="M2106.25,220.77c.08.25.35.39.61.3"/>
+  </g>
+  <g id="ARC-40" data-name="ARC">
+    <path class="cls-3" d="M2106.86,221.07c.25-.08.38-.35.3-.6,0,0,0,0,0-.01"/>
+  </g>
+  <g id="LWPOLYLINE-1082" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2107.5" y1="220.46" x2="2106.54" y2="216.62"/>
+  </g>
+  <g id="LWPOLYLINE-1083" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2142.4,204.45l.31,1.39c.06.06.06.15.01.21l-1.92.64"/>
+  </g>
+  <g id="ARC-41" data-name="ARC">
+    <path class="cls-3" d="M2140.76,206.96c2.24-.76,4.44-1.63,6.59-2.61"/>
+  </g>
+  <g id="LWPOLYLINE-1084" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2142.08" y1="204.13" x2="2136.95" y2="205.73"/>
+  </g>
+  <g id="LWPOLYLINE-1085" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2131.19 207.33 2139.52 204.45 2147.53 201.89"/>
+  </g>
+  <g id="ARC-42" data-name="ARC">
+    <path class="cls-3" d="M2147.42,217.6c1.07-1.14,1.88-2.49,2.39-3.97"/>
+  </g>
+  <g id="ARC-43" data-name="ARC">
+    <path class="cls-3" d="M2150.28,213.71c.53-1.55.79-3.18.76-4.82"/>
+  </g>
+  <g id="ARC-44" data-name="ARC">
+    <path class="cls-3" d="M2150.72,208.84c-.02-1.83-.33-3.65-.9-5.39"/>
+  </g>
+  <g id="SPLINE-32" data-name="SPLINE">
+    <path class="cls-3" d="M2142.07,204.24c-.02-.08-.12-.13-.2-.1"/>
+  </g>
+  <g id="ARC-45" data-name="ARC">
+    <path class="cls-3" d="M2150.05,203.54c-.24-1.28-1.44-2.14-2.73-1.95"/>
+  </g>
+  <g id="LWPOLYLINE-1086" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2141.76,209.9l-.96-3.84c.03-.17.01-.35-.05-.52"/>
+  </g>
+  <g id="LWPOLYLINE-1087" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2139.52" y1="207.33" x2="2137.6" y2="207.66"/>
+  </g>
+  <g id="ARC-46" data-name="ARC">
+    <path class="cls-3" d="M2132.61,209.31c-.59.2-.9.83-.71,1.41"/>
+  </g>
+  <g id="ARC-47" data-name="ARC">
+    <path class="cls-3" d="M2132.42,209.26c2.31-.49,4.6-1.09,6.85-1.81"/>
+  </g>
+  <g id="SPLINE-33" data-name="SPLINE">
+    <path class="cls-3" d="M2136.75,205.74c-.09.03-.13.12-.1.2"/>
+  </g>
+  <g id="SPLINE-34" data-name="SPLINE">
+    <path class="cls-3" d="M2137.29,207.54c.03.09.12.13.2.1"/>
+  </g>
+  <g id="LWPOLYLINE-1088" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2137.28" y1="207.65" x2="2136.96" y2="206.05"/>
+  </g>
+  <g id="ARC-48" data-name="ARC">
+    <path class="cls-3" d="M2140.48,205.82c0-.06-.02-.12-.04-.18"/>
+  </g>
+  <g id="SPLINE-35" data-name="SPLINE">
+    <path class="cls-3" d="M2140.44,205.64c-.04-.1-.09-.19-.16-.27"/>
+  </g>
+  <g id="SPLINE-36" data-name="SPLINE">
+    <path class="cls-3" d="M2140.29,205.37c-.07-.08-.15-.14-.25-.19"/>
+  </g>
+  <g id="SPLINE-37" data-name="SPLINE">
+    <path class="cls-3" d="M2140.04,205.18c-.09-.05-.2-.08-.3-.09"/>
+  </g>
+  <g id="SPLINE-38" data-name="SPLINE">
+    <path class="cls-3" d="M2139.74,205.09c-.1,0-.21,0-.31.04"/>
+  </g>
+  <g id="SPLINE-39" data-name="SPLINE">
+    <path class="cls-3" d="M2139.43,205.13c-.1.03-.19.08-.28.16"/>
+  </g>
+  <g id="SPLINE-40" data-name="SPLINE">
+    <path class="cls-3" d="M2139.16,205.29c-.08.07-.14.16-.19.25"/>
+  </g>
+  <g id="SPLINE-41" data-name="SPLINE">
+    <path class="cls-3" d="M2138.97,205.53c-.05.09-.08.2-.09.3"/>
+  </g>
+  <g id="SPLINE-42" data-name="SPLINE">
+    <path class="cls-3" d="M2138.88,205.83c0,.1,0,.21.04.31"/>
+  </g>
+  <g id="SPLINE-43" data-name="SPLINE">
+    <path class="cls-3" d="M2140.74,205.54c-.04-.14-.12-.27-.21-.38"/>
+  </g>
+  <g id="SPLINE-44" data-name="SPLINE">
+    <path class="cls-3" d="M2138.95,205.04c-.11.09-.2.21-.27.35"/>
+  </g>
+  <g id="SPLINE-45" data-name="SPLINE">
+    <path class="cls-3" d="M2138.68,205.39c-.07.13-.1.28-.12.42"/>
+  </g>
+  <g id="ARC-49" data-name="ARC">
+    <path class="cls-3" d="M2138.56,205.81c-.03.36.12.72.4.95"/>
+  </g>
+  <g id="SPLINE-46" data-name="SPLINE">
+    <path class="cls-3" d="M2140.5,209.89c.08.25.35.39.61.3"/>
+  </g>
+  <g id="ARC-50" data-name="ARC">
+    <path class="cls-3" d="M2141.11,210.19c.25-.08.38-.34.3-.59,0,0,0-.01,0-.02"/>
+  </g>
+  <g id="LWPOLYLINE-1089" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2140.48" y1="210.22" x2="2138.88" y2="206.38"/>
+  </g>
+  <g id="ARC-51" data-name="ARC">
+    <path class="cls-3" d="M2131.2,206.97c-1.15.6-1.61,2.01-1.05,3.18"/>
+  </g>
+  <g id="ARC-52" data-name="ARC">
+    <path class="cls-3" d="M2135.95,218.18c1.28.89,2.74,1.49,4.28,1.78"/>
+  </g>
+  <g id="ARC-53" data-name="ARC">
+    <path class="cls-3" d="M2132.58,215.15c.95,1.33,2.13,2.49,3.48,3.42"/>
+  </g>
+  <g id="ARC-54" data-name="ARC">
+    <path class="cls-3" d="M2130.18,209.94c.57,1.74,1.41,3.39,2.48,4.88"/>
+  </g>
+  <g id="CIRCLE-21" data-name="CIRCLE">
+    <circle class="cls-3" cx="2286.3" cy="316.35" r="1.13"/>
+  </g>
+  <g id="LWPOLYLINE-1090" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2288.71" y1="311.71" x2="2285.19" y2="311.07"/>
+  </g>
+  <g id="LWPOLYLINE-1091" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2274.95 320.99 2275.59 321.31 2276.55 321.63 2277.51 321.95 2278.15 322.27 2279.11 322.59 2280.39 322.91 2281.99 323.23 2283.91 323.55 2287.11 323.87 2288.08 316.5 2288.71 309.47 2285.52 309.15"/>
+  </g>
+  <g id="LWPOLYLINE-1092" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2287.43 321.63 2284.23 321.31 2284.87 316.18"/>
+  </g>
+  <g id="LWPOLYLINE-1093" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2284.55 318.75 2284.23 319.39 2284.23 319.71 2283.91 320.03 2283.59 320.03 2283.59 320.35 2283.27 320.35 2282.95 320.35 2282.63 320.35 2282.31 320.35 2281.99 320.35 2281.67 320.35 2281.35 320.35 2281.03 320.35 2280.71 320.35 2280.39 320.35 2280.07 320.35 2279.75 320.35 2279.43 320.35 2279.11 320.35 2278.79 320.03 2278.47 320.03 2278.15 320.03 2277.83 320.03 2277.51 320.03 2277.19 320.03 2276.87 320.03 2276.55 320.03 2276.23 320.03 2276.23 319.71 2275.91 319.71 2275.59 319.71 2275.27 319.39 2274.95 319.39 2274.95 319.07 2274.63 318.75 2274.63 318.43 2274.63 318.11 2274.63 317.79 2274.63 317.47 2274.63 316.83 2274.63 316.51 2274.63 315.87 2274.63 315.23"/>
+  </g>
+  <g id="LWPOLYLINE-1094" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2284.23 321.31 2283.59 321.31 2282.63 321.31 2282.31 321.31 2281.67 321.31 2281.03 321.31 2280.39 321.31 2280.07 321.31 2279.43 321.31 2279.11 321.31 2278.78 321.31 2278.15 321.31 2277.82 321.31 2277.51 321.31 2276.87 321.31 2276.55 321.31 2276.22 321.31 2275.91 321.31 2275.59 321.31 2275.59 320.99 2275.27 320.99 2274.95 320.99 2274.63 320.99 2274.31 320.67 2273.99 320.67 2273.67 320.35 2273.67 320.03 2273.35 319.71 2273.35 318.75 2273.03 317.79 2273.03 316.51 2273.35 314.9 2273.67 313.3 2273.99 312.03 2273.99 311.07 2274.31 310.43 2274.63 310.1 2274.95 309.79 2275.27 309.47 2275.59 309.47 2275.91 309.47 2276.22 309.47 2276.55 309.47 2276.87 309.47 2277.19 309.47 2277.51 309.47 2277.82 309.47 2278.47 309.79 2278.78 309.79 2279.11 309.79 2279.43 309.79 2280.07 310.1 2280.39 310.1 2280.71 310.1 2281.35 310.1 2281.67 310.43 2282.31 310.43 2282.95 310.43 2283.27 310.75 2283.91 310.75 2284.55 311.07 2285.19 311.07"/>
+  </g>
+  <g id="LWPOLYLINE-1095" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2285.51 309.14 2283.59 308.82 2281.99 308.82 2280.71 308.82 2279.75 308.82 2278.79 309.14 2277.83 309.14 2276.87 309.14 2276.23 309.46"/>
+  </g>
+  <g id="LWPOLYLINE-1096" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2284.87 313.63 2284.87 313.31 2284.87 312.99 2284.87 312.67 2284.87 312.35 2284.55 312.35 2284.55 312.02 2284.23 312.02 2283.91 312.02 2283.59 312.02 2283.27 311.71 2282.95 311.71 2282.63 311.71 2282.31 311.71 2281.99 311.39 2281.67 311.39 2281.35 311.39 2281.03 311.39 2280.71 311.39 2280.39 311.07 2280.07 311.07 2279.75 311.07 2279.43 311.07 2279.11 311.07 2278.79 311.07 2278.46 310.75 2278.15 310.75 2277.83 310.75 2277.51 310.75 2277.19 310.75 2276.87 310.75 2276.55 310.75 2276.55 311.07 2276.23 311.07 2275.91 311.07 2275.91 311.39 2275.59 311.39 2275.59 311.71 2275.27 312.02 2275.27 312.35 2274.95 312.67 2274.95 312.99 2274.95 313.31 2274.63 313.95 2274.63 314.27 2274.63 315.23"/>
+  </g>
+  <g id="LWPOLYLINE-1097" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2285.19" y1="311.07" x2="2284.87" y2="316.19"/>
+  </g>
+  <g id="CIRCLE-22" data-name="CIRCLE">
+    <circle class="cls-3" cx="2290.17" cy="281.45" r="1.13"/>
+  </g>
+  <g id="LWPOLYLINE-1098" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2291.27" y1="287.05" x2="2288.08" y2="286.42"/>
+  </g>
+  <g id="LWPOLYLINE-1099" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2280.07 274.57 2280.71 274.57 2281.99 274.25 2282.96 274.25 2283.59 274.25 2284.56 274.25 2285.83 274.25 2287.43 274.25 2289.35 274.25 2292.88 274.57 2291.92 281.93 2290.96 288.97 2287.76 288.65"/>
+  </g>
+  <g id="LWPOLYLINE-1100" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2292.56 276.81 2289.36 276.49 2288.72 281.61"/>
+  </g>
+  <g id="LWPOLYLINE-1101" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2289.03 278.73 2289.03 278.41 2289.03 278.09 2288.71 277.77 2288.71 277.45 2288.39 277.45 2288.07 277.45 2288.07 277.13 2287.76 277.13 2287.43 277.13 2287.11 277.13 2286.79 276.81 2286.47 276.81 2286.15 276.81 2285.83 276.81 2285.51 276.81 2285.2 276.49 2284.87 276.49 2284.55 276.49 2284.23 276.49 2283.91 276.49 2283.59 276.17 2283.27 276.17 2282.95 276.17 2282.64 276.17 2282.31 276.17 2281.99 276.17 2281.67 276.17 2281.35 276.17 2281.03 276.17 2280.71 276.17 2280.39 276.17 2280.07 276.17 2280.07 276.49 2279.75 276.49 2279.75 276.81 2279.43 276.81 2279.43 277.13 2279.11 277.45 2279.11 277.77 2278.79 278.09 2278.79 278.41 2278.79 279.05 2278.47 279.69 2278.47 280.33"/>
+  </g>
+  <g id="LWPOLYLINE-1102" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2289.35 276.49 2288.72 276.17 2288.07 276.17 2287.43 275.85 2286.79 275.85 2286.16 275.53 2285.83 275.53 2285.2 275.53 2284.87 275.53 2284.23 275.21 2283.91 275.21 2283.59 275.21 2282.96 274.88 2282.63 274.88 2282.31 274.88 2281.99 274.88 2281.67 274.88 2281.35 274.88 2281.03 274.56 2280.71 274.56 2280.39 274.56 2280.07 274.56 2279.75 274.56 2279.43 274.88 2279.11 274.88 2278.79 274.88 2278.79 275.21 2278.47 275.85 2278.15 276.49 2277.83 277.45 2277.51 278.73 2277.19 280.33 2277.19 281.94 2277.19 283.21 2277.19 284.17 2277.19 284.81 2277.51 285.13 2277.83 285.77 2278.15 286.1 2278.47 286.1 2278.79 286.1 2278.79 286.41 2279.11 286.41 2279.43 286.41 2279.75 286.41 2280.07 286.41 2280.39 286.41 2280.71 286.41 2281.03 286.41 2281.35 286.41 2281.67 286.41 2282.31 286.41 2282.63 286.41 2282.96 286.41 2283.59 286.73 2283.91 286.73 2284.56 286.73 2284.87 286.73 2285.52 286.73 2286.16 286.73 2286.79 286.73 2287.43 286.41 2288.07 286.41"/>
+  </g>
+  <g id="LWPOLYLINE-1103" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2287.75 288.65 2285.83 288.33 2284.23 288.02 2283.27 287.69 2282.31 287.38 2281.35 287.38 2280.39 287.05 2279.43 286.42 2278.79 286.09"/>
+  </g>
+  <g id="LWPOLYLINE-1104" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2288.39 284.17 2288.39 284.49 2288.07 284.81 2288.07 285.13 2287.75 285.45 2287.43 285.45 2287.11 285.45 2286.79 285.45 2286.47 285.45 2286.15 285.45 2285.83 285.45 2285.51 285.45 2285.19 285.45 2284.87 285.45 2284.56 285.45 2284.23 285.45 2283.91 285.45 2283.59 285.45 2283.27 285.45 2282.96 285.45 2282.63 285.45 2282.31 285.45 2281.99 285.45 2281.67 285.45 2281.35 285.45 2281.03 285.13 2280.71 285.13 2280.39 285.13 2280.07 285.13 2279.75 285.13 2279.75 284.81 2279.43 284.81 2279.11 284.81 2279.11 284.49 2278.79 284.49 2278.79 284.17 2278.79 283.85 2278.47 283.53 2278.47 283.21 2278.47 282.9 2278.47 282.57 2278.47 282.25 2278.47 281.61 2278.47 280.97 2278.47 280.34"/>
+  </g>
+  <g id="LWPOLYLINE-1105" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2288.07" y1="286.41" x2="2288.71" y2="281.61"/>
+  </g>
+  <g id="LWPOLYLINE-1106" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2124.15 276.49 2124.15 261.76 2129.6 276.49 2135.36 261.76 2135.36 276.49"/>
+  </g>
+  <g id="LWPOLYLINE-1107" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2150.08 276.49 2141.12 276.49 2141.12 261.76 2150.08 261.76"/>
+  </g>
+  <g id="LWPOLYLINE-1108" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2141.12" y1="268.8" x2="2146.57" y2="268.8"/>
+  </g>
+  <g id="LWPOLYLINE-1109" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2154.57 276.49 2154.57 261.76 2164.18 276.49 2164.18 261.76"/>
+  </g>
+  <g id="LWPOLYLINE-1110" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1044.57 545.1 1045.21 546.7 1043.93 547.02 1043.61 545.43 1044.57 545.1"/>
+  </g>
+  <g id="LWPOLYLINE-1111" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1043.61 545.42 1043.93 547.02 1042.01 547.66 1041.37 546.06 1043.61 545.42"/>
+  </g>
+  <g id="LWPOLYLINE-1112" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="964.53 571.36 966.77 577.44 970.29 576.48 968.05 570.08 964.53 571.36"/>
+  </g>
+  <g id="LWPOLYLINE-1113" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1041.69" y1="546.39" x2="968.37" y2="570.39"/>
+  </g>
+  <g id="LWPOLYLINE-1114" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1042.01" y1="547.34" x2="968.69" y2="571.67"/>
+  </g>
+  <g id="LWPOLYLINE-1115" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="888.33 596.33 888.97 598.25 889.93 597.93 889.29 596.01 888.33 596.33"/>
+  </g>
+  <g id="LWPOLYLINE-1116" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="891.53" y1="595.69" x2="964.85" y2="571.68"/>
+  </g>
+  <g id="LWPOLYLINE-1117" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="891.85" y1="596.65" x2="965.17" y2="572.64"/>
+  </g>
+  <g id="LWPOLYLINE-1118" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="889.29 596.01 889.93 597.93 891.85 597.29 891.53 595.37 889.29 596.01"/>
+  </g>
+  <g id="LWPOLYLINE-1119" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="964.53 571.36 966.77 577.44 970.29 576.48 968.05 570.08 964.53 571.36"/>
+  </g>
+  <g id="LWPOLYLINE-1120" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.83 501.88 1177.76 508.29 1174.23 509.25 1172.31 503.16 1175.83 501.88"/>
+  </g>
+  <g id="LWPOLYLINE-1121" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1252.03 476.91 1252.67 478.51 1251.71 478.83 1251.07 477.23 1252.03 476.91"/>
+  </g>
+  <g id="LWPOLYLINE-1122" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.15" y1="478.19" x2="1175.84" y2="502.2"/>
+  </g>
+  <g id="LWPOLYLINE-1123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.47" y1="479.15" x2="1176.16" y2="503.16"/>
+  </g>
+  <g id="LWPOLYLINE-1124" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1251.07 477.23 1251.71 478.83 1249.47 479.48 1248.83 477.87 1251.07 477.23"/>
+  </g>
+  <g id="LWPOLYLINE-1125" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.83 501.88 1177.76 508.29 1174.23 509.25 1172.31 503.16 1175.83 501.88"/>
+  </g>
+  <g id="LWPOLYLINE-1126" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1095.79 528.13 1096.43 530.06 1097.39 529.74 1096.75 527.81 1095.79 528.13"/>
+  </g>
+  <g id="LWPOLYLINE-1127" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1096.75 527.82 1097.39 529.74 1099.63 529.09 1098.99 527.18 1096.75 527.82"/>
+  </g>
+  <g id="LWPOLYLINE-1128" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.83 501.88 1177.76 508.29 1174.23 509.25 1172.31 503.16 1175.83 501.88"/>
+  </g>
+  <g id="LWPOLYLINE-1129" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1099" y1="527.5" x2="1172.31" y2="503.49"/>
+  </g>
+  <g id="LWPOLYLINE-1130" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1099.31" y1="528.45" x2="1172.63" y2="504.45"/>
+  </g>
+  <g id="LWPOLYLINE-1131" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.83 501.88 1177.76 508.29 1174.23 509.25 1172.31 503.16 1175.83 501.88"/>
+  </g>
+  <g id="LWPOLYLINE-1132" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1379.78 434.97 1381.7 441.05 1385.22 440.09 1383.3 433.69 1379.78 434.97"/>
+  </g>
+  <g id="LWPOLYLINE-1133" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1303.26 459.94 1303.9 461.86 1304.86 461.22 1304.54 459.62 1303.26 459.94"/>
+  </g>
+  <g id="LWPOLYLINE-1134" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1306.46" y1="459.3" x2="1379.77" y2="435.29"/>
+  </g>
+  <g id="LWPOLYLINE-1135" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1306.78" y1="460.26" x2="1380.09" y2="436.25"/>
+  </g>
+  <g id="LWPOLYLINE-1136" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1304.54 459.62 1304.86 461.22 1307.1 460.58 1306.46 458.98 1304.54 459.62"/>
+  </g>
+  <g id="LWPOLYLINE-1137" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1379.78 434.97 1383.3 433.69 1385.22 440.09 1381.7 441.05 1379.78 434.97 1383.3 433.69 1385.22 440.09 1381.7 441.05 1379.78 434.97 1381.7 441.05 1385.22 440.09 1383.3 433.69 1379.78 434.97"/>
+  </g>
+  <g id="LWPOLYLINE-1138" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1459.5 408.71 1460.13 410.32 1459.17 410.63 1458.54 409.04 1459.5 408.71"/>
+  </g>
+  <g id="LWPOLYLINE-1139" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1458.54 409.04 1459.18 410.63 1456.93 411.27 1456.61 409.67 1458.54 409.04"/>
+  </g>
+  <g id="LWPOLYLINE-1140" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1456.62" y1="410" x2="1383.3" y2="434"/>
+  </g>
+  <g id="LWPOLYLINE-1141" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1456.93" y1="410.95" x2="1383.62" y2="434.96"/>
+  </g>
+  <g id="LWPOLYLINE-1142" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1590.76 365.49 1592.68 371.9 1589.16 372.86 1587.24 366.77 1590.76 365.49"/>
+  </g>
+  <g id="LWPOLYLINE-1143" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1666.96 340.52 1667.6 342.12 1666.64 342.44 1666 340.84 1666.96 340.52"/>
+  </g>
+  <g id="LWPOLYLINE-1144" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1664.08" y1="341.8" x2="1590.76" y2="365.81"/>
+  </g>
+  <g id="LWPOLYLINE-1145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1664.4" y1="342.76" x2="1591.08" y2="366.77"/>
+  </g>
+  <g id="LWPOLYLINE-1146" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1666 340.84 1666.64 342.44 1664.72 343.08 1664.07 341.48 1666 340.84"/>
+  </g>
+  <g id="LWPOLYLINE-1147" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1590.76 365.49 1587.24 366.77 1589.16 372.86 1592.68 371.9 1590.76 365.49 1587.24 366.77 1589.16 372.86 1592.68 371.9 1590.76 365.49 1592.68 371.9 1589.16 372.86 1587.24 366.77 1590.76 365.49"/>
+  </g>
+  <g id="LWPOLYLINE-1148" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1511.04 391.75 1511.36 393.35 1512.64 393.03 1512 391.43 1511.04 391.75"/>
+  </g>
+  <g id="LWPOLYLINE-1149" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1512 391.43 1512.64 393.03 1514.57 392.39 1513.93 390.79 1512 391.43"/>
+  </g>
+  <g id="LWPOLYLINE-1150" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1513.92" y1="391.11" x2="1587.24" y2="367.1"/>
+  </g>
+  <g id="LWPOLYLINE-1151" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1514.25" y1="392.07" x2="1587.56" y2="368.06"/>
+  </g>
+  <g id="LWPOLYLINE-1152" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1794.71 298.58 1796.94 304.66 1800.47 303.7 1798.23 297.3 1794.71 298.58"/>
+  </g>
+  <g id="LWPOLYLINE-1153" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1718.51 323.55 1719.15 325.15 1720.11 324.83 1719.47 323.23 1718.51 323.55"/>
+  </g>
+  <g id="LWPOLYLINE-1154" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1721.71" y1="322.91" x2="1794.7" y2="298.9"/>
+  </g>
+  <g id="LWPOLYLINE-1155" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1722.03" y1="323.87" x2="1795.02" y2="299.86"/>
+  </g>
+  <g id="LWPOLYLINE-1156" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1719.47 323.23 1720.11 324.84 1722.03 324.19 1721.39 322.59 1719.47 323.23"/>
+  </g>
+  <g id="LWPOLYLINE-1157" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1794.71 298.58 1798.23 297.3 1800.47 303.7 1796.94 304.66 1794.71 298.58 1798.23 297.3 1800.47 303.7 1796.94 304.66 1794.71 298.58 1796.94 304.66 1800.47 303.7 1798.23 297.3 1794.71 298.58"/>
+  </g>
+  <g id="LWPOLYLINE-1158" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1874.43 272.33 1875.07 273.93 1874.1 274.25 1873.47 272.65 1874.43 272.33"/>
+  </g>
+  <g id="LWPOLYLINE-1159" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1873.47 272.65 1874.1 274.25 1872.19 274.88 1871.54 273.28 1873.47 272.65"/>
+  </g>
+  <g id="LWPOLYLINE-1160" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1871.54" y1="273.61" x2="1798.23" y2="297.62"/>
+  </g>
+  <g id="LWPOLYLINE-1161" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1871.87" y1="274.57" x2="1798.55" y2="298.57"/>
+  </g>
+  <g id="LWPOLYLINE-1162" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1925.97 255.36 1926.61 256.96 1927.57 256.64 1926.93 255.04 1925.97 255.36"/>
+  </g>
+  <g id="LWPOLYLINE-1163" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1926.93 255.04 1927.57 256.64 1929.49 256 1928.85 254.4 1926.93 255.04"/>
+  </g>
+  <g id="LWPOLYLINE-1164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1929.17" y1="254.72" x2="2001.53" y2="230.71"/>
+  </g>
+  <g id="LWPOLYLINE-1165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1929.49" y1="255.68" x2="2001.85" y2="231.98"/>
+  </g>
+  <g id="LWPOLYLINE-1166" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2079.01 205.09 2079.65 206.7 2078.69 207.02 2078.05 205.41 2079.01 205.09"/>
+  </g>
+  <g id="LWPOLYLINE-1167" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2078.05 205.41 2078.69 207.02 2076.45 207.66 2076.13 206.05 2078.05 205.41"/>
+  </g>
+  <g id="LWPOLYLINE-1168" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2076.13" y1="206.37" x2="2005.05" y2="229.74"/>
+  </g>
+  <g id="LWPOLYLINE-1169" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2076.45" y1="207.33" x2="2005.37" y2="230.7"/>
+  </g>
+  <g id="CIRCLE-23" data-name="CIRCLE">
+    <circle class="cls-3" cx="2170.09" cy="359.25" r="2.72"/>
+  </g>
+  <g id="LWPOLYLINE-1170" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2169.29" y1="361.65" x2="2167.06" y2="362.61"/>
+  </g>
+  <g id="CIRCLE-24" data-name="CIRCLE">
+    <circle class="cls-3" cx="2170.1" cy="359.25" r="2.08"/>
+  </g>
+  <g id="LWPOLYLINE-1171" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2169.93" y1="359.09" x2="2168.01" y2="359.73"/>
+  </g>
+  <g id="SPLINE-47" data-name="SPLINE">
+    <path class="cls-3" d="M2168.05,359.65c.04.17.09.34.17.5"/>
+  </g>
+  <g id="LWPOLYLINE-1172" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2168.33 360.05 2169.94 359.73 2170.58 361.33"/>
+  </g>
+  <g id="SPLINE-48" data-name="SPLINE">
+    <path class="cls-3" d="M2170.49,361.29c.09-.02.17-.04.25-.06"/>
+  </g>
+  <g id="SPLINE-49" data-name="SPLINE">
+    <path class="cls-3" d="M2170.74,361.23c.08-.02.16-.06.24-.1"/>
+  </g>
+  <g id="LWPOLYLINE-1173" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2171.21,361.33l-.64-1.92,1.6-.64c-.05-.15-.12-.28-.2-.41"/>
+  </g>
+  <g id="LWPOLYLINE-1174" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2172.18 358.45 2170.25 359.09 2169.62 357.17"/>
+  </g>
+  <g id="SPLINE-50" data-name="SPLINE">
+    <path class="cls-3" d="M2169.7,357.21c-.09.02-.17.04-.25.06"/>
+  </g>
+  <g id="SPLINE-51" data-name="SPLINE">
+    <path class="cls-3" d="M2169.45,357.27c-.08.03-.17.06-.24.1"/>
+  </g>
+  <g id="LWPOLYLINE-1175" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2169.29" y1="357.49" x2="2169.93" y2="359.09"/>
+  </g>
+  <g id="LWPOLYLINE-1176" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2167.05 362.61 2165.78 358.45 2168.01 357.81"/>
+  </g>
+  <g id="LWPOLYLINE-1177" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2172.5 360.69 2174.42 360.05 2173.14 356.21 2170.9 356.85"/>
+  </g>
+  <g id="CIRCLE-25" data-name="CIRCLE">
+    <circle class="cls-3" cx="400.24" cy="778.66" r="2.72"/>
+  </g>
+  <g id="LWPOLYLINE-1178" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="402.96" y1="779.46" x2="403.6" y2="781.7"/>
+  </g>
+  <g id="CIRCLE-26" data-name="CIRCLE">
+    <circle class="cls-3" cx="400.25" cy="778.66" r="2.08"/>
+  </g>
+  <g id="LWPOLYLINE-1179" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="400.4" y1="779.14" x2="400.72" y2="780.74"/>
+  </g>
+  <g id="SPLINE-52" data-name="SPLINE">
+    <path class="cls-3" d="M400.64,780.7c.17-.04.34-.09.49-.16"/>
+  </g>
+  <g id="LWPOLYLINE-1180" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="401.36 780.74 400.73 778.82 402.64 778.18"/>
+  </g>
+  <g id="SPLINE-53" data-name="SPLINE">
+    <path class="cls-3" d="M402.22,778.01c-.02-.08-.06-.16-.1-.24"/>
+  </g>
+  <g id="LWPOLYLINE-1181" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M402.29,778.26c.02-.13.03-.27.04-.4l-1.6.64-.64-1.92"/>
+  </g>
+  <g id="SPLINE-54" data-name="SPLINE">
+    <path class="cls-3" d="M399.85,776.62c-.17.04-.34.09-.49.16"/>
+  </g>
+  <g id="LWPOLYLINE-1182" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="399.44 776.9 400.08 778.5 398.48 779.14"/>
+  </g>
+  <g id="ARC-55" data-name="ARC">
+    <path class="cls-3" d="M398.2,779.06c.02.08.04.17.07.25"/>
+  </g>
+  <g id="SPLINE-55" data-name="SPLINE">
+    <path class="cls-3" d="M398.27,779.31c.02.08.06.17.1.24"/>
+  </g>
+  <g id="LWPOLYLINE-1183" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="398.48" y1="779.46" x2="400.4" y2="779.14"/>
+  </g>
+  <g id="LWPOLYLINE-1184" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="403.61 781.7 399.77 782.98 398.81 780.74"/>
+  </g>
+  <g id="LWPOLYLINE-1185" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="402" y1="776.58" x2="401.04" y2="773.38"/>
+  </g>
+  <g id="LWPOLYLINE-1186" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="397.84" y1="777.86" x2="396.88" y2="774.66"/>
+  </g>
+  <g id="CIRCLE-27" data-name="CIRCLE">
+    <circle class="cls-3" cx="398.32" cy="772.26" r="2.72"/>
+  </g>
+  <g id="LWPOLYLINE-1187" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="505.42" y1="1243.38" x2="505.42" y2="1037.83"/>
+  </g>
+  <g id="LWPOLYLINE-1188" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="539.99" y1="1243.38" x2="539.99" y2="1238.89"/>
+  </g>
+  <g id="LWPOLYLINE-1189" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="501.26" y1="1243.38" x2="501.26" y2="1033.67"/>
+  </g>
+  <g id="LWPOLYLINE-1190" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="531.03" y1="1033.35" x2="531.03" y2="997.81"/>
+  </g>
+  <g id="LWPOLYLINE-1191" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="535.19 959.71 531.03 959.71 531.03 954.91"/>
+  </g>
+  <g id="LWPOLYLINE-1192" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="535.19" y1="1037.83" x2="535.19" y2="997.81"/>
+  </g>
+  <g id="LWPOLYLINE-1193" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="535.19" y1="959.71" x2="535.19" y2="954.91"/>
+  </g>
+  <g id="LWPOLYLINE-1194" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="559.52" y1="954.91" x2="559.52" y2="950.75"/>
+  </g>
+  <g id="LWPOLYLINE-1195" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="651.73 954.91 611.07 954.91 611.07 950.75"/>
+  </g>
+  <g id="LWPOLYLINE-1196" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="501.26" y1="1153.73" x2="505.41" y2="1153.73"/>
+  </g>
+  <g id="LWPOLYLINE-1197" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="501.26" y1="1217.76" x2="505.41" y2="1217.76"/>
+  </g>
+  <g id="LWPOLYLINE-1198" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="503.17" y1="1154.37" x2="503.17" y2="1185.11"/>
+  </g>
+  <g id="LWPOLYLINE-1199" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="503.17" y1="1186.39" x2="503.17" y2="1217.44"/>
+  </g>
+  <g id="LWPOLYLINE-1200" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="503.5" y1="1154.37" x2="503.5" y2="1185.11"/>
+  </g>
+  <g id="LWPOLYLINE-1201" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="503.5" y1="1186.39" x2="503.5" y2="1217.44"/>
+  </g>
+  <g id="LWPOLYLINE-1202" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="502.85" y="1153.73" width=".96" height=".64"/>
+  </g>
+  <g id="LWPOLYLINE-1203" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="502.85" y="1217.44" width=".96" height=".32"/>
+  </g>
+  <g id="LWPOLYLINE-1204" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="502.85" y="1185.11" width=".96" height="1.28"/>
+  </g>
+  <g id="LWPOLYLINE-1205" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1139 499.34 1139 499.97 1146.05 499.97 1139"/>
+  </g>
+  <g id="LWPOLYLINE-1206" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1139 499.97 1146.05 499.34 1146.05 499.34 1139"/>
+  </g>
+  <g id="LWPOLYLINE-1207" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1149.25 499.34 1149.25 499.97 1155.66 499.97 1149.25"/>
+  </g>
+  <g id="LWPOLYLINE-1208" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1149.25 499.97 1155.66 499.34 1155.66 499.34 1149.25"/>
+  </g>
+  <g id="LWPOLYLINE-1209" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1158.85 499.34 1158.85 499.97 1164.94 499.97 1158.85"/>
+  </g>
+  <g id="LWPOLYLINE-1210" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1158.85 499.97 1164.94 499.34 1164.94 499.34 1158.85"/>
+  </g>
+  <g id="LWPOLYLINE-1211" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1168.14 499.34 1168.14 499.97 1174.55 499.97 1168.14"/>
+  </g>
+  <g id="LWPOLYLINE-1212" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1168.14 499.97 1174.55 499.34 1174.55 499.34 1168.14"/>
+  </g>
+  <g id="LWPOLYLINE-1213" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1177.74 499.34 1177.74 499.97 1184.15 499.97 1177.74"/>
+  </g>
+  <g id="LWPOLYLINE-1214" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1177.74 499.97 1184.15 499.34 1184.15 499.34 1177.74"/>
+  </g>
+  <g id="LWPOLYLINE-1215" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1187.35 499.34 1187.35 499.97 1193.76 499.97 1187.35"/>
+  </g>
+  <g id="LWPOLYLINE-1216" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1187.35 499.97 1193.76 499.34 1193.76 499.34 1187.35"/>
+  </g>
+  <g id="LWPOLYLINE-1217" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1196.95 499.34 1196.95 499.97 1203.36 499.97 1196.95"/>
+  </g>
+  <g id="LWPOLYLINE-1218" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1196.95 499.97 1203.36 499.34 1203.36 499.34 1196.95"/>
+  </g>
+  <g id="LWPOLYLINE-1219" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1206.56 499.34 1206.56 499.97 1212.96 499.97 1206.56"/>
+  </g>
+  <g id="LWPOLYLINE-1220" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1206.56 499.97 1212.96 499.34 1212.96 499.34 1206.56"/>
+  </g>
+  <g id="LWPOLYLINE-1221" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1215.84 499.34 1215.84 499.97 1222.25 499.97 1215.84"/>
+  </g>
+  <g id="LWPOLYLINE-1222" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1215.84 499.97 1222.25 499.34 1222.25 499.34 1215.84"/>
+  </g>
+  <g id="LWPOLYLINE-1223" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.97 1225.45 499.34 1225.45 499.97 1232.49 499.97 1225.45"/>
+  </g>
+  <g id="LWPOLYLINE-1224" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="499.34 1225.45 499.97 1232.49 499.34 1232.49 499.34 1225.45"/>
+  </g>
+  <g id="LWPOLYLINE-1225" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="499.97" y1="1232.49" x2="499.34" y2="1232.49"/>
+  </g>
+  <g id="LWPOLYLINE-1226" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="500.29 1232.81 501.25 1232.81 499.02 1232.81 499.02 1230.89 499.33 1230.89 499.33 1232.81 499.97 1232.81 499.97 1230.89 500.29 1230.89 500.29 1232.81"/>
+  </g>
+  <g id="LWPOLYLINE-1227" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="500.29 1139 501.25 1139 501.25 1138.68 499.02 1138.68 499.02 1140.6 499.33 1140.6 499.33 1139 499.97 1139 499.97 1140.6 500.29 1140.6 500.29 1139"/>
+  </g>
+  <g id="LWPOLYLINE-1228" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="468.6 1097.7 495.49 1124.6 494.21 1125.88 467.32 1098.98"/>
+  </g>
+  <g id="LWPOLYLINE-1229" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="469.56 1096.74 466.36 1099.94 463.79 1103.47 461.55 1107.3 459.63 1111.46 458.35 1115.63 457.71 1120.11 457.39 1124.6"/>
+  </g>
+  <g id="LWPOLYLINE-1230" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="501.26" y1="1033.67" x2="531.03" y2="1033.67"/>
+  </g>
+  <g id="LWPOLYLINE-1231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="670.94" y1="954.91" x2="678.95" y2="954.91"/>
+  </g>
+  <g id="LWPOLYLINE-1232" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="854.71 950.75 854.71 954.91 860.8 954.91"/>
+  </g>
+  <g id="LWPOLYLINE-1233" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="531.03" y1="997.81" x2="535.19" y2="997.81"/>
+  </g>
+  <g id="LWPOLYLINE-1234" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="611.07" y1="950.75" x2="652.69" y2="950.75"/>
+  </g>
+  <g id="LWPOLYLINE-1235" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="854.71" y1="950.75" x2="861.44" y2="950.75"/>
+  </g>
+  <g id="LWPOLYLINE-1236" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="693.67" y1="792.91" x2="876.8" y2="792.91"/>
+  </g>
+  <g id="LWPOLYLINE-1237" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="505.42" y1="1037.83" x2="535.19" y2="1037.83"/>
+  </g>
+  <g id="LWPOLYLINE-1238" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="503.82 986.61 531.03 959.71 532.31 960.99 505.42 987.88"/>
+  </g>
+  <g id="LWPOLYLINE-1239" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="503.17 985.97 506.37 988.85 509.9 991.41 513.74 993.65 517.9 995.57 522.07 996.85 526.54 997.49 531.03 997.81"/>
+  </g>
+  <g id="LWPOLYLINE-1240" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="827.5 923.53 854.71 950.75 853.12 952.03 826.22 925.13"/>
+  </g>
+  <g id="LWPOLYLINE-1241" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="828.46 922.89 825.26 926.09 822.69 929.62 820.45 933.46 818.85 937.62 817.57 941.79 816.61 946.26 816.29 950.75"/>
+  </g>
+  <g id="LWPOLYLINE-1242" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="814.69" y="950.75" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1243" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="814.69" y1="952.99" x2="748.42" y2="952.99"/>
+  </g>
+  <g id="LWPOLYLINE-1244" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="814.69" y1="952.67" x2="748.42" y2="952.67"/>
+  </g>
+  <g id="LWPOLYLINE-1245" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="746.82" y="950.75" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1246" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="678.94" y="950.75" width="1.6" height="4.16"/>
+  </g>
+  <g id="LWPOLYLINE-1247" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="680.54" y1="952.99" x2="746.82" y2="952.99"/>
+  </g>
+  <g id="LWPOLYLINE-1248" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="680.54" y1="952.67" x2="746.82" y2="952.67"/>
+  </g>
+  <g id="LWPOLYLINE-1249" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="670.3" y1="950.75" x2="678.95" y2="950.75"/>
+  </g>
+  <g id="LWPOLYLINE-1250" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="649.49" y1="741.04" x2="631.88" y2="687.58"/>
+  </g>
+  <g id="LWPOLYLINE-1251" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="639.24" y1="744.24" x2="621.95" y2="691.1"/>
+  </g>
+  <g id="LWPOLYLINE-1252" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="629.32" y1="747.77" x2="611.71" y2="694.3"/>
+  </g>
+  <g id="LWPOLYLINE-1253" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="619.07" y1="750.97" x2="601.78" y2="697.51"/>
+  </g>
+  <g id="LWPOLYLINE-1254" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="609.15" y1="754.49" x2="591.54" y2="701.03"/>
+  </g>
+  <g id="LWPOLYLINE-1255" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="598.9" y1="757.69" x2="581.61" y2="704.23"/>
+  </g>
+  <g id="LWPOLYLINE-1256" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="588.98" y1="760.89" x2="571.37" y2="707.75"/>
+  </g>
+  <g id="LWPOLYLINE-1257" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="578.73" y1="764.41" x2="561.44" y2="710.95"/>
+  </g>
+  <g id="LWPOLYLINE-1258" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="642.77 714.47 642.13 712.87 640.53 712.22 639.25 712.87 638.61 714.47 639.25 715.75 640.53 716.39 642.13 715.75 642.77 714.47"/>
+  </g>
+  <g id="LWPOLYLINE-1259" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="640.52 714.47 549.92 744.25 559.2 749.05"/>
+  </g>
+  <g id="LWPOLYLINE-1260" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="549.92" y1="744.24" x2="554.72" y2="735.28"/>
+  </g>
+  <g id="LWPOLYLINE-1261" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="556.32 771.78 542.24 751.93 544.48 747.45 534.23 748.09 536.47 743.6 522.38 723.75"/>
+  </g>
+  <g id="LWPOLYLINE-1262" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="539.99" y1="747.77" x2="531.35" y2="720.87"/>
+  </g>
+  <g id="LWPOLYLINE-1263" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="568.81" y1="767.62" x2="551.2" y2="714.15"/>
+  </g>
+  <g id="LWPOLYLINE-1264" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="558.88" y1="770.82" x2="541.27" y2="717.67"/>
+  </g>
+  <g id="LWPOLYLINE-1265" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="413.53 767.62 411.93 766.66 410.01 766.66 407.76 767.62 406.17 768.58 405.52 770.18 405.84 771.45 406.8 772.42 407.76 772.74 409.05 773.06 412.89 773.06 414.17 773.06 414.81 773.38 415.77 774.34 416.41 776.26 415.77 777.86 414.17 778.82 411.93 779.78 410.01 779.78 408.4 778.82"/>
+  </g>
+  <g id="LWPOLYLINE-1266" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="420.57 776.9 416.41 764.74 421.53 763.13 423.45 763.13 424.41 763.45 425.38 764.42 426.02 766.02 425.7 767.61 425.38 768.25 423.77 769.21 418.65 771.14"/>
+  </g>
+  <g id="LWPOLYLINE-1267" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="383.76 1052.24 410.97 1079.13 412.25 1077.86 385.35 1050.64"/>
+  </g>
+  <g id="LWPOLYLINE-1268" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="383.11 1052.88 386.31 1050 389.84 1047.11 393.68 1044.87 397.84 1043.27 402.01 1041.99 406.48 1041.03 410.97 1041.03"/>
+  </g>
+  <g id="LWPOLYLINE-1269" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="371.91 862.06 406.16 879.35 405.2 880.95 371.27 863.66"/>
+  </g>
+  <g id="LWPOLYLINE-1270" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="372.55 861.1 370.63 864.94 369.35 869.43 368.39 873.59 368.07 878.07 368.07 882.55 368.71 887.04 369.99 891.2"/>
+  </g>
+  <g id="LWPOLYLINE-1271" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="231.68" y1="839.97" x2="262.42" y2="843.17"/>
+  </g>
+  <g id="LWPOLYLINE-1272" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="232" y1="836.45" x2="259.21" y2="839.01"/>
+  </g>
+  <g id="LWPOLYLINE-1273" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="265.94" y1="808.28" x2="262.41" y2="843.18"/>
+  </g>
+  <g id="LWPOLYLINE-1274" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.09" y1="809.56" x2="259.21" y2="839.01"/>
+  </g>
+  <g id="ARC-56" data-name="ARC">
+    <path class="cls-3" d="M297.53,1014.02c-.18-.5-.39-1-.62-1.48"/>
+  </g>
+  <g id="LWPOLYLINE-1275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="297.31 1012.54 290.59 998.46 286.75 1000.06 283.87 1001.65 280.98 1002.93 277.14 1004.53 283.87 1018.95"/>
+  </g>
+  <g id="LWPOLYLINE-1276" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="297.95" y1="1022.78" x2="297.95" y2="1022.78"/>
+  </g>
+  <g id="LWPOLYLINE-1277" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="295.71" y1="1020.54" x2="295.71" y2="1020.54"/>
+  </g>
+  <g id="ARC-57" data-name="ARC">
+    <path class="cls-3" d="M288.94,1025.28c1.06.67,2.26,1.1,3.51,1.27"/>
+  </g>
+  <g id="ARC-58" data-name="ARC">
+    <path class="cls-3" d="M286.19,1022.75c.84,1.01,1.84,1.88,2.95,2.57"/>
+  </g>
+  <g id="ARC-59" data-name="ARC">
+    <path class="cls-3" d="M283.62,1018.63c.66,1.4,1.49,2.71,2.48,3.89"/>
+  </g>
+  <g id="SPLINE-56" data-name="SPLINE">
+    <path class="cls-3" d="M291.04,1025.88c.13-.09.2-.27.18-.43"/>
+  </g>
+  <g id="ARC-60" data-name="ARC">
+    <path class="cls-3" d="M290.58,1025.96c.16.06.33.03.46-.08"/>
+  </g>
+  <g id="LWPOLYLINE-1278" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="291.23" y1="1025.67" x2="291.23" y2="1023.11"/>
+  </g>
+  <g id="SPLINE-57" data-name="SPLINE">
+    <path class="cls-3" d="M290.91,1022.89c-.02-.16-.11-.28-.24-.36"/>
+  </g>
+  <g id="ARC-61" data-name="ARC">
+    <path class="cls-3" d="M288.85,1021.17c.5.55,1.08,1.01,1.72,1.37"/>
+  </g>
+  <g id="ARC-62" data-name="ARC">
+    <path class="cls-3" d="M286.57,1013.56c-.16.77-.19,1.56-.08,2.33"/>
+  </g>
+  <g id="ARC-63" data-name="ARC">
+    <path class="cls-3" d="M292.96,1012.88c-.53-.58-1.15-1.07-1.84-1.44"/>
+  </g>
+  <g id="SPLINE-58" data-name="SPLINE">
+    <path class="cls-3" d="M295.72,1020.3c-.02.16.02.3.12.42"/>
+  </g>
+  <g id="LWPOLYLINE-1279" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="295.71" y1="1020.86" x2="297.63" y2="1022.78"/>
+  </g>
+  <g id="SPLINE-59" data-name="SPLINE">
+    <path class="cls-3" d="M297.44,1022.31c.11.12.28.17.44.14"/>
+  </g>
+  <g id="SPLINE-60" data-name="SPLINE">
+    <path class="cls-3" d="M297.89,1022.46c.16-.03.29-.14.35-.3"/>
+  </g>
+  <g id="ARC-64" data-name="ARC">
+    <path class="cls-3" d="M295.33,1010.72c-.77-.85-1.68-1.56-2.69-2.11"/>
+  </g>
+  <g id="LWPOLYLINE-1280" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M292.86,1008.35c-.62-.29-1.28-.49-1.95-.61l-.64-1.28-6.72,3.2.64,1.28"/>
+  </g>
+  <g id="ARC-65" data-name="ARC">
+    <path class="cls-3" d="M284.07,1010.77c-.31.62-.54,1.28-.68,1.95"/>
+  </g>
+  <g id="ARC-66" data-name="ARC">
+    <path class="cls-3" d="M283.43,1012.91c-.23,1.12-.27,2.28-.11,3.42"/>
+  </g>
+  <g id="ARC-67" data-name="ARC">
+    <path class="cls-3" d="M283.03,1016.46c.27,1.95.98,3.82,2.06,5.47"/>
+  </g>
+  <g id="ARC-68" data-name="ARC">
+    <path class="cls-3" d="M291.02,1024.54c.53.2,1.08.35,1.65.43"/>
+  </g>
+  <g id="LWPOLYLINE-1281" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="876.8" y1="784.9" x2="880.96" y2="784.9"/>
+  </g>
+  <g id="LWPOLYLINE-1282" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="233.6" y1="852.14" x2="232.96" y2="858.22"/>
+  </g>
+  <g id="SPLINE-61" data-name="SPLINE">
+    <path class="cls-3" d="M241.91,851.82c.09-.79-.48-1.5-1.27-1.59"/>
+  </g>
+  <g id="ARC-69" data-name="ARC">
+    <path class="cls-3" d="M240.65,850.23c-.79-.09-1.51.49-1.6,1.28s.49,1.51,1.28,1.6,1.5-.48,1.6-1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1283" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="232" y1="849.58" x2="232" y2="852.14"/>
+  </g>
+  <g id="SPLINE-62" data-name="SPLINE">
+    <path class="cls-3" d="M232.95,853.03c.05-.44-.27-.84-.7-.88"/>
+  </g>
+  <g id="ARC-70" data-name="ARC">
+    <path class="cls-3" d="M232.25,852.14c-.43-.05-.83.26-.88.69s.26.83.69.88.83-.26.88-.69c0,0,0-.01,0-.02"/>
+  </g>
+  <g id="SPLINE-63" data-name="SPLINE">
+    <path class="cls-3" d="M233.27,848.87c.05-.44-.27-.84-.7-.88"/>
+  </g>
+  <g id="ARC-71" data-name="ARC">
+    <path class="cls-3" d="M232.57,847.98c-.43-.05-.83.25-.88.69s.25.83.69.88.83-.25.88-.69c0,0,0-.01,0-.02"/>
+  </g>
+  <g id="LWPOLYLINE-1284" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="232.96 849.9 238.08 851.18 237.76 852.14 232.64 852.46"/>
+  </g>
+  <g id="SPLINE-64" data-name="SPLINE">
+    <path class="cls-3" d="M228.81,860.14c-.09.79.48,1.5,1.27,1.59"/>
+  </g>
+  <g id="LWPOLYLINE-1285" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="229.12" y1="860.14" x2="231.36" y2="841.25"/>
+  </g>
+  <g id="LWPOLYLINE-1286" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="246.41" y1="863.66" x2="230.4" y2="861.74"/>
+  </g>
+  <g id="SPLINE-65" data-name="SPLINE">
+    <path class="cls-3" d="M246.4,863.65c.79.09,1.5-.48,1.59-1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1287" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="249.93" y1="843.49" x2="248.01" y2="862.39"/>
+  </g>
+  <g id="ARC-72" data-name="ARC">
+    <path class="cls-3" d="M250.24,843.18c.09-.79-.47-1.5-1.26-1.59,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1288" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="232.96" y1="839.97" x2="248.97" y2="841.89"/>
+  </g>
+  <g id="ARC-73" data-name="ARC">
+    <path class="cls-3" d="M232.64,839.66c-.79-.09-1.5.48-1.59,1.27"/>
+  </g>
+  <g id="LWPOLYLINE-1289" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M232.66,858.07c-.13,1.54,1,2.89,2.54,3.03l8.96.96c1.41.18,2.71-.83,2.88-2.24l1.6-14.08c.21-1.55-.87-2.97-2.41-3.19"/>
+  </g>
+  <g id="LWPOLYLINE-1290" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="246.41" y1="842.85" x2="237.44" y2="841.89"/>
+  </g>
+  <g id="LWPOLYLINE-1291" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="234.56" y1="844.13" x2="233.92" y2="850.22"/>
+  </g>
+  <g id="ARC-74" data-name="ARC">
+    <path class="cls-3" d="M237.27,841.59c-1.49-.17-2.84.9-3.01,2.39"/>
+  </g>
+  <g id="LWPOLYLINE-1292" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="950.75" x2="526.55" y2="944.02"/>
+  </g>
+  <g id="LWPOLYLINE-1293" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="940.82" x2="526.55" y2="934.42"/>
+  </g>
+  <g id="LWPOLYLINE-1294" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="931.22" x2="526.55" y2="924.82"/>
+  </g>
+  <g id="LWPOLYLINE-1295" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="921.61" x2="526.55" y2="915.21"/>
+  </g>
+  <g id="LWPOLYLINE-1296" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="912.01" x2="526.55" y2="905.61"/>
+  </g>
+  <g id="LWPOLYLINE-1297" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="902.72" x2="526.55" y2="896.32"/>
+  </g>
+  <g id="LWPOLYLINE-1298" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="893.12" x2="526.55" y2="886.72"/>
+  </g>
+  <g id="LWPOLYLINE-1299" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="883.51" x2="526.55" y2="877.11"/>
+  </g>
+  <g id="LWPOLYLINE-1300" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="873.91" x2="526.55" y2="867.5"/>
+  </g>
+  <g id="LWPOLYLINE-1301" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="864.3" x2="526.55" y2="857.9"/>
+  </g>
+  <g id="LWPOLYLINE-1302" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.55" y1="855.02" x2="526.55" y2="848.3"/>
+  </g>
+  <g id="LWPOLYLINE-1303" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="876.8 664.2 876.8 746.8 880.96 746.8"/>
+  </g>
+  <g id="LWPOLYLINE-1304" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="849.91 757.69 876.8 784.91 878.09 783.62 851.19 756.41"/>
+  </g>
+  <g id="LWPOLYLINE-1305" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="848.95 758.65 852.15 755.77 856 752.89 859.83 750.64 863.67 749.04 868.16 747.77 872.32 746.81 876.8 746.81"/>
+  </g>
+  <g id="LWPOLYLINE-1306" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1297.17" y1="473.39" x2="1298.77" y2="478.51"/>
+  </g>
+  <g id="LWPOLYLINE-1307" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="312.04" y1="860.46" x2="348.86" y2="859.82"/>
+  </g>
+  <g id="LWPOLYLINE-1308" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="257.29" y1="870.07" x2="307.56" y2="870.71"/>
+  </g>
+  <g id="LWPOLYLINE-1309" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="257.29 870.07 247.05 941.46 352.38 942.74"/>
+  </g>
+  <g id="LWPOLYLINE-1310" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="261.13 874.23 251.85 937.3 347.9 938.58"/>
+  </g>
+  <g id="LWPOLYLINE-1311" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="228.16" y1="869.75" x2="231.68" y2="869.75"/>
+  </g>
+  <g id="LWPOLYLINE-1312" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="234.88" y1="869.75" x2="241.29" y2="869.75"/>
+  </g>
+  <g id="LWPOLYLINE-1313" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="244.48" y1="869.75" x2="250.57" y2="870.07"/>
+  </g>
+  <g id="LWPOLYLINE-1314" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="253.77" y1="870.07" x2="257.29" y2="870.07"/>
+  </g>
+  <g id="LWPOLYLINE-1315" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.13" y1="874.23" x2="311.72" y2="874.87"/>
+  </g>
+  <g id="LWPOLYLINE-1316" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M328.69,793.23l-1.92.64-1.6-5.12,14.09-4.49,1.6,5.13-1.92.64-8.96,5.76c-.54-.8-.97-1.66-1.28-2.56Z"/>
+  </g>
+  <g id="LWPOLYLINE-1317" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M291.23,1066.01l9.61-4.48c-2.94-6.07-3.35-13.05-1.14-19.43"/>
+  </g>
+  <g id="LWPOLYLINE-1318" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="291.55" y1="1066.97" x2="301.16" y2="1062.48"/>
+  </g>
+  <g id="LWPOLYLINE-1319" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="324.2" y1="1051.6" x2="329.01" y2="1049.36"/>
+  </g>
+  <g id="LWPOLYLINE-1320" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="380.23 956.51 209.59 1036.23 227.84 1077.53 224.31 1079.13 208.31 1043.28"/>
+  </g>
+  <g id="LWPOLYLINE-1321" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1858.74 575.84 1858.74 1052.56 1975.92 1052.56"/>
+  </g>
+  <g id="LWPOLYLINE-1322" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1980.72 1048.08 1862.9 1048.08 1862.9 580"/>
+  </g>
+  <g id="LWPOLYLINE-1323" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="694.95 747.44 703.6 771.45 713.52 767.61 704.88 743.92 694.95 747.44"/>
+  </g>
+  <g id="LWPOLYLINE-1324" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="625.8 782.66 624.2 781.7 622.28 781.7 620.03 782.66 618.75 783.94 617.79 785.55 618.43 786.5 619.39 787.46 620.03 787.79 621.31 788.11 625.16 787.79 626.44 788.11 627.4 788.43 628.36 789.39 629 790.99 628.36 792.59 626.76 793.87 624.52 794.51 622.6 794.51 621 793.87"/>
+  </g>
+  <g id="LWPOLYLINE-1325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="632.52" y1="778.18" x2="637" y2="790.03"/>
+  </g>
+  <g id="LWPOLYLINE-1326" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="628.68" y1="779.46" x2="636.69" y2="776.58"/>
+  </g>
+  <g id="LWPOLYLINE-1327" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="643.41 787.79 638.92 775.94 644.04 774.02 645.97 774.02 646.6 774.34 647.57 775.3 648.21 776.26 647.89 777.86 647.57 778.51 645.97 779.78 640.85 781.38"/>
+  </g>
+  <g id="LWPOLYLINE-1328" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="645.01" y1="780.1" x2="651.09" y2="784.9"/>
+  </g>
+  <g id="LWPOLYLINE-1329" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="650.77 771.46 657.49 775.62 660.06 768.26"/>
+  </g>
+  <g id="LWPOLYLINE-1330" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="657.49" y1="775.62" x2="659.73" y2="781.7"/>
+  </g>
+  <g id="LWPOLYLINE-1331" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="666.46" y1="779.46" x2="662.3" y2="767.3"/>
+  </g>
+  <g id="LWPOLYLINE-1332" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="670.3" y1="764.41" x2="665.18" y2="775.3"/>
+  </g>
+  <g id="LWPOLYLINE-1333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="667.1" y1="771.46" x2="674.46" y2="776.58"/>
+  </g>
+  <g id="LWPOLYLINE-1334" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="685.99 772.42 678.62 774.98 674.14 763.13 681.5 760.25"/>
+  </g>
+  <g id="LWPOLYLINE-1335" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="676.38" y1="768.58" x2="680.86" y2="766.98"/>
+  </g>
+  <g id="LWPOLYLINE-1336" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="689.51 771.14 685.03 758.97 690.15 757.37 692.07 757.05 692.71 757.69 693.99 758.33 694.31 759.61 693.99 760.89 693.67 761.86 692.39 762.81 687.27 764.74"/>
+  </g>
+  <g id="LWPOLYLINE-1337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="691.11" y1="763.45" x2="697.52" y2="768.25"/>
+  </g>
+  <g id="LWPOLYLINE-1338" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="651.41" y1="747.12" x2="652.05" y2="749.05"/>
+  </g>
+  <g id="LWPOLYLINE-1339" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="880.96" y1="746.8" x2="880.96" y2="605.62"/>
+  </g>
+  <g id="LWPOLYLINE-1340" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="880.96" y1="962.91" x2="880.96" y2="784.9"/>
+  </g>
+  <g id="LWPOLYLINE-1341" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="876.8" y1="950.75" x2="876.8" y2="784.9"/>
+  </g>
+  <g id="LWPOLYLINE-1342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2022.34" y1="575.84" x2="1858.74" y2="575.84"/>
+  </g>
+  <g id="LWPOLYLINE-1343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="876.8" y1="656.84" x2="876.8" y2="607.21"/>
+  </g>
+  <g id="LWPOLYLINE-1344" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2044.11 406.15 2120.63 414.8 2116.47 450.65"/>
+  </g>
+  <g id="LWPOLYLINE-1345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2022.02" y1="580" x2="1862.9" y2="580"/>
+  </g>
+  <g id="LWPOLYLINE-1346" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2043.47 409.68 2116.15 418 2115.83 422.16"/>
+  </g>
+  <g id="LWPOLYLINE-1347" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2114.55" y1="434.01" x2="2112.94" y2="446.17"/>
+  </g>
+  <g id="LWPOLYLINE-1348" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1985.2" y1="451.3" x2="1966.31" y2="393.99"/>
+  </g>
+  <g id="LWPOLYLINE-1349" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1975.92 645.95 2002.81 672.85 2001.53 674.13 1974.64 647.23"/>
+  </g>
+  <g id="LWPOLYLINE-1350" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1976.56 644.99 1973.67 648.19 1971.11 651.72 1968.87 655.56 1966.95 659.72 1965.67 664.2 1965.03 668.36 1964.71 672.85"/>
+  </g>
+  <g id="LWPOLYLINE-1351" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1945.82 1079.45 1975.6 1055.45 1976.88 1057.05 1947.1 1080.73"/>
+  </g>
+  <g id="LWPOLYLINE-1352" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1945.18 1078.49 1948.06 1082.01 1951.27 1084.9 1955.11 1087.46 1958.95 1089.7 1963.11 1091.3 1967.27 1092.58 1971.76 1093.21"/>
+  </g>
+  <g id="LWPOLYLINE-1353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1980.72" y1="451.3" x2="1962.47" y2="395.26"/>
+  </g>
+  <g id="LWPOLYLINE-1354" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1970.8 359.73 2005.05 377.01 2004.09 378.61 1970.16 361.33"/>
+  </g>
+  <g id="LWPOLYLINE-1355" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1971.43 358.77 1969.51 362.61 1968.23 366.78 1967.27 371.25 1966.95 375.74 1966.95 380.22 1967.6 384.39 1968.87 388.86"/>
+  </g>
+  <g id="LWPOLYLINE-1356" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1987.44 402.63 1986.16 401.03 1983.92 400.39 1981.04 400.39 1979.12 401.03 1977.52 402.63 1977.52 403.91 1978.16 405.19 1979.12 406.15 1980.39 406.8 1984.56 408.08 1986.16 408.72 1986.8 409.68 1987.44 410.95 1987.44 413.19 1986.16 414.48 1983.92 415.12 1981.04 415.12 1979.12 414.48 1977.52 413.19"/>
+  </g>
+  <g id="LWPOLYLINE-1357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1996.73" y1="400.39" x2="1996.73" y2="415.12"/>
+  </g>
+  <g id="LWPOLYLINE-1358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1991.61" y1="400.39" x2="2001.53" y2="400.39"/>
+  </g>
+  <g id="LWPOLYLINE-1359" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2008.57 400.39 2007.29 401.03 2005.69 402.63 2005.05 403.91 2004.41 406.15 2004.41 409.68 2005.05 411.6 2005.69 413.2 2007.29 414.47 2008.57 415.12 2011.45 415.12 2013.06 414.47 2014.34 413.2 2014.98 411.6 2015.62 409.68 2015.62 406.15 2014.98 403.91 2014.34 402.63 2013.06 401.03 2011.45 400.39 2008.57 400.39"/>
+  </g>
+  <g id="LWPOLYLINE-1360" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2020.1 415.12 2020.1 400.39 2026.5 400.39 2028.42 401.04 2029.06 401.67 2030.02 403.27 2030.02 404.56 2029.06 406.16 2028.42 406.79 2026.5 407.43 2020.1 407.43"/>
+  </g>
+  <g id="LWPOLYLINE-1361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2024.9" y1="407.44" x2="2030.03" y2="415.12"/>
+  </g>
+  <g id="LWPOLYLINE-1362" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2035.47 413.84 2034.83 414.48 2035.47 415.11 2036.1 414.48"/>
+  </g>
+  <g id="LWPOLYLINE-1363" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1928.21 618.1 1926.61 616.5 1924.69 615.86 1921.81 615.86 1919.57 616.5 1918.29 618.1 1918.29 619.38 1918.93 620.66 1919.57 621.62 1921.16 622.26 1925.33 623.55 1926.61 624.5 1927.25 625.15 1928.21 626.43 1928.21 628.66 1926.61 629.95 1924.69 630.59 1921.81 630.59 1919.57 629.95 1918.29 628.66"/>
+  </g>
+  <g id="LWPOLYLINE-1364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1937.18" y1="615.86" x2="1937.18" y2="630.58"/>
+  </g>
+  <g id="LWPOLYLINE-1365" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1932.38" y1="615.86" x2="1942.3" y2="615.86"/>
+  </g>
+  <g id="LWPOLYLINE-1366" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1949.34 615.86 1947.74 616.5 1946.46 618.1 1945.82 619.38 1945.18 621.62 1945.18 625.14 1945.82 627.07 1946.46 628.67 1947.74 629.94 1949.34 630.58 1952.22 630.58 1953.5 629.94 1954.79 628.67 1955.74 627.07 1956.39 625.14 1956.39 621.62 1955.74 619.38 1954.79 618.1 1953.5 616.5 1952.22 615.86 1949.34 615.86"/>
+  </g>
+  <g id="LWPOLYLINE-1367" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1960.55 630.59 1960.55 615.86 1966.96 615.86 1969.19 616.5 1969.83 617.14 1970.47 618.74 1970.47 620.02 1969.83 621.62 1969.19 622.26 1966.96 622.9 1960.55 622.9"/>
+  </g>
+  <g id="LWPOLYLINE-1368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.67" y1="622.9" x2="1970.47" y2="630.59"/>
+  </g>
+  <g id="LWPOLYLINE-1369" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1976.24 629.3 1975.6 629.94 1976.24 630.58 1976.87 629.94"/>
+  </g>
+  <g id="LWPOLYLINE-1370" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2034.51" y1="458.98" x2="2038.35" y2="459.3"/>
+  </g>
+  <g id="LWPOLYLINE-1371" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2012.42 672.85 2030.66 497.08 2034.5 497.4"/>
+  </g>
+  <g id="CIRCLE-28" data-name="CIRCLE">
+    <circle class="cls-3" cx="2071.49" cy="374.62" r=".8"/>
+  </g>
+  <g id="ARC-75" data-name="ARC">
+    <path class="cls-3" d="M2072.23,374.9c-.37-.24-.86-.13-1.1.24-.03.05-.05.1-.07.15"/>
+  </g>
+  <g id="CIRCLE-29" data-name="CIRCLE">
+    <circle class="cls-3" cx="2068.28" cy="382.62" r=".8"/>
+  </g>
+  <g id="LWPOLYLINE-1372" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2055.32 377.34 2073.57 371.58 2079.32 389.5 2061.08 395.59 2055.32 377.34"/>
+  </g>
+  <g id="LWPOLYLINE-1373" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2066.2" y1="392.07" x2="2075.81" y2="388.87"/>
+  </g>
+  <g id="ARC-76" data-name="ARC">
+    <path class="cls-3" d="M2075.64,388.76c1.09-.35,1.69-1.52,1.34-2.61,0,0,0,0,0-.01"/>
+  </g>
+  <g id="LWPOLYLINE-1374" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2077.09" y1="386.31" x2="2073.57" y2="375.1"/>
+  </g>
+  <g id="ARC-77" data-name="ARC">
+    <path class="cls-3" d="M2073.14,374.94c-.35-1.09-1.52-1.69-2.62-1.34"/>
+  </g>
+  <g id="LWPOLYLINE-1375" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2070.68" y1="373.82" x2="2061.4" y2="376.7"/>
+  </g>
+  <g id="ARC-78" data-name="ARC">
+    <path class="cls-3" d="M2061.24,376.8c-1.09.35-1.69,1.52-1.34,2.62"/>
+  </g>
+  <g id="LWPOLYLINE-1376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2060.12" y1="379.58" x2="2063.64" y2="390.79"/>
+  </g>
+  <g id="ARC-79" data-name="ARC">
+    <path class="cls-3" d="M2063.42,390.63c.35,1.09,1.52,1.69,2.61,1.34,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2116.47" y1="450.66" x2="2040.27" y2="442.01"/>
+  </g>
+  <g id="LWPOLYLINE-1378" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2078.69 387.26 2079.01 387.26 2078.69 385.99 2078.05 386.3 2078.69 387.26"/>
+  </g>
+  <g id="LWPOLYLINE-1379" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.94" y1="446.17" x2="2040.59" y2="437.85"/>
+  </g>
+  <g id="LWPOLYLINE-1380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="678.94" y1="950.75" x2="678.94" y2="954.91"/>
+  </g>
+  <g id="LWPOLYLINE-1381" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="327.41" y1="990.45" x2="329.01" y2="989.81"/>
+  </g>
+  <g id="ARC-80" data-name="ARC">
+    <path class="cls-3" d="M322.65,992.61c2.24-.76,4.43-1.64,6.58-2.62"/>
+  </g>
+  <g id="LWPOLYLINE-1382" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="326.45" y1="988.53" x2="331.25" y2="986.29"/>
+  </g>
+  <g id="LWPOLYLINE-1383" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="336.37 983.41 328.69 987.25 321 990.77"/>
+  </g>
+  <g id="ARC-81" data-name="ARC">
+    <path class="cls-3" d="M322.61,992.8c-.56.26-.8.93-.54,1.49"/>
+  </g>
+  <g id="SPLINE-66" data-name="SPLINE">
+    <path class="cls-3" d="M327.1,990.36c.04.08.14.12.22.08"/>
+  </g>
+  <g id="SPLINE-67" data-name="SPLINE">
+    <path class="cls-3" d="M326.22,988.54c-.08.04-.12.14-.08.22"/>
+  </g>
+  <g id="LWPOLYLINE-1384" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="327.09" y1="990.45" x2="326.45" y2="988.85"/>
+  </g>
+  <g id="LWPOLYLINE-1385" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="330.61" y1="992.37" x2="328.69" y2="989.17"/>
+  </g>
+  <g id="LWPOLYLINE-1386" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M336.89,985.94c-2.04,1.18-4.14,2.25-6.28,3.22l1.6-.96"/>
+  </g>
+  <g id="ARC-82" data-name="ARC">
+    <path class="cls-3" d="M338.19,986.61c-.26-.56-.93-.8-1.49-.54h0"/>
+  </g>
+  <g id="SPLINE-68" data-name="SPLINE">
+    <path class="cls-3" d="M331.23,986.38c-.04-.08-.13-.12-.22-.08"/>
+  </g>
+  <g id="SPLINE-69" data-name="SPLINE">
+    <path class="cls-3" d="M331.8,988.19c.08-.04.12-.14.08-.21"/>
+  </g>
+  <g id="LWPOLYLINE-1387" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="332.21" y1="987.89" x2="331.57" y2="986.61"/>
+  </g>
+  <g id="SPLINE-70" data-name="SPLINE">
+    <path class="cls-3" d="M328.44,988.71c.02.06.06.11.1.16"/>
+  </g>
+  <g id="SPLINE-71" data-name="SPLINE">
+    <path class="cls-3" d="M328.37,988.4c0,.1.03.21.08.3"/>
+  </g>
+  <g id="SPLINE-72" data-name="SPLINE">
+    <path class="cls-3" d="M328.41,988.09c-.04.1-.06.2-.05.31"/>
+  </g>
+  <g id="SPLINE-73" data-name="SPLINE">
+    <path class="cls-3" d="M328.58,987.83c-.07.08-.12.17-.16.27"/>
+  </g>
+  <g id="SPLINE-74" data-name="SPLINE">
+    <path class="cls-3" d="M328.83,987.64c-.1.04-.18.11-.25.18"/>
+  </g>
+  <g id="SPLINE-75" data-name="SPLINE">
+    <path class="cls-3" d="M329.13,987.57c-.1,0-.21.03-.3.08"/>
+  </g>
+  <g id="SPLINE-76" data-name="SPLINE">
+    <path class="cls-3" d="M329.44,987.61c-.1-.04-.2-.06-.31-.05"/>
+  </g>
+  <g id="SPLINE-77" data-name="SPLINE">
+    <path class="cls-3" d="M329.71,987.78c-.08-.07-.17-.12-.27-.16"/>
+  </g>
+  <g id="SPLINE-78" data-name="SPLINE">
+    <path class="cls-3" d="M329.89,988.03c-.04-.1-.1-.18-.18-.25"/>
+  </g>
+  <g id="SPLINE-79" data-name="SPLINE">
+    <path class="cls-3" d="M328.15,988.84c.09.2.23.36.42.47"/>
+  </g>
+  <g id="SPLINE-80" data-name="SPLINE">
+    <path class="cls-3" d="M328.05,988.42c0,.15.04.29.1.43"/>
+  </g>
+  <g id="SPLINE-81" data-name="SPLINE">
+    <path class="cls-3" d="M328.11,987.99c-.05.14-.08.28-.07.43"/>
+  </g>
+  <g id="SPLINE-82" data-name="SPLINE">
+    <path class="cls-3" d="M328.34,987.61c-.1.11-.18.23-.23.37"/>
+  </g>
+  <g id="ARC-83" data-name="ARC">
+    <path class="cls-3" d="M328.69,987.35c-.13.06-.25.15-.35.26"/>
+  </g>
+  <g id="SPLINE-83" data-name="SPLINE">
+    <path class="cls-3" d="M329.12,987.25c-.15,0-.29.04-.43.1"/>
+  </g>
+  <g id="SPLINE-84" data-name="SPLINE">
+    <path class="cls-3" d="M329.55,987.31c-.14-.05-.28-.08-.43-.06"/>
+  </g>
+  <g id="SPLINE-85" data-name="SPLINE">
+    <path class="cls-3" d="M329.92,987.54c-.11-.1-.23-.18-.37-.23"/>
+  </g>
+  <g id="SPLINE-86" data-name="SPLINE">
+    <path class="cls-3" d="M330.28,988.5c.04-.36-.09-.72-.35-.96"/>
+  </g>
+  <g id="ARC-84" data-name="ARC">
+    <path class="cls-3" d="M330.33,992.09c.11.24.4.34.64.23s.34-.4.23-.64c0,0,0,0,0-.01"/>
+  </g>
+  <g id="LWPOLYLINE-1388" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="331.57" y1="992.05" x2="330.29" y2="988.21"/>
+  </g>
+  <g id="LWPOLYLINE-1389" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="391.76" y1="980.52" x2="317.81" y2="1015.1"/>
+  </g>
+  <g id="LWPOLYLINE-1390" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="364.54" y1="973.48" x2="362.95" y2="974.12"/>
+  </g>
+  <g id="LWPOLYLINE-1391" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="363.91" y1="971.56" x2="359.11" y2="973.8"/>
+  </g>
+  <g id="LWPOLYLINE-1392" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="353.66 976.04 361.34 972.2 369.03 968.68"/>
+  </g>
+  <g id="ARC-85" data-name="ARC">
+    <path class="cls-3" d="M373.2,980.13c.34-1.6.4-3.25.18-4.87"/>
+  </g>
+  <g id="ARC-86" data-name="ARC">
+    <path class="cls-3" d="M373.03,975.38c-.24-1.82-.76-3.59-1.54-5.25"/>
+  </g>
+  <g id="SPLINE-87" data-name="SPLINE">
+    <path class="cls-3" d="M364.45,973.14c.08-.04.12-.14.08-.21"/>
+  </g>
+  <g id="SPLINE-88" data-name="SPLINE">
+    <path class="cls-3" d="M363.89,971.65c-.04-.08-.14-.12-.22-.08"/>
+  </g>
+  <g id="LWPOLYLINE-1393" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="364.87" y1="973.16" x2="364.23" y2="971.56"/>
+  </g>
+  <g id="ARC-87" data-name="ARC">
+    <path class="cls-3" d="M371.8,970.05c-.38-1.24-1.69-1.95-2.94-1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1394" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="364.22" y1="977" x2="362.63" y2="973.48"/>
+  </g>
+  <g id="LWPOLYLINE-1395" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="361.66" y1="974.76" x2="360.06" y2="975.72"/>
+  </g>
+  <g id="ARC-88" data-name="ARC">
+    <path class="cls-3" d="M355.27,978.07c-.56.26-.8.93-.54,1.49"/>
+  </g>
+  <g id="ARC-89" data-name="ARC">
+    <path class="cls-3" d="M354.99,977.88c2.24-.76,4.43-1.64,6.58-2.62"/>
+  </g>
+  <g id="SPLINE-89" data-name="SPLINE">
+    <path class="cls-3" d="M358.87,973.81c-.08.04-.12.14-.08.22"/>
+  </g>
+  <g id="SPLINE-90" data-name="SPLINE">
+    <path class="cls-3" d="M359.44,975.31c.04.08.13.12.22.08"/>
+  </g>
+  <g id="LWPOLYLINE-1396" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="359.74" y1="975.4" x2="359.1" y2="974.12"/>
+  </g>
+  <g id="ARC-90" data-name="ARC">
+    <path class="cls-3" d="M362.61,973.15c-.01-.06-.03-.12-.06-.17"/>
+  </g>
+  <g id="SPLINE-91" data-name="SPLINE">
+    <path class="cls-3" d="M362.55,972.98c-.04-.1-.11-.18-.18-.25"/>
+  </g>
+  <g id="SPLINE-92" data-name="SPLINE">
+    <path class="cls-3" d="M362.36,972.73c-.08-.08-.17-.12-.27-.16"/>
+  </g>
+  <g id="SPLINE-93" data-name="SPLINE">
+    <path class="cls-3" d="M362.1,972.57c-.1-.04-.2-.05-.31-.05"/>
+  </g>
+  <g id="SPLINE-94" data-name="SPLINE">
+    <path class="cls-3" d="M361.79,972.52c-.1,0-.21.03-.3.08"/>
+  </g>
+  <g id="SPLINE-95" data-name="SPLINE">
+    <path class="cls-3" d="M361.48,972.59c-.1.04-.18.1-.25.18"/>
+  </g>
+  <g id="SPLINE-96" data-name="SPLINE">
+    <path class="cls-3" d="M361.23,972.78c-.08.08-.12.17-.16.27"/>
+  </g>
+  <g id="SPLINE-97" data-name="SPLINE">
+    <path class="cls-3" d="M361.07,973.05c-.04.1-.06.2-.05.31"/>
+  </g>
+  <g id="ARC-91" data-name="ARC">
+    <path class="cls-3" d="M361.02,973.36c0,.11.03.21.08.3"/>
+  </g>
+  <g id="SPLINE-98" data-name="SPLINE">
+    <path class="cls-3" d="M362.58,972.49c-.11-.1-.23-.18-.37-.23"/>
+  </g>
+  <g id="SPLINE-99" data-name="SPLINE">
+    <path class="cls-3" d="M362.21,972.27c-.14-.05-.28-.08-.43-.06"/>
+  </g>
+  <g id="SPLINE-100" data-name="SPLINE">
+    <path class="cls-3" d="M361.77,972.2c-.15,0-.29.04-.43.1"/>
+  </g>
+  <g id="ARC-92" data-name="ARC">
+    <path class="cls-3" d="M361.35,972.3c-.13.06-.25.15-.35.26"/>
+  </g>
+  <g id="SPLINE-101" data-name="SPLINE">
+    <path class="cls-3" d="M361,972.56c-.1.11-.18.23-.22.37"/>
+  </g>
+  <g id="SPLINE-102" data-name="SPLINE">
+    <path class="cls-3" d="M360.77,972.94c-.05.14-.08.28-.07.43"/>
+  </g>
+  <g id="ARC-93" data-name="ARC">
+    <path class="cls-3" d="M360.7,973.37c.02.36.21.69.51.89"/>
+  </g>
+  <g id="SPLINE-103" data-name="SPLINE">
+    <path class="cls-3" d="M362.99,977.37c.11.24.4.34.64.23"/>
+  </g>
+  <g id="ARC-94" data-name="ARC">
+    <path class="cls-3" d="M363.63,977.59c.24-.11.34-.38.24-.62,0,0,0-.01,0-.02"/>
+  </g>
+  <g id="LWPOLYLINE-1397" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="363.26" y1="977.64" x2="361.03" y2="974.12"/>
+  </g>
+  <g id="ARC-95" data-name="ARC">
+    <path class="cls-3" d="M359.55,986.29c1.38.73,2.9,1.15,4.45,1.25"/>
+  </g>
+  <g id="ARC-96" data-name="ARC">
+    <path class="cls-3" d="M355.8,983.58c1.11,1.21,2.41,2.21,3.86,2.98"/>
+  </g>
+  <g id="LWPOLYLINE-1398" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="324.21 1051.6 323.89 1050.64 299.88 1042.31"/>
+  </g>
+  <g id="LWPOLYLINE-1399" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="315.88 1118.83 315.88 1118.51 328.69 1082.65"/>
+  </g>
+  <g id="ARC-97" data-name="ARC">
+    <path class="cls-3" d="M328.75,1082.38c-9.54-3.45-20.06-2.97-29.25,1.33"/>
+  </g>
+  <g id="SPLINE-104" data-name="SPLINE">
+    <path class="cls-3" d="M225.06,1029.5c.12.27.35.48.64.59"/>
+  </g>
+  <g id="ARC-98" data-name="ARC">
+    <path class="cls-3" d="M225.7,1030.09c.28.09.59.08.86-.05"/>
+  </g>
+  <g id="LWPOLYLINE-1400" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="225.28 1029.51 224.95 1029.19 223.68 1029.83 224 1030.15"/>
+  </g>
+  <g id="ARC-99" data-name="ARC">
+    <path class="cls-3" d="M223.61,1030.18c.63,1.35,2.24,1.95,3.6,1.33"/>
+  </g>
+  <g id="LWPOLYLINE-1401" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="227.52" y1="1031.43" x2="258.89" y2="1016.71"/>
+  </g>
+  <g id="ARC-100" data-name="ARC">
+    <path class="cls-3" d="M264.25,1018.55c-1.01-2.16-3.58-3.09-5.74-2.08,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="264.33" y1="1018.94" x2="279.38" y2="1050.64"/>
+  </g>
+  <g id="ARC-101" data-name="ARC">
+    <path class="cls-3" d="M279,1050.35c.64,1.36,2.26,1.95,3.62,1.31"/>
+  </g>
+  <g id="LWPOLYLINE-1403" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="282.9 1051.92 283.23 1051.6 282.58 1050.32 282.27 1050.32"/>
+  </g>
+  <g id="ARC-102" data-name="ARC">
+    <path class="cls-3" d="M280.45,1049.67c.26.56.93.8,1.49.54"/>
+  </g>
+  <g id="LWPOLYLINE-1404" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="280.66" y1="1050" x2="265.94" y2="1018.31"/>
+  </g>
+  <g id="ARC-103" data-name="ARC">
+    <path class="cls-3" d="M265.7,1017.87c-1.38-2.96-4.91-4.24-7.87-2.86,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.25" y1="1015.42" x2="226.88" y2="1030.14"/>
+  </g>
+  <g id="LWPOLYLINE-1406" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="254.09 1025.35 253.13 1023.75 246.4 1026.94 247.37 1028.23"/>
+  </g>
+  <g id="ARC-104" data-name="ARC">
+    <path class="cls-3" d="M247.25,1028.05c-.31.62-.54,1.28-.68,1.95"/>
+  </g>
+  <g id="ARC-105" data-name="ARC">
+    <path class="cls-3" d="M253.44,1043.24c.24.09.5-.02.59-.26.03-.07.04-.14.03-.21"/>
+  </g>
+  <g id="LWPOLYLINE-1407" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="254.41" y1="1042.95" x2="254.09" y2="1040.39"/>
+  </g>
+  <g id="SPLINE-105" data-name="SPLINE">
+    <path class="cls-3" d="M253.77,1040.18c-.02-.16-.11-.28-.24-.36"/>
+  </g>
+  <g id="ARC-106" data-name="ARC">
+    <path class="cls-3" d="M252.03,1038.46c.5.55,1.08,1.01,1.72,1.37"/>
+  </g>
+  <g id="ARC-107" data-name="ARC">
+    <path class="cls-3" d="M250.11,1029.5c-.19.37-.32.75-.4,1.15"/>
+  </g>
+  <g id="ARC-108" data-name="ARC">
+    <path class="cls-3" d="M252.94,1027.97c-1.31-.27-2.65.36-3.28,1.54"/>
+  </g>
+  <g id="ARC-109" data-name="ARC">
+    <path class="cls-3" d="M258.46,1037.64c.13-.72.15-1.47.05-2.2"/>
+  </g>
+  <g id="SPLINE-106" data-name="SPLINE">
+    <path class="cls-3" d="M258.58,1037.58c-.02.16.02.3.12.42"/>
+  </g>
+  <g id="LWPOLYLINE-1408" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.89" y1="1038.15" x2="260.49" y2="1040.07"/>
+  </g>
+  <g id="SPLINE-107" data-name="SPLINE">
+    <path class="cls-3" d="M260.3,1039.92c.11.12.28.17.44.14"/>
+  </g>
+  <g id="SPLINE-108" data-name="SPLINE">
+    <path class="cls-3" d="M260.75,1040.06c.16-.03.29-.14.35-.3"/>
+  </g>
+  <g id="LWPOLYLINE-1409" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="254.09 1017.02 253.45 1015.74 249.61 1017.66 246.73 1018.94 243.84 1020.22 240.01 1022.15 240.65 1023.43"/>
+  </g>
+  <g id="LWPOLYLINE-1410" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M241.6,1025.02l5.13,11.21c.68,1.4,1.54,2.71,2.56,3.9"/>
+  </g>
+  <g id="LWPOLYLINE-1411" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.57" y1="1037.83" x2="258.57" y2="1037.83"/>
+  </g>
+  <g id="LWPOLYLINE-1412" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.13" y1="1040.07" x2="261.13" y2="1040.07"/>
+  </g>
+  <g id="ARC-110" data-name="ARC">
+    <path class="cls-3" d="M260.71,1031.31c-.18-.51-.39-1-.62-1.49"/>
+  </g>
+  <g id="LWPOLYLINE-1413" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="260.17" y1="1030.15" x2="255.05" y2="1018.62"/>
+  </g>
+  <g id="LWPOLYLINE-1414" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="240.96" y1="1106.35" x2="235.84" y2="1074.97"/>
+  </g>
+  <g id="ARC-111" data-name="ARC">
+    <path class="cls-3" d="M235.85,1074.72c-2.75.43-5.43,1.22-7.97,2.35"/>
+  </g>
+  <g id="LWPOLYLINE-1415" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1714.02 508.93 1713.38 504.76 1688.09 508.6"/>
+  </g>
+  <g id="LWPOLYLINE-1416" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="296.03 811.16 294.43 809.88 292.51 809.24 289.63 809.24 287.38 809.88 286.11 811.16 286.11 812.76 286.75 814.04 287.38 815 288.98 815.64 293.15 816.92 294.43 817.57 295.39 818.52 296.03 819.8 296.03 822.04 294.43 823.32 292.51 823.96 289.63 823.96 287.38 823.32 286.11 822.04"/>
+  </g>
+  <g id="LWPOLYLINE-1417" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="309.47 823.96 300.19 823.96 300.19 809.24 309.47 809.24"/>
+  </g>
+  <g id="LWPOLYLINE-1418" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="300.19" y1="816.28" x2="305.96" y2="816.28"/>
+  </g>
+  <g id="LWPOLYLINE-1419" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="313.64 823.96 313.64 809.24 320.05 809.24 321.96 809.88 322.92 810.52 323.56 812.12 323.56 813.4 322.92 815 321.96 815.64 320.05 816.28 313.64 816.28"/>
+  </g>
+  <g id="LWPOLYLINE-1420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="318.44" y1="816.28" x2="323.57" y2="823.97"/>
+  </g>
+  <g id="LWPOLYLINE-1421" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="328.37 809.24 334.13 823.96 339.89 809.24"/>
+  </g>
+  <g id="LWPOLYLINE-1422" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="351.74 823.96 342.45 823.96 342.45 809.24 351.74 809.24"/>
+  </g>
+  <g id="LWPOLYLINE-1423" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="342.45" y1="816.28" x2="348.22" y2="816.28"/>
+  </g>
+  <g id="LWPOLYLINE-1424" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="355.9 823.96 355.9 809.24 362.31 809.24 364.55 809.88 365.19 810.52 365.83 812.12 365.83 813.4 365.19 815 364.55 815.64 362.31 816.28 355.9 816.28"/>
+  </g>
+  <g id="LWPOLYLINE-1425" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="361.02" y1="816.28" x2="365.82" y2="823.97"/>
+  </g>
+  <g id="LWPOLYLINE-1426" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="383.76" y1="806.35" x2="370.95" y2="829.08"/>
+  </g>
+  <g id="LWPOLYLINE-1427" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="286.11 845.73 286.11 831.01 292.51 831.01 294.43 831.65 295.39 832.29 296.03 833.89 296.03 836.13 295.39 837.41 294.43 838.05 292.51 838.69 286.11 838.69"/>
+  </g>
+  <g id="LWPOLYLINE-1428" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="300.83" y1="845.73" x2="300.83" y2="831.01"/>
+  </g>
+  <g id="LWPOLYLINE-1429" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="310.76" y1="831.01" x2="310.76" y2="845.73"/>
+  </g>
+  <g id="LWPOLYLINE-1430" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="300.83" y1="838.05" x2="310.76" y2="838.05"/>
+  </g>
+  <g id="LWPOLYLINE-1431" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="320.68 831.01 319.41 831.65 317.81 833.25 317.16 834.53 316.52 836.77 316.52 840.29 317.16 842.21 317.81 843.81 319.41 845.09 320.68 845.73 323.56 845.73 324.84 845.09 326.45 843.81 327.09 842.21 327.73 840.29 327.73 836.77 327.09 834.53 326.45 833.25 324.84 831.65 323.56 831.01 320.68 831.01"/>
+  </g>
+  <g id="LWPOLYLINE-1432" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="331.89 845.73 331.89 831.01 341.81 845.73 341.81 831.01"/>
+  </g>
+  <g id="LWPOLYLINE-1433" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="356.86 845.73 347.58 845.73 347.58 831.01 356.86 831.01"/>
+  </g>
+  <g id="LWPOLYLINE-1434" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="347.58" y1="838.05" x2="353.34" y2="838.05"/>
+  </g>
+  <g id="LWPOLYLINE-1435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="352.7" y1="897.28" x2="410.97" y2="1021.51"/>
+  </g>
+  <g id="LWPOLYLINE-1436" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="306.28" y1="991.09" x2="333.49" y2="1048.72"/>
+  </g>
+  <g id="LWPOLYLINE-1437" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="302.43" y1="992.69" x2="329.65" y2="1050.32"/>
+  </g>
+  <g id="LWPOLYLINE-1438" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="300.83" y1="1061.52" x2="301.16" y2="1062.48"/>
+  </g>
+  <g id="LWPOLYLINE-1439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="264.98" y1="1010.3" x2="299.56" y2="1083.93"/>
+  </g>
+  <g id="LWPOLYLINE-1440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="264.01" y1="1010.62" x2="298.59" y2="1084.57"/>
+  </g>
+  <g id="LWPOLYLINE-1441" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="379.91" y1="770.82" x2="421.54" y2="877.43"/>
+  </g>
+  <g id="LWPOLYLINE-1442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="374.47" y1="772.74" x2="415.13" y2="876.15"/>
+  </g>
+  <g id="LWPOLYLINE-1443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="352.38" y1="942.74" x2="353.34" y2="855.66"/>
+  </g>
+  <g id="LWPOLYLINE-1444" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="347.9" y1="938.58" x2="348.86" y2="859.82"/>
+  </g>
+  <g id="LWPOLYLINE-1445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="307.56" y1="870.71" x2="307.88" y2="856.3"/>
+  </g>
+  <g id="LWPOLYLINE-1446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="312.04" y1="874.87" x2="312.04" y2="860.46"/>
+  </g>
+  <g id="LWPOLYLINE-1447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="307.88" y1="856.3" x2="353.34" y2="855.66"/>
+  </g>
+  <g id="LWPOLYLINE-1448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="220.15" y1="941.14" x2="227.2" y2="941.14"/>
+  </g>
+  <g id="LWPOLYLINE-1449" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="230.4" y1="941.14" x2="236.81" y2="941.14"/>
+  </g>
+  <g id="LWPOLYLINE-1450" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="240" y1="941.46" x2="247.05" y2="941.46"/>
+  </g>
+  <g id="LWPOLYLINE-1451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="244.48" y1="1124.6" x2="237.12" y2="1107.95"/>
+  </g>
+  <g id="LWPOLYLINE-1452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="248.97" y1="1124.6" x2="240.96" y2="1106.35"/>
+  </g>
+  <g id="LWPOLYLINE-1453" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="876.8" y1="709.35" x2="862.72" y2="666.12"/>
+  </g>
+  <g id="LWPOLYLINE-1454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="329.65" y1="1050.32" x2="333.49" y2="1048.72"/>
+  </g>
+  <g id="LWPOLYLINE-1455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="209.59" y1="1031.43" x2="378.63" y2="952.67"/>
+  </g>
+  <g id="LWPOLYLINE-1456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="323.89" y1="1050.64" x2="328.68" y2="1048.4"/>
+  </g>
+  <g id="LWPOLYLINE-1457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1974.64" y1="455.46" x2="1974.64" y2="451.29"/>
+  </g>
+  <g id="LWPOLYLINE-1458" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1753.08 498.36 1913.49 472.75 1913.49 407.11"/>
+  </g>
+  <g id="LWPOLYLINE-1459" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="298.59" y1="1084.58" x2="299.55" y2="1083.94"/>
+  </g>
+  <g id="LWPOLYLINE-1460" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909" y1="475.31" x2="1832.16" y2="487.8"/>
+  </g>
+  <g id="LWPOLYLINE-1461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="240.96" y1="1106.35" x2="237.13" y2="1107.95"/>
+  </g>
+  <g id="LWPOLYLINE-1462" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1621.5" y1="510.85" x2="1555.54" y2="510.85"/>
+  </g>
+  <g id="LWPOLYLINE-1463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="869.12" y1="962.91" x2="880.96" y2="962.91"/>
+  </g>
+  <g id="LWPOLYLINE-1464" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="876.8" y1="723.11" x2="842.87" y2="618.42"/>
+  </g>
+  <g id="LWPOLYLINE-1465" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1621.5" y1="511.17" x2="1555.54" y2="511.17"/>
+  </g>
+  <g id="LWPOLYLINE-1466" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1917.97" y1="451.3" x2="1917.97" y2="410"/>
+  </g>
+  <g id="LWPOLYLINE-1467" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1934.94 455.46 1934.94 473.71 1753.73 502.52"/>
+  </g>
+  <g id="LWPOLYLINE-1468" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="860.8" y1="659.72" x2="847.03" y2="617.14"/>
+  </g>
+  <g id="LWPOLYLINE-1469" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1830.24" y1="488.11" x2="1753.4" y2="500.29"/>
+  </g>
+  <g id="LWPOLYLINE-1470" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1965.03 420.57 1964.08 418 1969.19 416.4 1973.99 430.48 1968.87 432.08 1967.91 429.52 1962.79 421.52"/>
+  </g>
+  <g id="ARC-112" data-name="ARC">
+    <path class="cls-3" d="M1964.8,420.39c-.78.26-1.53.62-2.22,1.07"/>
+  </g>
+  <g id="LWPOLYLINE-1471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1714.03" y1="508.93" x2="1688.09" y2="513.09"/>
+  </g>
+  <g id="LWPOLYLINE-1472" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1831.84 485.87 1829.92 486.19 1830.57 490.36 1832.48 490.04 1831.84 485.87"/>
+  </g>
+  <g id="LWPOLYLINE-1473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1830.24" y1="488.43" x2="1753.4" y2="500.61"/>
+  </g>
+  <g id="LWPOLYLINE-1474" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909" y1="475.63" x2="1832.16" y2="488.11"/>
+  </g>
+  <g id="LWPOLYLINE-1475" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1753.08 498.36 1751.16 498.68 1751.81 502.84 1753.72 502.52 1753.08 498.36"/>
+  </g>
+  <g id="LWPOLYLINE-1476" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1964.71 672.84 1964.71 677.97 1863.22 677.97"/>
+  </g>
+  <g id="LWPOLYLINE-1477" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1910.6 473.07 1908.68 473.39 1909.33 477.55 1911.24 477.23 1910.6 473.07"/>
+  </g>
+  <g id="LWPOLYLINE-1478" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1978.16" y1="430.17" x2="1982.32" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1479" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1985.52" y1="430.17" x2="1991.93" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1995.13" y1="430.17" x2="2001.53" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2004.73" y1="430.17" x2="2011.13" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1482" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2014.34" y1="430.17" x2="2020.42" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1483" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2023.62" y1="430.17" x2="2030.02" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1484" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2033.22" y1="430.17" x2="2037.39" y2="430.17"/>
+  </g>
+  <g id="LWPOLYLINE-1485" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2016.9" y1="677.97" x2="2002.81" y2="677.97"/>
+  </g>
+  <g id="LWPOLYLINE-1486" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2012.42" y1="672.85" x2="2002.81" y2="672.85"/>
+  </g>
+  <g id="LWPOLYLINE-1487" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1964.71" y1="672.85" x2="1862.9" y2="672.85"/>
+  </g>
+  <g id="LWPOLYLINE-1488" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2002.81" y1="677.97" x2="2002.81" y2="672.84"/>
+  </g>
+  <g id="LWPOLYLINE-1489" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2043.47" y1="368.69" x2="2035.15" y2="451.29"/>
+  </g>
+  <g id="LWPOLYLINE-1490" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2047.95" y1="368.05" x2="2038.35" y2="459.3"/>
+  </g>
+  <g id="LWPOLYLINE-1491" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2034.51" y1="497.4" x2="2021.7" y2="622.9"/>
+  </g>
+  <g id="LWPOLYLINE-1492" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2026.18" y1="623.54" x2="2025.54" y2="627.38"/>
+  </g>
+  <g id="LWPOLYLINE-1493" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2022.34" y1="627.06" x2="2016.89" y2="677.97"/>
+  </g>
+  <g id="LWPOLYLINE-1494" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1980.72" y1="1048.08" x2="1979.76" y2="1055.76"/>
+  </g>
+  <g id="LWPOLYLINE-1495" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1971.75 1093.22 1975.92 1093.86 1959.91 1243.38"/>
+  </g>
+  <g id="LWPOLYLINE-1496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1975.92" y1="1052.56" x2="1975.6" y2="1055.44"/>
+  </g>
+  <g id="LWPOLYLINE-1497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1971.75" y1="1093.22" x2="1955.74" y2="1243.37"/>
+  </g>
+  <g id="LWPOLYLINE-1498" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1979.76" y1="1055.76" x2="1975.6" y2="1055.44"/>
+  </g>
+  <g id="LWPOLYLINE-1499" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1881.15 605.61 1881.15 597.93 1886.91 597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1500" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1890.11" y1="597.93" x2="1896.51" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1501" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1899.72" y1="597.93" x2="1906.12" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1502" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909.32" y1="597.93" x2="1915.72" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1503" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1918.61" y1="597.93" x2="1925.02" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1504" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1928.21" y1="597.93" x2="1934.61" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1505" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1937.82" y1="597.93" x2="1944.22" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1947.42" y1="597.93" x2="1953.82" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1507" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1957.03" y1="597.93" x2="1963.43" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1508" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1966.63" y1="597.93" x2="1972.72" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1975.92" y1="597.93" x2="1982.32" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1985.52" y1="597.93" x2="1991.93" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1995.13" y1="597.93" x2="2001.53" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1512" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2004.73" y1="597.93" x2="2011.13" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2014.34" y1="597.93" x2="2020.1" y2="597.93"/>
+  </g>
+  <g id="LWPOLYLINE-1514" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1881.15" y1="654.92" x2="1886.91" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1515" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1890.11" y1="654.92" x2="1896.51" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1516" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1899.72" y1="654.92" x2="1905.8" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1909" y1="654.92" x2="1915.4" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1918.61" y1="654.92" x2="1925.02" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1519" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1928.21" y1="654.92" x2="1933.98" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1520" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1881.15" y1="608.82" x2="1881.15" y2="615.22"/>
+  </g>
+  <g id="LWPOLYLINE-1521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1881.15" y1="618.42" x2="1881.15" y2="624.82"/>
+  </g>
+  <g id="LWPOLYLINE-1522" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1881.15" y1="628.03" x2="1881.15" y2="634.43"/>
+  </g>
+  <g id="LWPOLYLINE-1523" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1881.15" y1="637.63" x2="1881.15" y2="643.72"/>
+  </g>
+  <g id="LWPOLYLINE-1524" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1881.15" y1="646.92" x2="1881.15" y2="654.92"/>
+  </g>
+  <g id="LWPOLYLINE-1525" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1933.97" y1="654.92" x2="1933.97" y2="662.28"/>
+  </g>
+  <g id="LWPOLYLINE-1526" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1933.97" y1="665.48" x2="1933.97" y2="672.85"/>
+  </g>
+  <g id="LWPOLYLINE-1527" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2065.56" y1="408.39" x2="2050.19" y2="361.97"/>
+  </g>
+  <g id="LWPOLYLINE-1528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2133.12" y1="334.76" x2="2131.84" y2="330.59"/>
+  </g>
+  <g id="LWPOLYLINE-1529" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2061.08" y1="408.07" x2="2047.96" y2="368.05"/>
+  </g>
+  <g id="LWPOLYLINE-1530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2259.26" y1="152.59" x2="2306.01" y2="158.03"/>
+  </g>
+  <g id="LWPOLYLINE-1531" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2167.05" y1="324.19" x2="2289.67" y2="338.28"/>
+  </g>
+  <g id="LWPOLYLINE-1532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2243.25" y1="537.1" x2="2193.95" y2="531.34"/>
+  </g>
+  <g id="LWPOLYLINE-1533" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2117.43" y1="803.79" x2="2136" y2="639.88"/>
+  </g>
+  <g id="LWPOLYLINE-1534" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2121.59" y1="804.11" x2="2140.16" y2="640.51"/>
+  </g>
+  <g id="LWPOLYLINE-1535" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.2" y1="811.48" x2="2147.52" y2="807.32"/>
+  </g>
+  <g id="LWPOLYLINE-1536" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.52" y1="807.32" x2="2162.57" y2="675.41"/>
+  </g>
+  <g id="LWPOLYLINE-1537" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2195.87 681.49 2192.35 710.95 2224.04 714.47 2227.56 685.01 2195.87 681.49"/>
+  </g>
+  <g id="LWPOLYLINE-1538" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2196.83 682.45 2193.63 709.98 2223.08 713.51 2226.28 685.97 2196.83 682.45"/>
+  </g>
+  <g id="LWPOLYLINE-1539" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2199.71 703.26 2201.31 690.77 2209 691.74"/>
+  </g>
+  <g id="LWPOLYLINE-1540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2200.67" y1="696.86" x2="2205.47" y2="697.5"/>
+  </g>
+  <g id="LWPOLYLINE-1541" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2210.6 704.54 2212.2 692.06 2217.32 692.7 2219.24 693.34 2219.88 693.98 2220.2 695.26 2220.2 696.54 2219.24 697.82 2218.6 698.14 2216.68 698.78 2211.23 698.14"/>
+  </g>
+  <g id="LWPOLYLINE-1542" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2215.72" y1="698.46" x2="2218.92" y2="705.51"/>
+  </g>
+  <g id="LWPOLYLINE-1543" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2004.41 909.77 2004.41 895.04 2010.17 909.77 2015.62 895.04 2015.62 909.77"/>
+  </g>
+  <g id="LWPOLYLINE-1544" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2030.67 909.77 2021.38 909.77 2021.38 895.04 2030.67 895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1545" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2021.38" y1="902.08" x2="2027.14" y2="902.08"/>
+  </g>
+  <g id="LWPOLYLINE-1546" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2044.11 909.77 2034.83 909.77 2034.83 895.04 2044.11 895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1547" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2034.83" y1="902.08" x2="2040.59" y2="902.08"/>
+  </g>
+  <g id="LWPOLYLINE-1548" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2053.08" y1="895.04" x2="2053.08" y2="909.76"/>
+  </g>
+  <g id="LWPOLYLINE-1549" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2048.27" y1="895.04" x2="2058.2" y2="895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1550" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2061.08" y1="909.77" x2="2061.08" y2="895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1551" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2066.52 909.77 2066.52 895.04 2076.45 909.77 2076.45 895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1552" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2092.78 898.56 2092.14 897.28 2090.54 895.68 2089.26 895.04 2086.37 895.04 2085.09 895.68 2083.49 897.28 2082.85 898.56 2082.21 900.8 2082.21 904.33 2082.85 906.25 2083.49 907.85 2085.09 909.12 2086.37 909.77 2089.26 909.77 2090.54 909.12 2092.14 907.85 2092.78 906.25 2092.78 904.33 2089.26 904.33"/>
+  </g>
+  <g id="LWPOLYLINE-1553" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2110.38 909.77 2110.38 895.04 2116.79 895.04 2119.03 895.68 2119.67 896.32 2120.31 897.92 2120.31 899.2 2119.67 900.8 2119.03 901.44 2116.79 902.08 2110.38 902.08"/>
+  </g>
+  <g id="LWPOLYLINE-1554" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2115.51" y1="902.08" x2="2120.31" y2="909.77"/>
+  </g>
+  <g id="LWPOLYLINE-1555" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2129.59 895.04 2127.99 895.68 2126.71 897.28 2126.07 898.56 2125.43 900.8 2125.43 904.32 2126.07 906.25 2126.71 907.85 2127.99 909.12 2129.59 909.76 2132.47 909.76 2133.75 909.12 2135.04 907.85 2136 906.25 2136.64 904.32 2136.64 900.8 2136 898.56 2135.04 897.28 2133.75 895.68 2132.47 895.04 2129.59 895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1556" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2144.96 895.04 2143.68 895.68 2142.4 897.28 2141.44 898.56 2140.8 900.8 2140.8 904.32 2141.44 906.25 2142.4 907.85 2143.68 909.12 2144.96 909.76 2147.84 909.76 2149.45 909.12 2150.73 907.85 2151.37 906.25 2152.01 904.32 2152.01 900.8 2151.37 898.56 2150.73 897.28 2149.45 895.68 2147.84 895.04 2144.96 895.04"/>
+  </g>
+  <g id="LWPOLYLINE-1557" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.49 909.77 2156.49 895.04 2161.94 909.77 2167.69 895.04 2167.69 909.77"/>
+  </g>
+  <g id="LWPOLYLINE-1558" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2004.41 866.22 2004.41 881.27 2012.74 881.27"/>
+  </g>
+  <g id="LWPOLYLINE-1559" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2016.26 866.22 2016.26 876.79 2017.22 879.03 2018.5 880.31 2020.74 881.27 2022.02 881.27 2024.26 880.31 2025.54 879.03 2026.18 876.79 2026.18 866.22"/>
+  </g>
+  <g id="LWPOLYLINE-1560" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2031.95 881.27 2031.95 866.22 2041.87 881.27 2041.87 866.22"/>
+  </g>
+  <g id="LWPOLYLINE-1561" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2058.2 869.75 2057.24 868.47 2055.96 867.19 2054.68 866.23 2051.79 866.23 2050.19 867.19 2048.91 868.47 2048.27 869.75 2047.64 871.99 2047.64 875.51 2048.27 877.75 2048.91 879.03 2050.19 880.31 2051.79 881.27 2054.68 881.27 2055.96 880.31 2057.24 879.03 2058.2 877.75"/>
+  </g>
+  <g id="LWPOLYLINE-1562" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2062.36" y1="881.27" x2="2062.36" y2="866.22"/>
+  </g>
+  <g id="LWPOLYLINE-1563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2072.28" y1="866.22" x2="2072.28" y2="881.27"/>
+  </g>
+  <g id="LWPOLYLINE-1564" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2062.36" y1="873.27" x2="2072.28" y2="873.27"/>
+  </g>
+  <g id="LWPOLYLINE-1565" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2090.54" y1="863.34" x2="2078.05" y2="886.07"/>
+  </g>
+  <g id="LWPOLYLINE-1566" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="357.18 795.15 349.5 797.71 345.66 785.55 353.02 783.3"/>
+  </g>
+  <g id="LWPOLYLINE-1567" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="347.58" y1="791.31" x2="352.06" y2="790.03"/>
+  </g>
+  <g id="LWPOLYLINE-1568" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="360.7 794.19 356.54 782.02 361.66 780.42 363.58 780.42 364.54 780.74 365.51 781.7 366.15 783.31 365.83 784.9 365.51 785.54 363.9 786.83 358.78 788.43"/>
+  </g>
+  <g id="LWPOLYLINE-1569" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="214.71 1105.71 215.35 1092.26 224 1102.83"/>
+  </g>
+  <g id="LWPOLYLINE-1570" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="215.35" y1="1101.22" x2="221.11" y2="1099.3"/>
+  </g>
+  <g id="LWPOLYLINE-1571" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="227.52 1101.54 223.36 1089.38 228.79 1087.78 230.72 1087.78 231.35 1088.1 232.32 1089.06 232.96 1090.98 232.64 1092.26 232.32 1092.9 230.72 1094.18 225.6 1095.78"/>
+  </g>
+  <g id="LWPOLYLINE-1572" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2150.08 363.57 2148.48 362.93 2146.56 362.61 2144.32 363.57 2142.72 364.53 2142.08 366.13 2142.4 367.41 2143.36 368.38 2144 368.7 2145.6 369.02 2149.12 369.02 2150.72 369.02 2151.36 369.34 2152.32 370.62 2152.97 372.22 2152.01 373.82 2150.72 374.78 2148.16 375.74 2146.25 375.74 2144.96 374.78"/>
+  </g>
+  <g id="LWPOLYLINE-1573" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.81 372.86 2152.97 360.69 2158.09 359.09 2160.01 359.09 2160.97 359.41 2161.93 360.37 2162.25 361.97 2162.25 363.57 2161.61 364.21 2160.33 365.17 2154.89 367.09"/>
+  </g>
+  <g id="LWPOLYLINE-1574" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2082.53 384.06 2078.69 371.9 2082.85 370.62 2084.77 370.62 2086.05 371.26 2087.01 372.22 2088.29 373.82 2089.26 376.7 2089.26 378.61 2088.93 379.9 2088.29 381.5 2086.69 382.78 2082.53 384.06"/>
+  </g>
+  <g id="LWPOLYLINE-1575" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2094.7 379.9 2090.86 368.05 2098.22 365.49"/>
+  </g>
+  <g id="LWPOLYLINE-1576" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2092.78" y1="373.82" x2="2097.26" y2="372.22"/>
+  </g>
+  <g id="ARC-113" data-name="ARC">
+    <path class="cls-3" d="M1236.99,1309.66c-.1.88-.09,1.77.04,2.65"/>
+  </g>
+  <g id="ARC-114" data-name="ARC">
+    <path class="cls-3" d="M1255.44,1311.77c-.1.88-.09,1.77.04,2.65"/>
+  </g>
+  <g id="MTEXT">
+    <text class="cls-1" transform="translate(1009.24 1328.35)"><tspan x="0" y="0">Mission Street</tspan></text>
+  </g>
+  <g id="MTEXT-2" data-name="MTEXT">
+    <text class="cls-2" transform="translate(1060.72 475.52) rotate(-18.5)"><tspan x="0" y="0">Otis Street</tspan></text>
+  </g>
+  <g id="LWPOLYLINE-1577" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2278.43,211.34c1.22.53,2.51.88,3.83,1.03,1.32.15,2.65.1,3.95-.14"/>
+  </g>
+  <g id="LWPOLYLINE-1578" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2292.03,202.1c-.36-.59-.8-1.13-1.31-1.6-.86-.8-1.85-1.45-2.92-1.92-1.8-.81-3.76-1.2-5.74-1.16"/>
+  </g>
+  <g id="LWPOLYLINE-1579" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2285.67,208.81c.82-.14,1.61-.42,2.34-.83.31-.18.6-.4.85-.65.92-.95,1.1-2.4.45-3.55-.24-.36-.52-.7-.84-.98-.57-.55-1.23-1-1.95-1.34-.92-.4-1.9-.66-2.9-.78-1-.12-2.02-.08-3.01.11"/>
+  </g>
+  <g id="LWPOLYLINE-1580" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2279.71,208.41c.92.4,1.9.66,2.91.78,1,.12,2.01.08,3-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1581" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2274.15,201.15c-.6.74-.98,1.63-1.09,2.58-.1.95.06,1.9.48,2.76.34.67.76,1.31,1.25,1.88.32.36.67.7,1.04,1"/>
+  </g>
+  <g id="LWPOLYLINE-1582" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2275.39,202.17c-.41.5-.66,1.11-.74,1.75-.06.68.08,1.36.4,1.97.27.54.61,1.05,1,1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1583" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2271.09,249.43c.84.8,1.8,1.45,2.86,1.93,1.21.53,2.5.88,3.82,1.03,1.32.15,2.65.11,3.96-.14"/>
+  </g>
+  <g id="LWPOLYLINE-1584" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2272.49,238.98c-1.09.52-2.05,1.27-2.82,2.19-.6.74-.98,1.63-1.09,2.58-.11.95.06,1.9.49,2.76"/>
+  </g>
+  <g id="LWPOLYLINE-1585" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2282.03,241.48c-.92-.4-1.9-.66-2.9-.78-1-.12-2.01-.08-3.01.11"/>
+  </g>
+  <g id="LWPOLYLINE-1586" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2284.82,244.12c-.24-.36-.52-.7-.84-.99-.57-.54-1.23-.97-1.95-1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1587" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2281.18,248.84c.72-.16,1.4-.44,2.02-.83.35-.21.68-.46.97-.75"/>
+  </g>
+  <g id="LWPOLYLINE-1588" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2273.38,247.19c.54.51,1.17.93,1.84,1.24.92.4,1.9.66,2.9.78,1,.12,2.01.08,3.01-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1589" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2281.78,251.98c1.13-.21,2.21-.61,3.2-1.19.55-.36,1.04-.8,1.48-1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1590" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2287.55,242.44c-.36-.59-.8-1.13-1.31-1.6-.86-.8-1.85-1.45-2.92-1.92"/>
+  </g>
+  <g id="LWPOLYLINE-1591" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2272.03,241.14c-.42.3-.8.66-1.13,1.05-.41.5-.66,1.11-.73,1.75-.07.64.04,1.29.33,1.86"/>
+  </g>
+  <g id="LWPOLYLINE-1592" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2097.46,221.85c1.03,4.75,5.71,7.76,10.46,6.73.16-.03.31-.07.46-.11,4.81-.95,7.94-5.61,7-10.42-.13-.67-.34-1.32-.62-1.94-.18-.57-.79-.89-1.37-.72-2.15.92-4.34,1.74-6.57,2.46"/>
+  </g>
+  <g id="LWPOLYLINE-1593" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2097.63,221.61c-.17-.64.21-1.29.85-1.46,2.31-.49,4.6-1.09,6.85-1.81"/>
+  </g>
+  <g id="LWPOLYLINE-1594" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2102.02,229.06c1.26.9,2.7,1.53,4.22,1.83,1.29.24,2.63.15,3.88-.26,1.25-.41,2.38-1.13,3.28-2.09,1.1-1.15,1.94-2.52,2.48-4.02.57-1.52.88-3.12.91-4.74-.02-1.85-.32-3.69-.9-5.45-.28-1.28-1.53-2.1-2.82-1.85"/>
+  </g>
+  <g id="LWPOLYLINE-1595" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2095.92,220.83c.55,1.74,1.36,3.39,2.4,4.89.95,1.33,2.13,2.49,3.48,3.42"/>
+  </g>
+  <g id="LWPOLYLINE-1596" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2104.31,216.69c-.02.15,0,.3.05.43.07.2.19.38.35.52"/>
+  </g>
+  <g id="LWPOLYLINE-1597" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2106.51,217.05c.09-.35,0-.72-.24-1-.1-.11-.22-.2-.35-.27"/>
+  </g>
+  <g id="LWPOLYLINE-1598" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2131.72,211.01c1.06,4.73,5.76,7.71,10.49,6.65.66-.15,1.3-.37,1.92-.67,4.52-1.74,6.77-6.81,5.03-11.33-.06-.15-.12-.29-.18-.43-.17-.57-.77-.89-1.33-.72"/>
+  </g>
+  <g id="LWPOLYLINE-1599" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2140.49,220.01c1.29.24,2.63.15,3.88-.26,1.25-.41,2.38-1.13,3.28-2.09"/>
+  </g>
+  <g id="LWPOLYLINE-1600" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2140.53,205.16c-.1-.11-.22-.2-.35-.27-.13-.06-.28-.1-.42-.12-.15-.01-.29,0-.43.06-.14.05-.27.12-.38.21"/>
+  </g>
+  <g id="LWPOLYLINE-1601" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M298.37,1022.3c.16-.42.29-.85.39-1.3.2-1.09.23-2.2.06-3.29-.18-1.36-.58-2.68-1.16-3.92-.56-1.2-1.3-2.31-2.19-3.3"/>
+  </g>
+  <g id="LWPOLYLINE-1602" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M292.65,1026.58c.94.13,1.91-.02,2.77-.43.86-.4,1.59-1.04,2.1-1.85.39-.56.72-1.17.96-1.81"/>
+  </g>
+  <g id="LWPOLYLINE-1603" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M286.2,1016.01c.14,1,.43,1.97.85,2.88.43.91.99,1.76,1.67,2.5"/>
+  </g>
+  <g id="LWPOLYLINE-1604" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M291.34,1011.17c-.4-.22-.83-.39-1.27-.49-1.27-.24-2.55.38-3.15,1.53-.19.37-.32.75-.4,1.15"/>
+  </g>
+  <g id="LWPOLYLINE-1605" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M295.6,1020.35c.13-.77.14-1.55.02-2.32-.14-1-.42-1.97-.85-2.88-.43-.91-.99-1.76-1.67-2.5"/>
+  </g>
+  <g id="LWPOLYLINE-1606" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M292.86,1024.99c.64.08,1.29-.02,1.87-.29.59-.23,1.1-.62,1.47-1.13.32-.51.58-1.07.76-1.65"/>
+  </g>
+  <g id="LWPOLYLINE-1607" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M321.81,994.46c1.6,4.6,6.64,7.03,11.24,5.42.14-.05.28-.1.42-.16,4.64-1.49,7.2-6.45,5.71-11.1-.21-.65-.49-1.28-.85-1.87"/>
+  </g>
+  <g id="LWPOLYLINE-1608" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M327.22,1001.02c1.34.72,2.82,1.15,4.34,1.26,1.31.08,2.63-.17,3.82-.72,1.19-.56,2.23-1.41,3-2.47.93-1.26,1.59-2.72,1.91-4.25"/>
+  </g>
+  <g id="LWPOLYLINE-1609" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M320.76,990.55c-1.05.73-1.33,2.17-.62,3.24.76,1.65,1.77,3.17,3,4.52,1.11,1.21,2.42,2.22,3.87,2.98"/>
+  </g>
+  <g id="LWPOLYLINE-1610" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M340.54,994.86c.32-1.56.37-3.17.15-4.75-.24-1.85-.76-3.64-1.55-5.33-.39-1.24-1.69-1.95-2.94-1.6"/>
+  </g>
+  <g id="LWPOLYLINE-1611" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M354.48,979.45c1.61,4.6,6.64,7.02,11.23,5.42.65-.23,1.26-.53,1.84-.89,4.29-2.28,5.92-7.61,3.64-11.91-.07-.13-.15-.27-.22-.4"/>
+  </g>
+  <g id="LWPOLYLINE-1612" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M363,974.6c2.13-1.02,4.21-2.15,6.23-3.38.63-.26,1.35.04,1.62.67"/>
+  </g>
+  <g id="LWPOLYLINE-1613" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M364.21,987.55c1.31.08,2.63-.17,3.82-.72,1.19-.56,2.23-1.4,3.01-2.47.93-1.27,1.58-2.72,1.91-4.25"/>
+  </g>
+  <g id="LWPOLYLINE-1614" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M362.94,973.47c.03-.21,0-.43-.1-.62-.06-.14-.15-.26-.26-.35"/>
+  </g>
+  <g id="LWPOLYLINE-1615" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M353.42,975.5c-1.07.74-1.36,2.19-.65,3.28.79,1.65,1.83,3.17,3.09,4.51"/>
+  </g>
+  <g id="LWPOLYLINE-1616" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M254.2,1041.82c.49.21,1,.36,1.52.46.64.08,1.29-.01,1.88-.28.58-.28,1.07-.71,1.41-1.26.34-.47.61-.99.82-1.52"/>
+  </g>
+  <g id="LWPOLYLINE-1617" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M261.97,1034.88c-.18-1.32-.56-2.6-1.13-3.8-.56-1.2-1.3-2.31-2.2-3.29"/>
+  </g>
+  <g id="LWPOLYLINE-1618" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M258.52,1028.01c-.77-.85-1.69-1.56-2.7-2.11-.65-.31-1.34-.54-2.04-.68"/>
+  </g>
+  <g id="LWPOLYLINE-1619" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M246.29,1030.2c-.23,1.12-.27,2.28-.11,3.42.27,2,.99,3.91,2.09,5.59"/>
+  </g>
+  <g id="LWPOLYLINE-1620" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M249.43,1030.85c-.16.81-.17,1.64-.04,2.46.14,1,.43,1.97.85,2.88.43.91.99,1.76,1.67,2.5"/>
+  </g>
+  <g id="LWPOLYLINE-1621" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M256.15,1030.16c-.57-.57-1.22-1.03-1.94-1.38-.36-.2-.75-.34-1.15-.43"/>
+  </g>
+  <g id="LWPOLYLINE-1622" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M258.8,1035.32c-.14-1-.43-1.97-.85-2.88-.43-.91-.99-1.76-1.67-2.5"/>
+  </g>
+  <g id="LWPOLYLINE-1623" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M249.05,1040.04c.89,1,1.93,1.85,3.08,2.52,1.02.67,2.17,1.12,3.38,1.31.94.13,1.91-.02,2.77-.43.86-.4,1.59-1.04,2.1-1.85.39-.56.72-1.17.96-1.81"/>
+  </g>
+  <g id="LWPOLYLINE-1624" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M261.23,1039.59c.15-.38.26-.77.34-1.17.23-1.12.27-2.28.11-3.42"/>
+  </g>
+</svg>

--- a/public/floorplans/Floor 4.svg
+++ b/public/floorplans/Floor 4.svg
@@ -1,0 +1,5756 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="LAYER_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2507.39 1410.79">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 54.09px;
+      }
+
+      .cls-1, .cls-2 {
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-2 {
+        font-size: 54.09px;
+      }
+
+      .cls-3 {
+        fill: none;
+        stroke: #000;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: .71px;
+      }
+    </style>
+  </defs>
+  <g id="LWPOLYLINE">
+    <polygon class="cls-3" points="1075.99 967.21 1075.99 971.22 1076.66 971.22 1076.66 962.54 1075.99 962.54 1075.99 966.55 1068.32 966.55 1068.32 962.54 1067.66 962.54 1067.66 971.22 1068.32 971.22 1068.32 967.21 1075.99 967.21"/>
+  </g>
+  <g id="CIRCLE">
+    <circle class="cls-3" cx="1071.83" cy="966.72" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-2" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="832.44" y="1263.49" width="47.37" height="19.02"/>
+  </g>
+  <g id="LWPOLYLINE-3" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1942.46" y="1268.16" width="56.38" height="18.68"/>
+  </g>
+  <g id="LWPOLYLINE-4" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2235.4 1268.16 2184.35 1268.16 2184.35 1286.84 2244.74 1286.84"/>
+  </g>
+  <g id="LWPOLYLINE-5" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1998.85" y1="1282.5" x2="2184.35" y2="1282.5"/>
+  </g>
+  <g id="LWPOLYLINE-6" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="308.29" y1="1214.78" x2="302.61" y2="1214.78"/>
+  </g>
+  <g id="LWPOLYLINE-7" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="308.29" y1="1164.06" x2="302.61" y2="1164.06"/>
+  </g>
+  <g id="LWPOLYLINE-8" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="361.67" y="1268.16" width="56.72" height="18.68"/>
+  </g>
+  <g id="LWPOLYLINE-9" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="143.47 1268.16 175.83 1268.16 175.83 1286.84"/>
+  </g>
+  <g id="LWPOLYLINE-10" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="175.83" y1="1282.17" x2="361.67" y2="1282.17"/>
+  </g>
+  <g id="LWPOLYLINE-11" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="175.83" y1="1282.5" x2="361.67" y2="1282.5"/>
+  </g>
+  <g id="LWPOLYLINE-12" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="175.83" y1="1271.49" x2="361.67" y2="1271.49"/>
+  </g>
+  <g id="LWPOLYLINE-13" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="175.83" y1="1286.84" x2="119.11" y2="1286.84"/>
+  </g>
+  <g id="LWPOLYLINE-14" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="655.94 653.92 602.56 671.61 608.23 689.29 661.61 671.61 655.94 653.92"/>
+  </g>
+  <g id="LWPOLYLINE-15" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M391.36,745.67l-159.15,52.38,159.15-52.38Z"/>
+  </g>
+  <g id="CIRCLE-2" data-name="CIRCLE">
+    <circle class="cls-3" cx="1288.03" cy="660.43" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-16" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1292.19 967.21 1292.19 971.22 1292.86 971.22 1292.86 962.54 1292.19 962.54 1292.19 966.55 1284.52 966.55 1284.52 962.54 1283.85 962.54 1283.85 971.22 1284.52 971.22 1284.52 967.21 1292.19 967.21"/>
+  </g>
+  <g id="CIRCLE-3" data-name="CIRCLE">
+    <circle class="cls-3" cx="1288.03" cy="966.72" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-17" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1508.06 967.21 1508.06 971.22 1508.73 971.22 1508.73 962.54 1508.06 962.54 1508.06 966.55 1500.39 966.55 1500.39 962.54 1499.71 962.54 1499.71 971.22 1500.39 971.22 1500.39 967.21 1508.06 967.21"/>
+  </g>
+  <g id="LWPOLYLINE-18" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1725.93 967.21 1725.93 971.22 1726.59 971.22 1726.59 962.54 1725.93 962.54 1725.93 966.55 1718.25 966.55 1718.25 962.54 1717.58 962.54 1717.58 971.22 1718.25 971.22 1718.25 967.21 1725.93 967.21"/>
+  </g>
+  <g id="LWPOLYLINE-19" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1979.49 967.21 1979.49 971.22 1980.16 971.22 1980.16 962.54 1979.49 962.54 1979.49 966.55 1971.82 966.55 1971.82 962.54 1971.15 962.54 1971.15 971.22 1971.82 971.22 1971.82 967.21 1979.49 967.21"/>
+  </g>
+  <g id="CIRCLE-4" data-name="CIRCLE">
+    <circle class="cls-3" cx="1975.66" cy="966.72" r="9.84"/>
+  </g>
+  <g id="LWPOLYLINE-20" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1979.49 660.93 1979.49 665.27 1980.16 665.27 1980.16 656.25 1979.49 656.25 1979.49 660.6 1971.82 660.6 1971.82 656.25 1971.15 656.25 1971.15 665.27 1971.82 665.27 1971.82 660.93 1979.49 660.93"/>
+  </g>
+  <g id="CIRCLE-5" data-name="CIRCLE">
+    <circle class="cls-3" cx="1975.32" cy="660.43" r="9.84"/>
+  </g>
+  <g id="LWPOLYLINE-21" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1725.93 660.93 1725.93 665.27 1726.26 665.27 1726.26 656.25 1725.93 656.25 1725.93 660.6 1717.91 660.6 1717.91 656.25 1717.58 656.25 1717.58 665.27 1717.91 665.27 1717.91 660.93 1725.93 660.93"/>
+  </g>
+  <g id="LWPOLYLINE-22" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="860.13 967.21 860.13 971.22 860.46 971.22 860.46 962.54 860.13 962.54 860.13 966.55 852.12 966.55 852.12 962.54 851.79 962.54 851.79 971.22 852.12 971.22 852.12 967.21 860.13 967.21"/>
+  </g>
+  <g id="CIRCLE-6" data-name="CIRCLE">
+    <circle class="cls-3" cx="855.62" cy="966.72" r="8.84"/>
+  </g>
+  <g id="LWPOLYLINE-23" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="643.26 967.21 643.26 971.22 643.93 971.22 643.93 962.54 643.26 962.54 643.26 966.55 635.59 966.55 635.59 962.54 635.25 962.54 635.25 971.22 635.59 971.22 635.59 967.21 643.26 967.21"/>
+  </g>
+  <g id="LWPOLYLINE-24" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="410.71 966.21 410.71 970.22 411.05 970.22 411.05 961.54 410.71 961.54 410.71 965.55 402.7 965.55 402.7 961.54 402.37 961.54 402.37 970.22 402.7 970.22 402.7 966.21 410.71 966.21"/>
+  </g>
+  <g id="CIRCLE-7" data-name="CIRCLE">
+    <circle class="cls-3" cx="406.54" cy="965.72" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-25" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1508.06 660.93 1508.06 665.27 1508.73 665.27 1508.73 656.25 1508.06 656.25 1508.06 660.6 1500.39 660.6 1500.39 656.25 1499.71 656.25 1499.71 665.27 1500.39 665.27 1500.39 660.93 1508.06 660.93"/>
+  </g>
+  <g id="CIRCLE-8" data-name="CIRCLE">
+    <circle class="cls-3" cx="1503.89" cy="660.43" r="8.84"/>
+  </g>
+  <g id="LWPOLYLINE-26" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1292.19 660.93 1292.19 665.27 1292.53 665.27 1292.53 656.25 1292.19 656.25 1292.19 660.6 1284.18 660.6 1284.18 656.25 1283.85 656.25 1283.85 665.27 1284.18 665.27 1284.18 660.93 1292.19 660.93"/>
+  </g>
+  <g id="LWPOLYLINE-27" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1075.99 660.93 1075.99 665.27 1076.66 665.27 1076.66 656.25 1075.99 656.25 1075.99 660.6 1068.32 660.6 1068.32 656.25 1067.66 656.25 1067.66 665.27 1068.32 665.27 1068.32 660.93 1075.99 660.93"/>
+  </g>
+  <g id="CIRCLE-9" data-name="CIRCLE">
+    <circle class="cls-3" cx="1071.83" cy="660.43" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-28" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="860.13 660.93 860.13 665.27 860.46 665.27 860.46 656.25 860.13 656.25 860.13 660.6 852.12 660.6 852.12 656.25 851.79 656.25 851.79 665.27 852.12 665.27 852.12 660.93 860.13 660.93"/>
+  </g>
+  <g id="CIRCLE-10" data-name="CIRCLE">
+    <circle class="cls-3" cx="855.62" cy="660.43" r="8.84"/>
+  </g>
+  <g id="LWPOLYLINE-29" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2214.05 660.93 2214.05 665.27 2214.71 665.27 2214.71 656.25 2214.05 656.25 2214.05 660.6 2206.37 660.6 2206.37 656.25 2205.71 656.25 2205.71 665.27 2206.37 665.27 2206.37 660.93 2214.05 660.93"/>
+  </g>
+  <g id="CIRCLE-11" data-name="CIRCLE">
+    <circle class="cls-3" cx="2209.54" cy="660.43" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-30" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1960.81 452.07 1962.15 455.74 1962.48 455.74 1959.81 447.4 1959.48 447.4 1960.81 451.4 1953.14 453.74 1951.81 450.07 1951.47 450.07 1954.14 458.41 1954.81 458.41 1953.47 454.41 1960.81 452.07"/>
+  </g>
+  <g id="CIRCLE-12" data-name="CIRCLE">
+    <circle class="cls-3" cx="1956.98" cy="452.58" r="8.84"/>
+  </g>
+  <g id="LWPOLYLINE-31" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2142.98 419.04 2144.31 423.04 2143.65 423.38 2140.98 415.04 2141.31 414.7 2142.65 418.71 2149.99 416.38 2148.65 412.37 2149.32 412.03 2151.98 420.37 2151.65 420.71 2150.32 416.7 2142.98 419.04"/>
+  </g>
+  <g id="CIRCLE-13" data-name="CIRCLE">
+    <circle class="cls-3" cx="2146.15" cy="417.54" r="8.84"/>
+  </g>
+  <g id="LWPOLYLINE-32" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1068.65 528.81 1069.99 532.81 1070.32 532.81 1067.65 524.47 1066.99 524.47 1068.32 528.47 1060.98 530.81 1059.65 526.81 1059.31 527.14 1061.98 535.48 1062.32 535.48 1060.98 531.48 1068.65 528.81"/>
+  </g>
+  <g id="LWPOLYLINE-33" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="635.92 671.27 637.26 675.28 637.92 674.94 635.25 666.6 634.59 666.6 635.92 670.61 628.58 673.28 627.25 669.27 626.58 669.27 629.58 677.61 629.92 677.61 628.58 673.61 635.92 671.27"/>
+  </g>
+  <g id="LWPOLYLINE-34" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="423.73 741 425.06 745.01 425.39 745.01 422.72 736.66 422.06 736.66 423.39 740.67 416.05 743.01 414.72 739 414.38 739.34 417.05 747.68 417.72 747.68 416.38 743.68 423.73 741"/>
+  </g>
+  <g id="LWPOLYLINE-35" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1725.93 1277.17 1725.93 1281.5 1726.26 1281.5 1726.26 1272.49 1725.93 1272.49 1725.93 1276.83 1717.91 1276.83 1717.91 1272.49 1717.58 1272.49 1717.58 1281.5 1717.91 1281.5 1717.91 1277.17 1725.93 1277.17"/>
+  </g>
+  <g id="LWPOLYLINE-36" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1292.19 1272.83 1292.19 1277.17 1292.53 1277.17 1292.53 1268.16 1292.19 1268.16 1292.19 1272.5 1284.18 1272.5 1284.18 1268.16 1283.85 1268.16 1283.85 1277.17 1284.18 1277.17 1284.18 1272.83 1292.19 1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-37" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1075.99 1272.83 1075.99 1277.17 1076.66 1277.17 1076.66 1268.16 1075.99 1268.16 1075.99 1272.5 1068.32 1272.5 1068.32 1268.16 1067.66 1268.16 1067.66 1277.17 1068.32 1277.17 1068.32 1272.83 1075.99 1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-38" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="860.13 1273.16 860.13 1277.17 860.46 1277.17 860.46 1268.49 860.13 1268.49 860.13 1272.49 852.12 1272.49 852.12 1268.49 851.79 1268.49 851.79 1277.17 852.12 1277.17 852.12 1273.16 860.13 1273.16"/>
+  </g>
+  <g id="LWPOLYLINE-39" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="635.25 1275.17 635.25 1279.5 635.59 1279.5 635.59 1270.49 635.25 1270.49 635.25 1274.83 627.24 1274.83 627.24 1270.49 626.92 1270.49 626.92 1279.5 627.24 1279.5 627.24 1275.17 635.25 1275.17"/>
+  </g>
+  <g id="LWPOLYLINE-40" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="394.03 1275.17 394.03 1279.5 394.36 1279.5 394.36 1270.49 394.03 1270.49 394.03 1274.83 386.02 1274.83 386.02 1270.49 385.68 1270.49 385.68 1279.5 386.02 1279.5 386.02 1275.17 394.03 1275.17"/>
+  </g>
+  <g id="LWPOLYLINE-41" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1979.49 1277.17 1979.49 1281.5 1980.16 1281.5 1980.16 1272.49 1979.49 1272.49 1979.49 1276.83 1971.82 1276.83 1971.82 1272.49 1971.15 1272.49 1971.15 1281.5 1971.82 1281.5 1971.82 1277.17 1979.49 1277.17"/>
+  </g>
+  <g id="LWPOLYLINE-42" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="161.48 1054.96 157.14 1054.63 157.14 1055.29 165.82 1056.3 166.15 1055.63 161.82 1055.29 162.82 1047.29 166.82 1047.95 166.82 1047.29 158.15 1046.29 158.15 1046.95 162.15 1047.29 161.48 1054.96"/>
+  </g>
+  <g id="LWPOLYLINE-43" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="187.84 821.75 183.84 821.41 183.84 821.75 192.51 822.75 192.51 822.41 188.51 821.75 189.17 814.07 193.51 814.74 193.51 814.07 184.84 813.08 184.84 813.73 188.84 814.07 187.84 821.75"/>
+  </g>
+  <g id="LWPOLYLINE-44" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2242.07 1273.5 2246.08 1273.83 2246.08 1273.16 2237.4 1272.16 2237.4 1272.83 2241.4 1273.16 2240.74 1281.17 2236.4 1280.5 2236.4 1281.17 2245.07 1282.17 2245.4 1281.51 2241.07 1281.17 2242.07 1273.5"/>
+  </g>
+  <g id="LWPOLYLINE-45" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2267.76 970.88 2263.76 970.22 2263.42 970.88 2272.43 971.88 2272.43 971.22 2268.43 970.88 2269.09 962.87 2273.1 963.54 2273.44 962.87 2264.43 961.88 2264.43 962.54 2268.43 962.87 2267.76 970.88"/>
+  </g>
+  <g id="LWPOLYLINE-46" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2299.79 663.6 2295.79 662.93 2295.45 663.6 2304.46 664.6 2304.46 663.93 2300.46 663.6 2301.13 655.93 2305.13 656.26 2305.13 655.59 2296.45 654.93 2296.45 655.25 2300.46 655.59 2299.79 663.6"/>
+  </g>
+  <g id="LWPOLYLINE-47" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2328.82 384.01 2324.82 383.67 2324.82 384.01 2333.49 385.01 2333.49 384.34 2329.48 384.01 2330.15 376.33 2334.49 376.67 2334.49 376 2325.49 375.34 2325.49 375.67 2329.82 376.33 2328.82 384.01"/>
+  </g>
+  <g id="LWPOLYLINE-48" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2374.86 99.41 2376.2 103.42 2376.53 103.42 2373.86 94.74 2373.53 95.07 2374.86 99.08 2367.18 101.41 2365.86 97.41 2365.52 97.74 2368.19 106.08 2368.85 105.75 2367.52 102.09 2374.86 99.41"/>
+  </g>
+  <g id="LWPOLYLINE-49" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="178.16" y1="1280.84" x2="180.5" y2="1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-50" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="180.5 1278.5 183.5 1281.17 186.5 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-51" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="186.5 1278.5 189.17 1281.17 192.18 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-52" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="192.18 1278.5 195.18 1281.17 198.18 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-53" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="198.18 1278.5 200.85 1281.17 203.86 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-54" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="203.86 1278.5 206.86 1281.17 209.87 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-55" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="209.87 1278.5 212.86 1281.17 215.54 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-56" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="215.54 1278.5 218.54 1281.17 221.54 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-57" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="221.54 1278.5 224.54 1281.17 227.55 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-58" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="227.55 1278.5 230.21 1281.17 233.22 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-59" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="233.22 1278.5 236.22 1281.17 239.22 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-60" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="239.22 1278.5 241.89 1281.17 244.9 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-61" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="244.9 1278.5 247.9 1281.17 250.9 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-62" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="250.9 1278.5 253.9 1281.17 256.58 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-63" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="256.58 1278.5 259.57 1281.17 262.58 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-64" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="262.58 1278.5 265.58 1281.17 267.58 1279.17"/>
+  </g>
+  <g id="LWPOLYLINE-65" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="175.82" y="1276.5" width="2.34" height="5.67"/>
+  </g>
+  <g id="LWPOLYLINE-66" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="267.58" y="1276.5" width="2.34" height="5.67"/>
+  </g>
+  <g id="LWPOLYLINE-67" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="359.33" y="1276.5" width="2.34" height="5.67"/>
+  </g>
+  <g id="LWPOLYLINE-68" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="359.33" y1="1276.5" x2="178.16" y2="1276.5"/>
+  </g>
+  <g id="LWPOLYLINE-69" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="269.92 1279.84 271.25 1281.17 274.26 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-70" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="274.26 1278.5 277.26 1281.17 280.25 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-71" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="280.26 1278.5 282.93 1281.17 285.93 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-72" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="285.94 1278.5 288.93 1281.17 291.93 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-73" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="291.94 1278.5 294.94 1281.17 297.61 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-74" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="297.61 1278.5 300.61 1281.17 303.61 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-75" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="303.62 1278.5 306.62 1281.17 309.29 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-76" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="309.29 1278.5 312.29 1281.17 315.29 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-77" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="315.3 1278.5 318.3 1281.17 321.29 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-78" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="321.3 1278.5 323.97 1281.17 326.97 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-79" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="326.97 1278.5 329.97 1281.17 332.97 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-80" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="332.97 1278.5 335.64 1281.17 338.64 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-81" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="338.65 1278.5 341.65 1281.17 344.65 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-82" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="344.66 1278.5 347.65 1281.17 350.33 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-83" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="350.33 1278.5 353.33 1281.17 356.32 1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-84" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="359.33" y1="1281.17" x2="359.33" y2="1281.17"/>
+  </g>
+  <g id="LWPOLYLINE-85" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="359.33" y1="1281.17" x2="356.33" y2="1278.5"/>
+  </g>
+  <g id="LWPOLYLINE-86" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="659.28 1282.5 663.95 1282.5 663.95 1263.49 631.92 1263.49 631.92 1268.16 603.22 1268.16 603.22 1286.84 659.28 1286.84 659.28 1282.5"/>
+  </g>
+  <g id="LWPOLYLINE-87" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="663.95" y1="1278.17" x2="832.44" y2="1278.17"/>
+  </g>
+  <g id="LWPOLYLINE-88" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="663.95" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-89" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="667.28" y1="1269.49" x2="746.02" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-90" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="667.28" y1="1268.49" x2="746.02" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-91" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="664.95" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-92" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="831.1" y="1268.16" width="1.33" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-93" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="829.1" y="1268.16" width="2" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-94" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="750.03" y1="1269.49" x2="829.1" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-95" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="750.03" y1="1268.49" x2="829.1" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-96" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1048.31" y="1263.49" width="47.71" height="19.02"/>
+  </g>
+  <g id="LWPOLYLINE-97" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1048.3" y1="1278.17" x2="879.81" y2="1278.17"/>
+  </g>
+  <g id="LWPOLYLINE-98" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1264.5,1278.17h-168.49,168.49Z"/>
+  </g>
+  <g id="LWPOLYLINE-99" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1480.37" y1="1278.17" x2="1311.88" y2="1278.17"/>
+  </g>
+  <g id="LWPOLYLINE-100" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1756.96 1268.16 1728.27 1268.16 1728.27 1263.49 1696.57 1263.49 1696.57 1282.5 1700.9 1282.5 1700.9 1286.84 1756.96 1286.84 1756.96 1268.16"/>
+  </g>
+  <g id="LWPOLYLINE-101" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1528.08" y1="1278.17" x2="1696.57" y2="1278.17"/>
+  </g>
+  <g id="LWPOLYLINE-102" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="166.82 868.12 173.16 812.74 230.88 793.72 236.89 811.74"/>
+  </g>
+  <g id="LWPOLYLINE-103" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="331.97" y1="772.03" x2="393.37" y2="752.02"/>
+  </g>
+  <g id="LWPOLYLINE-104" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="235.55" y1="800.72" x2="236.89" y2="798.05"/>
+  </g>
+  <g id="LWPOLYLINE-105" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="236.89 798.06 240.56 799.73 242.56 796.06"/>
+  </g>
+  <g id="LWPOLYLINE-106" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="242.56 796.05 246.23 798.06 248.23 794.39"/>
+  </g>
+  <g id="LWPOLYLINE-107" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="248.23 794.39 251.9 796.06 253.57 792.39"/>
+  </g>
+  <g id="LWPOLYLINE-108" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="253.57 792.39 257.24 794.39 259.24 790.72"/>
+  </g>
+  <g id="LWPOLYLINE-109" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="259.24 790.72 262.91 792.38 264.91 788.71"/>
+  </g>
+  <g id="LWPOLYLINE-110" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="264.91 788.72 268.58 790.72 270.25 787.05"/>
+  </g>
+  <g id="LWPOLYLINE-111" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="270.25 787.05 274.25 788.72 275.92 785.05"/>
+  </g>
+  <g id="LWPOLYLINE-112" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="275.92 785.04 279.59 787.05 281.59 783.38"/>
+  </g>
+  <g id="LWPOLYLINE-113" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="281.59 783.38 285.26 785.04 286.93 781.37"/>
+  </g>
+  <g id="LWPOLYLINE-114" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="286.93 781.38 290.94 783.38 292.6 779.71"/>
+  </g>
+  <g id="LWPOLYLINE-115" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="292.6 779.71 296.27 781.37 298.28 777.71"/>
+  </g>
+  <g id="LWPOLYLINE-116" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="298.28 777.7 301.95 779.71 303.95 776.04"/>
+  </g>
+  <g id="LWPOLYLINE-117" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="303.95 776.04 307.62 777.71 309.29 774.04"/>
+  </g>
+  <g id="LWPOLYLINE-118" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="311.62" y1="775.37" x2="309.28" y2="774.04"/>
+  </g>
+  <g id="LWPOLYLINE-119" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="233" y="797.59" width="2.11" height="5.28" transform="translate(-241.04 115.08) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-120" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="312.29 777.37 314.63 776.7 312.96 771.37 310.62 772.03 312.29 777.37"/>
+  </g>
+  <g id="LWPOLYLINE-121" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="391.03 751.68 393.03 751.01 391.36 745.67 389.03 746.34 391.03 751.68"/>
+  </g>
+  <g id="LWPOLYLINE-122" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="235.89" y1="802.39" x2="393.03" y2="751.01"/>
+  </g>
+  <g id="LWPOLYLINE-123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="234.22" y1="797.39" x2="391.36" y2="745.68"/>
+  </g>
+  <g id="LWPOLYLINE-124" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="313.96" y1="774.7" x2="314.96" y2="772.37"/>
+  </g>
+  <g id="LWPOLYLINE-125" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="314.96 772.37 318.63 774.03 320.63 770.37"/>
+  </g>
+  <g id="LWPOLYLINE-126" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="320.63 770.37 324.3 772.37 325.97 768.7"/>
+  </g>
+  <g id="LWPOLYLINE-127" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="325.97 768.7 329.64 770.36 331.64 766.7"/>
+  </g>
+  <g id="LWPOLYLINE-128" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="331.64 766.69 335.31 768.7 337.31 765.03"/>
+  </g>
+  <g id="LWPOLYLINE-129" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="337.31 765.03 340.98 767.03 342.65 763.03"/>
+  </g>
+  <g id="LWPOLYLINE-130" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="342.65 763.02 346.32 765.03 348.32 761.36"/>
+  </g>
+  <g id="LWPOLYLINE-131" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="348.32 761.36 351.99 763.36 353.99 759.35"/>
+  </g>
+  <g id="LWPOLYLINE-132" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="353.99 759.36 357.66 761.36 359.33 757.69"/>
+  </g>
+  <g id="LWPOLYLINE-133" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="359.33 757.69 363 759.69 365 755.68"/>
+  </g>
+  <g id="LWPOLYLINE-134" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="365 755.68 368.67 757.69 370.68 754.02"/>
+  </g>
+  <g id="LWPOLYLINE-135" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="370.68 754.02 374.35 756.02 376.01 752.35"/>
+  </g>
+  <g id="LWPOLYLINE-136" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="376.01 752.35 380.02 754.02 381.69 750.35"/>
+  </g>
+  <g id="LWPOLYLINE-137" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="381.69 750.35 385.36 752.35 387.36 748.68"/>
+  </g>
+  <g id="LWPOLYLINE-138" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="390.36" y1="750.01" x2="387.36" y2="748.68"/>
+  </g>
+  <g id="LWPOLYLINE-139" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="872.14 582.86 818.76 600.54 824.43 618.23 878.14 600.54 872.14 582.86"/>
+  </g>
+  <g id="LWPOLYLINE-140" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1088.34 511.79 1034.96 529.47 1040.63 547.16 1094.35 529.47 1088.34 511.79"/>
+  </g>
+  <g id="LWPOLYLINE-141" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2379.53 87.4 2325.82 105.08 2331.49 122.76"/>
+  </g>
+  <g id="LWPOLYLINE-142" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2379.53" y1="87.4" x2="2380.53" y2="91.07"/>
+  </g>
+  <g id="LWPOLYLINE-143" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2168,161.47l159.15-52.05-159.15,52.05Z"/>
+  </g>
+  <g id="LWPOLYLINE-144" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2331.49" y1="122.77" x2="2172.34" y2="175.15"/>
+  </g>
+  <g id="LWPOLYLINE-145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2249.41" y1="137.11" x2="2249.74" y2="136.45"/>
+  </g>
+  <g id="LWPOLYLINE-146" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2249.75 136.45 2253.42 138.11 2255.42 134.45"/>
+  </g>
+  <g id="LWPOLYLINE-147" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2255.42 134.44 2259.09 136.44 2260.76 132.78"/>
+  </g>
+  <g id="LWPOLYLINE-148" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2260.76 132.78 2264.43 134.44 2266.43 130.78"/>
+  </g>
+  <g id="LWPOLYLINE-149" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2266.43 130.77 2270.1 132.78 2272.1 129.11"/>
+  </g>
+  <g id="LWPOLYLINE-150" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2272.1 129.1 2275.77 130.77 2277.44 127.11"/>
+  </g>
+  <g id="LWPOLYLINE-151" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2277.44 127.1 2281.11 129.11 2283.11 125.44"/>
+  </g>
+  <g id="LWPOLYLINE-152" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2283.11 125.44 2286.78 127.1 2288.78 123.44"/>
+  </g>
+  <g id="LWPOLYLINE-153" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2288.78 123.43 2292.45 125.43 2294.12 121.77"/>
+  </g>
+  <g id="LWPOLYLINE-154" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2294.12 121.77 2297.79 123.43 2299.79 119.77"/>
+  </g>
+  <g id="LWPOLYLINE-155" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2299.79 119.76 2303.46 121.77 2305.46 118.1"/>
+  </g>
+  <g id="LWPOLYLINE-156" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2305.46 118.09 2309.13 119.76 2310.8 116.1"/>
+  </g>
+  <g id="LWPOLYLINE-157" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2310.8 116.09 2314.81 118.1 2316.47 114.43"/>
+  </g>
+  <g id="LWPOLYLINE-158" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2316.47 114.43 2320.14 116.09 2322.15 112.43"/>
+  </g>
+  <g id="LWPOLYLINE-159" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2322.15 112.42 2325.82 114.42 2326.15 113.76"/>
+  </g>
+  <g id="LWPOLYLINE-160" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2328.82 114.42 2326.82 115.09 2324.82 110.09 2327.15 109.42 2328.82 114.42"/>
+  </g>
+  <g id="LWPOLYLINE-161" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2250.41 140.45 2248.07 141.12 2246.41 135.78 2248.74 135.11 2250.41 140.45"/>
+  </g>
+  <g id="LWPOLYLINE-162" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2171.67 166.14 2169.67 166.8 2168 161.46 2170 160.8 2171.67 166.14"/>
+  </g>
+  <g id="LWPOLYLINE-163" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2326.82" y1="115.09" x2="2169.67" y2="166.81"/>
+  </g>
+  <g id="LWPOLYLINE-164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2324.81" y1="110.09" x2="2168" y2="161.47"/>
+  </g>
+  <g id="LWPOLYLINE-165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2171.01" y1="163.47" x2="2171.67" y2="161.8"/>
+  </g>
+  <g id="LWPOLYLINE-166" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.68 161.8 2175.34 163.81 2177.35 160.14"/>
+  </g>
+  <g id="LWPOLYLINE-167" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2177.35 160.13 2181.02 161.8 2183.02 158.14"/>
+  </g>
+  <g id="LWPOLYLINE-168" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2183.02 158.13 2186.69 160.13 2188.36 156.47"/>
+  </g>
+  <g id="LWPOLYLINE-169" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2188.36 156.47 2192.03 158.13 2194.03 154.46"/>
+  </g>
+  <g id="LWPOLYLINE-170" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2194.03 154.46 2197.7 156.46 2199.7 152.79"/>
+  </g>
+  <g id="LWPOLYLINE-171" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2199.7 152.8 2203.37 154.8 2205.04 150.79"/>
+  </g>
+  <g id="LWPOLYLINE-172" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2205.04 150.79 2209.04 152.79 2210.71 149.13"/>
+  </g>
+  <g id="LWPOLYLINE-173" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2210.71 149.12 2214.38 151.13 2216.38 147.12"/>
+  </g>
+  <g id="LWPOLYLINE-174" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2216.38 147.12 2220.05 149.12 2221.72 145.46"/>
+  </g>
+  <g id="LWPOLYLINE-175" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2221.72 145.45 2225.72 147.45 2227.39 143.45"/>
+  </g>
+  <g id="LWPOLYLINE-176" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2227.39 143.45 2231.06 145.45 2233.06 141.79"/>
+  </g>
+  <g id="LWPOLYLINE-177" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2233.07 141.78 2236.73 143.79 2238.74 140.12"/>
+  </g>
+  <g id="LWPOLYLINE-178" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2238.74 140.11 2242.41 141.78 2244.07 138.12"/>
+  </g>
+  <g id="LWPOLYLINE-179" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2244.07 138.11 2247.74 140.12 2247.74 139.78"/>
+  </g>
+  <g id="LWPOLYLINE-180" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="663.95" y1="1263.49" x2="832.44" y2="1263.49"/>
+  </g>
+  <g id="LWPOLYLINE-181" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1286.19" y1="650.92" x2="1286.19" y2="466.42"/>
+  </g>
+  <g id="LWPOLYLINE-182" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1073.33 768.36 1045.3 768.36 1045.3 763.69"/>
+  </g>
+  <g id="LWPOLYLINE-183" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="308.62" y1="1271.49" x2="308.62" y2="1214.77"/>
+  </g>
+  <g id="LWPOLYLINE-184" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="308.62" y1="1164.06" x2="308.62" y2="1147.71"/>
+  </g>
+  <g id="LWPOLYLINE-185" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="302.61" y1="1271.49" x2="302.61" y2="1214.77"/>
+  </g>
+  <g id="LWPOLYLINE-186" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="302.61" y1="1164.06" x2="302.61" y2="1154.39"/>
+  </g>
+  <g id="LWPOLYLINE-187" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="297.27" y="1211.44" width="13.01" height="3.33"/>
+  </g>
+  <g id="LWPOLYLINE-188" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="297.27 1211.44 297.27 1167.4 310.29 1167.4 310.29 1164.06 297.27 1164.06 297.27 1167.4"/>
+  </g>
+  <g id="LWPOLYLINE-189" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="283.26 1167.4 211.87 1167.4 211.87 1244.13 283.26 1244.13 283.26 1211.44 295.94 1211.44 295.94 1247.47 208.86 1247.47 208.86 1164.07 295.94 1164.07 295.94 1167.4 283.26 1167.4"/>
+  </g>
+  <g id="LWPOLYLINE-190" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="226.54 1199.43 216.87 1199.43 216.87 1184.08 226.54 1184.08"/>
+  </g>
+  <g id="LWPOLYLINE-191" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.87" y1="1191.42" x2="222.87" y2="1191.42"/>
+  </g>
+  <g id="LWPOLYLINE-192" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="230.88 1184.08 230.88 1199.43 239.55 1199.43"/>
+  </g>
+  <g id="LWPOLYLINE-193" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="252.9 1199.43 243.23 1199.43 243.23 1184.08 252.9 1184.08"/>
+  </g>
+  <g id="LWPOLYLINE-194" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="243.23" y1="1191.42" x2="249.23" y2="1191.42"/>
+  </g>
+  <g id="LWPOLYLINE-195" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="257.24 1184.08 263.24 1199.43 269.25 1184.08"/>
+  </g>
+  <g id="LWPOLYLINE-196" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="272.92 1198.09 272.25 1198.76 272.92 1199.43 273.59 1198.76"/>
+  </g>
+  <g id="LWPOLYLINE-197" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="279.59 1187.08 280.93 1186.08 283.26 1184.09 283.26 1199.43"/>
+  </g>
+  <g id="LWPOLYLINE-198" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="156.48" y1="1154.39" x2="302.61" y2="1154.39"/>
+  </g>
+  <g id="LWPOLYLINE-199" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="308.62 1142.37 308.62 1147.71 157.15 1147.71"/>
+  </g>
+  <g id="LWPOLYLINE-200" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="402.7 757.02 423.39 820.08 496.46 796.05"/>
+  </g>
+  <g id="LWPOLYLINE-201" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="505.8" y1="791.72" x2="633.92" y2="749.35"/>
+  </g>
+  <g id="LWPOLYLINE-202" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="505.8 791.72 506.47 793.72 634.92 751.35"/>
+  </g>
+  <g id="CIRCLE-14" data-name="CIRCLE">
+    <circle class="cls-3" cx="1721.76" cy="660.43" r="9.84"/>
+  </g>
+  <g id="CIRCLE-15" data-name="CIRCLE">
+    <circle class="cls-3" cx="1721.76" cy="966.38" r="9.84"/>
+  </g>
+  <g id="CIRCLE-16" data-name="CIRCLE">
+    <circle class="cls-3" cx="1503.89" cy="966.72" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-203" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="852.45 600.21 853.46 603.88 854.12 603.88 851.45 595.53 850.79 595.53 852.12 599.54 844.78 601.88 843.45 597.87 843.11 598.21 845.78 606.54 846.11 606.54 844.78 602.55 852.45 600.21"/>
+  </g>
+  <g id="LWPOLYLINE-204" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="874.81" y1="768.36" x2="1003.93" y2="768.36"/>
+  </g>
+  <g id="LWPOLYLINE-205" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1081" y1="665.6" x2="1218.79" y2="665.6"/>
+  </g>
+  <g id="LWPOLYLINE-206" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1292.19" y1="586.53" x2="1431.32" y2="586.53"/>
+  </g>
+  <g id="LWPOLYLINE-207" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1472.7 581.86 1472.7 586.53 1500.72 586.53"/>
+  </g>
+  <g id="LWPOLYLINE-208" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1483.04" y1="642.25" x2="1486.04" y2="642.25"/>
+  </g>
+  <g id="LWPOLYLINE-209" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1519.74" y1="642.25" x2="1523.74" y2="642.25"/>
+  </g>
+  <g id="LWPOLYLINE-210" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1483.04 642.25 1483.04 673.27 1523.74 673.27"/>
+  </g>
+  <g id="LWPOLYLINE-211" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1487.37 650.92 1487.37 668.94 1501.05 668.94"/>
+  </g>
+  <g id="LWPOLYLINE-212" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1507.39" y1="668.94" x2="1519.74" y2="668.94"/>
+  </g>
+  <g id="LWPOLYLINE-213" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1502.39" y1="504.79" x2="1642.18" y2="504.79"/>
+  </g>
+  <g id="LWPOLYLINE-214" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1683.56 500.12 1683.56 504.79 1710.58 504.79"/>
+  </g>
+  <g id="LWPOLYLINE-215" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1502.39" y1="500.12" x2="1642.18" y2="500.12"/>
+  </g>
+  <g id="LWPOLYLINE-216" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1683.56" y1="500.12" x2="1706.24" y2="500.12"/>
+  </g>
+  <g id="LWPOLYLINE-217" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1292.19" y1="581.86" x2="1431.32" y2="581.86"/>
+  </g>
+  <g id="LWPOLYLINE-218" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1472.7" y1="581.86" x2="1496.38" y2="581.86"/>
+  </g>
+  <g id="LWPOLYLINE-219" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1082" y1="660.93" x2="1218.79" y2="660.93"/>
+  </g>
+  <g id="LWPOLYLINE-220" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="874.81" y1="763.69" x2="1003.93" y2="763.69"/>
+  </g>
+  <g id="LWPOLYLINE-221" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1045.3" y1="763.69" x2="1068.99" y2="763.69"/>
+  </g>
+  <g id="LWPOLYLINE-222" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1047.3" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-223" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1044.97" y1="1269.49" x2="965.89" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-224" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1044.97" y1="1268.49" x2="965.89" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-225" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1044.96" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-226" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="879.81" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-227" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="880.81" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-228" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="883.15" y1="1269.49" x2="962.22" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-229" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="883.15" y1="1268.49" x2="962.22" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-230" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1048.3" y1="1263.49" x2="879.81" y2="1263.49"/>
+  </g>
+  <g id="LWPOLYLINE-231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="873.47" y1="587.19" x2="1036.29" y2="533.48"/>
+  </g>
+  <g id="LWPOLYLINE-232" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="878.14" y1="600.54" x2="1040.63" y2="546.83"/>
+  </g>
+  <g id="LWPOLYLINE-233" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1017.27 735.67 1045.3 763.69 1043.97 765.36 1015.94 737"/>
+  </g>
+  <g id="LWPOLYLINE-234" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1017.94 735 1014.94 738.33 1011.93 742 1009.59 746.01 1007.93 750.35 1006.6 754.68 1005.93 759.35 1005.6 763.69"/>
+  </g>
+  <g id="LWPOLYLINE-235" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1290.53" y1="651.25" x2="1290.53" y2="464.74"/>
+  </g>
+  <g id="LWPOLYLINE-236" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1496.38" y1="581.86" x2="1496.38" y2="397.36"/>
+  </g>
+  <g id="LWPOLYLINE-237" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1500.72" y1="586.53" x2="1500.72" y2="395.68"/>
+  </g>
+  <g id="LWPOLYLINE-238" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1523.74" y1="673.27" x2="1523.74" y2="642.25"/>
+  </g>
+  <g id="LWPOLYLINE-239" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1519.74" y1="668.94" x2="1519.74" y2="650.92"/>
+  </g>
+  <g id="LWPOLYLINE-240" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1232.14 632.9 1260.17 660.93 1258.83 662.6 1230.8 634.23"/>
+  </g>
+  <g id="LWPOLYLINE-241" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1232.81 632.24 1229.81 635.57 1227.13 639.24 1224.79 643.25 1222.8 647.59 1221.46 651.92 1220.8 656.59 1220.46 660.93"/>
+  </g>
+  <g id="LWPOLYLINE-242" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1251.16 458.41 1304.87 440.73 1310.54 458.41 1256.83 475.76 1251.16 458.41"/>
+  </g>
+  <g id="LWPOLYLINE-243" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1277.51 460.41 1278.85 464.42 1278.18 464.42 1275.51 456.07 1275.85 455.74 1277.18 459.75 1284.52 457.41 1283.19 453.41 1283.85 453.41 1286.52 461.74 1286.18 461.74 1284.85 457.75 1277.51 460.41"/>
+  </g>
+  <g id="LWPOLYLINE-244" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1252.49" y1="462.41" x2="1090.01" y2="516.13"/>
+  </g>
+  <g id="LWPOLYLINE-245" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1256.83" y1="475.76" x2="1094.34" y2="529.47"/>
+  </g>
+  <g id="LWPOLYLINE-246" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1444.67 553.83 1472.7 581.86 1471.36 583.52 1443.33 555.16"/>
+  </g>
+  <g id="LWPOLYLINE-247" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1445.67 553.16 1442.34 556.49 1439.66 560.17 1437.32 564.17 1435.33 568.52 1433.99 572.85 1433.33 577.52 1432.99 581.86"/>
+  </g>
+  <g id="LWPOLYLINE-248" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1264.5" y="1263.49" width="47.37" height="19.02"/>
+  </g>
+  <g id="LWPOLYLINE-249" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1500.39 1272.83 1500.39 1277.17 1499.72 1277.17 1499.72 1268.16 1500.39 1268.16 1500.39 1272.5 1508.06 1272.5 1508.06 1268.16 1508.73 1268.16 1508.73 1277.17 1508.06 1277.17 1508.06 1272.83 1500.39 1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-250" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1480.37" y="1263.49" width="47.71" height="19.02"/>
+  </g>
+  <g id="LWPOLYLINE-251" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1311.88 1278.17 1480.37 1278.17 1311.88 1278.17"/>
+  </g>
+  <g id="LWPOLYLINE-252" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2112.95 175.15 2166.66 157.47 2172.34 175.15 2118.96 192.5 2112.95 175.15"/>
+  </g>
+  <g id="LWPOLYLINE-253" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2135.31 178.15 2136.64 182.15 2136.31 182.49 2133.3 173.81 2133.98 173.81 2135.31 177.82 2142.65 175.48 2141.31 171.48 2141.98 171.14 2144.65 179.48 2143.98 179.82 2142.98 175.81 2135.31 178.15"/>
+  </g>
+  <g id="LWPOLYLINE-254" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="147.47 1077.98 129.79 1231.13 125.45 1230.79 119.11 1286.84"/>
+  </g>
+  <g id="LWPOLYLINE-255" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="143.47" y1="1268.16" x2="193.85" y2="825.75"/>
+  </g>
+  <g id="LWPOLYLINE-256" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="307.29 951.53 206.52 950.2 212.86 892.81"/>
+  </g>
+  <g id="LWPOLYLINE-257" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="302.95 947.19 211.19 945.86 216.87 897.15"/>
+  </g>
+  <g id="LWPOLYLINE-258" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="142.8" y1="1077.65" x2="149.47" y2="1021.26"/>
+  </g>
+  <g id="LWPOLYLINE-259" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="153.81" y1="1021.93" x2="171.16" y2="868.79"/>
+  </g>
+  <g id="LWPOLYLINE-260" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M444.75,727.99l159.15-52.05-159.15,52.05Z"/>
+  </g>
+  <g id="LWPOLYLINE-261" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="605.89" y1="681.95" x2="446.75" y2="734.33"/>
+  </g>
+  <g id="LWPOLYLINE-262" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="526.15" y1="703.97" x2="526.49" y2="702.97"/>
+  </g>
+  <g id="LWPOLYLINE-263" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="526.49 702.97 530.16 704.97 532.16 701.3"/>
+  </g>
+  <g id="LWPOLYLINE-264" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="532.16 701.3 535.83 702.97 537.83 699.3"/>
+  </g>
+  <g id="LWPOLYLINE-265" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="537.83 699.3 541.5 701.3 543.17 697.63"/>
+  </g>
+  <g id="LWPOLYLINE-266" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="543.17 697.63 546.84 699.3 548.84 695.63"/>
+  </g>
+  <g id="LWPOLYLINE-267" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="548.84 695.63 552.51 697.63 554.51 693.97"/>
+  </g>
+  <g id="LWPOLYLINE-268" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="554.51 693.96 558.18 695.63 559.85 691.96"/>
+  </g>
+  <g id="LWPOLYLINE-269" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="559.85 691.96 563.52 693.96 565.52 690.29"/>
+  </g>
+  <g id="LWPOLYLINE-270" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="565.52 690.29 569.19 692.29 571.19 688.63"/>
+  </g>
+  <g id="LWPOLYLINE-271" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="571.19 688.62 574.86 690.29 576.53 686.62"/>
+  </g>
+  <g id="LWPOLYLINE-272" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="576.53 686.62 580.54 688.62 582.21 684.96"/>
+  </g>
+  <g id="LWPOLYLINE-273" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="582.2 684.95 585.87 686.62 587.88 682.95"/>
+  </g>
+  <g id="LWPOLYLINE-274" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="587.88 682.95 591.55 684.95 593.55 681.29"/>
+  </g>
+  <g id="LWPOLYLINE-275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="593.55 681.28 597.22 682.95 598.89 679.29"/>
+  </g>
+  <g id="LWPOLYLINE-276" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="598.89 679.28 602.56 681.28 602.89 680.62"/>
+  </g>
+  <g id="LWPOLYLINE-277" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="602.67" y="676.14" width="2.11" height="5.28" transform="translate(-182.68 224.04) rotate(-18.31)"/>
+  </g>
+  <g id="LWPOLYLINE-278" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="527.15 706.97 525.15 707.64 523.15 702.3 525.49 701.63 527.15 706.97"/>
+  </g>
+  <g id="LWPOLYLINE-279" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="448.75 732.66 446.41 733.33 444.75 727.99 446.75 727.33 448.75 732.66"/>
+  </g>
+  <g id="LWPOLYLINE-280" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="603.56" y1="681.62" x2="446.41" y2="733.33"/>
+  </g>
+  <g id="LWPOLYLINE-281" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="601.89" y1="676.61" x2="444.75" y2="727.99"/>
+  </g>
+  <g id="LWPOLYLINE-282" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="447.75" y1="729.99" x2="448.41" y2="728.33"/>
+  </g>
+  <g id="LWPOLYLINE-283" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="448.41 728.33 452.42 730.33 454.09 726.66"/>
+  </g>
+  <g id="LWPOLYLINE-284" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="454.09 726.66 457.76 728.66 459.76 724.99"/>
+  </g>
+  <g id="LWPOLYLINE-285" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="459.76 724.99 463.43 726.66 465.43 722.99"/>
+  </g>
+  <g id="LWPOLYLINE-286" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="465.43 722.99 469.1 724.99 470.77 721.32"/>
+  </g>
+  <g id="LWPOLYLINE-287" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="470.77 721.32 474.44 722.99 476.44 719.32"/>
+  </g>
+  <g id="LWPOLYLINE-288" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="476.44 719.32 480.11 721.32 482.11 717.65"/>
+  </g>
+  <g id="LWPOLYLINE-289" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="482.11 717.65 485.78 719.32 487.45 715.65"/>
+  </g>
+  <g id="LWPOLYLINE-290" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="487.45 715.65 491.12 717.65 493.12 713.98"/>
+  </g>
+  <g id="LWPOLYLINE-291" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="493.12 713.98 496.79 715.65 498.79 711.98"/>
+  </g>
+  <g id="LWPOLYLINE-292" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="498.79 711.98 502.46 713.98 504.13 710.32"/>
+  </g>
+  <g id="LWPOLYLINE-293" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="504.13 710.31 507.8 712.31 509.8 708.31"/>
+  </g>
+  <g id="LWPOLYLINE-294" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="509.8 708.31 513.47 710.31 515.48 706.64"/>
+  </g>
+  <g id="LWPOLYLINE-295" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="515.48 706.64 519.15 708.64 520.82 704.98"/>
+  </g>
+  <g id="LWPOLYLINE-296" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="524.82" y1="706.64" x2="524.82" y2="706.64"/>
+  </g>
+  <g id="LWPOLYLINE-297" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="524.82" y1="706.64" x2="520.81" y2="704.97"/>
+  </g>
+  <g id="LWPOLYLINE-298" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1492.71 389.68 1494.05 393.35 1493.38 393.68 1490.71 385.34 1491.38 385.01 1492.38 389.02 1500.05 386.68 1498.72 382.67 1499.05 382.34 1501.72 391.01 1501.38 391.01 1500.05 387.01 1492.71 389.68"/>
+  </g>
+  <g id="LWPOLYLINE-299" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1467.35 387.34 1521.07 369.66 1526.74 387.34 1473.36 404.69 1467.35 387.34"/>
+  </g>
+  <g id="LWPOLYLINE-300" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1306.21" y1="445.06" x2="1468.69" y2="391.35"/>
+  </g>
+  <g id="LWPOLYLINE-301" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1310.54" y1="458.41" x2="1473.36" y2="404.7"/>
+  </g>
+  <g id="LWPOLYLINE-302" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1737.27 298.6 1683.56 316.28 1689.56 333.63 1742.94 316.28 1737.27 298.6"/>
+  </g>
+  <g id="LWPOLYLINE-303" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1717.25 315.61 1718.58 319.62 1719.26 319.62 1716.25 310.94 1715.92 311.27 1717.25 315.28 1709.58 317.61 1708.58 313.61 1707.91 313.94 1710.58 322.28 1711.25 321.95 1709.91 318.29 1717.25 315.61"/>
+  </g>
+  <g id="LWPOLYLINE-304" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1685.22" y1="320.28" x2="1522.41" y2="373.99"/>
+  </g>
+  <g id="LWPOLYLINE-305" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1689.56" y1="333.63" x2="1526.75" y2="387.34"/>
+  </g>
+  <g id="LWPOLYLINE-306" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1933.45 244.54 1934.78 248.55 1935.46 248.55 1932.45 239.87 1932.12 240.21 1933.45 244.22 1926.11 246.55 1924.78 242.54 1924.11 242.88 1927.11 251.22 1927.45 250.88 1926.11 246.88 1933.45 244.54"/>
+  </g>
+  <g id="LWPOLYLINE-307" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1953.47 227.53 1900.09 245.21 1905.77 262.56 1959.14 245.21 1953.47 227.53"/>
+  </g>
+  <g id="LWPOLYLINE-308" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1738.61" y1="302.6" x2="1901.42" y2="249.22"/>
+  </g>
+  <g id="LWPOLYLINE-309" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1742.94" y1="316.28" x2="1905.76" y2="262.57"/>
+  </g>
+  <g id="LWPOLYLINE-310" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="135.79 1278.83 131.79 1278.5 131.79 1278.83 140.46 1279.84 140.46 1279.5 136.46 1278.83 137.13 1271.16 141.46 1271.49 141.46 1271.16 132.79 1270.16 132.46 1270.49 136.79 1271.16 135.79 1278.83"/>
+  </g>
+  <g id="LWPOLYLINE-311" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="193.85" y1="825.75" x2="236.88" y2="811.74"/>
+  </g>
+  <g id="LWPOLYLINE-312" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="443.41 723.99 390.03 741.67 395.7 759.35 449.42 741.67 443.41 723.99"/>
+  </g>
+  <g id="LWPOLYLINE-313" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1462.02" y1="413.04" x2="1454.34" y2="415.71"/>
+  </g>
+  <g id="LWPOLYLINE-314" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1451.34" y1="416.71" x2="1445.01" y2="418.71"/>
+  </g>
+  <g id="LWPOLYLINE-315" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1441.67" y1="419.71" x2="1435.33" y2="422.05"/>
+  </g>
+  <g id="LWPOLYLINE-316" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1432.32" y1="423.04" x2="1425.98" y2="425.05"/>
+  </g>
+  <g id="LWPOLYLINE-317" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1422.98" y1="426.05" x2="1416.65" y2="428.05"/>
+  </g>
+  <g id="LWPOLYLINE-318" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1413.31" y1="429.05" x2="1406.97" y2="431.39"/>
+  </g>
+  <g id="LWPOLYLINE-319" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1403.96" y1="432.39" x2="1397.63" y2="434.39"/>
+  </g>
+  <g id="LWPOLYLINE-320" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1394.62" y1="435.39" x2="1388.28" y2="437.39"/>
+  </g>
+  <g id="LWPOLYLINE-321" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1384.95" y1="438.39" x2="1378.94" y2="440.39"/>
+  </g>
+  <g id="LWPOLYLINE-322" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1375.6" y1="441.73" x2="1369.27" y2="443.73"/>
+  </g>
+  <g id="LWPOLYLINE-323" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1366.26" y1="444.73" x2="1359.92" y2="446.73"/>
+  </g>
+  <g id="LWPOLYLINE-324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1356.59" y1="447.73" x2="1350.58" y2="449.73"/>
+  </g>
+  <g id="LWPOLYLINE-325" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1347.24" y1="450.74" x2="1340.91" y2="453.08"/>
+  </g>
+  <g id="LWPOLYLINE-326" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1337.9" y1="454.07" x2="1331.56" y2="456.07"/>
+  </g>
+  <g id="LWPOLYLINE-327" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1328.23" y1="457.08" x2="1322.22" y2="459.08"/>
+  </g>
+  <g id="LWPOLYLINE-328" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1318.89" y1="460.08" x2="1312.55" y2="462.42"/>
+  </g>
+  <g id="LWPOLYLINE-329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1309.54" y1="463.41" x2="1301.87" y2="465.75"/>
+  </g>
+  <g id="LWPOLYLINE-330" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1266.17" y1="477.43" x2="1260.16" y2="479.43"/>
+  </g>
+  <g id="LWPOLYLINE-331" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1257.16" y1="480.43" x2="1250.82" y2="482.77"/>
+  </g>
+  <g id="LWPOLYLINE-332" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1247.49" y1="483.77" x2="1241.48" y2="485.77"/>
+  </g>
+  <g id="LWPOLYLINE-333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1238.14" y1="486.77" x2="1231.8" y2="488.77"/>
+  </g>
+  <g id="LWPOLYLINE-334" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1228.8" y1="489.77" x2="1222.46" y2="491.77"/>
+  </g>
+  <g id="LWPOLYLINE-335" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1219.13" y1="493.11" x2="1213.12" y2="495.11"/>
+  </g>
+  <g id="LWPOLYLINE-336" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1209.78" y1="496.11" x2="1203.44" y2="498.11"/>
+  </g>
+  <g id="LWPOLYLINE-337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1200.44" y1="499.11" x2="1194.1" y2="501.12"/>
+  </g>
+  <g id="LWPOLYLINE-338" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1190.77" y1="502.12" x2="1184.76" y2="504.46"/>
+  </g>
+  <g id="LWPOLYLINE-339" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1181.43" y1="505.45" x2="1175.09" y2="507.46"/>
+  </g>
+  <g id="LWPOLYLINE-340" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1172.08" y1="508.46" x2="1165.74" y2="510.46"/>
+  </g>
+  <g id="LWPOLYLINE-341" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1162.74" y1="511.46" x2="1156.4" y2="513.8"/>
+  </g>
+  <g id="LWPOLYLINE-342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1153.07" y1="514.79" x2="1146.73" y2="516.8"/>
+  </g>
+  <g id="LWPOLYLINE-343" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1143.72" y1="517.8" x2="1137.38" y2="519.8"/>
+  </g>
+  <g id="LWPOLYLINE-344" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1134.38" y1="520.8" x2="1128.04" y2="523.14"/>
+  </g>
+  <g id="LWPOLYLINE-345" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1124.71" y1="524.14" x2="1118.37" y2="526.14"/>
+  </g>
+  <g id="LWPOLYLINE-346" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1115.36" y1="527.14" x2="1109.36" y2="529.14"/>
+  </g>
+  <g id="LWPOLYLINE-347" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1462.02 413.03 1464.02 418.37 1456.01 421.05"/>
+  </g>
+  <g id="LWPOLYLINE-348" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1453.01" y1="422.04" x2="1446.67" y2="424.05"/>
+  </g>
+  <g id="LWPOLYLINE-349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1443.33" y1="425.05" x2="1437.33" y2="427.05"/>
+  </g>
+  <g id="LWPOLYLINE-350" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1433.99" y1="428.05" x2="1427.66" y2="430.39"/>
+  </g>
+  <g id="LWPOLYLINE-351" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1424.65" y1="431.38" x2="1418.31" y2="433.39"/>
+  </g>
+  <g id="LWPOLYLINE-352" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1415.31" y1="434.39" x2="1408.97" y2="436.39"/>
+  </g>
+  <g id="LWPOLYLINE-353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1405.63" y1="437.39" x2="1399.29" y2="439.73"/>
+  </g>
+  <g id="LWPOLYLINE-354" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1396.29" y1="440.73" x2="1389.95" y2="442.73"/>
+  </g>
+  <g id="LWPOLYLINE-355" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1386.95" y1="443.73" x2="1380.61" y2="445.73"/>
+  </g>
+  <g id="LWPOLYLINE-356" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1377.27" y1="446.73" x2="1370.93" y2="448.74"/>
+  </g>
+  <g id="LWPOLYLINE-357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1367.93" y1="450.07" x2="1361.59" y2="452.07"/>
+  </g>
+  <g id="LWPOLYLINE-358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1358.59" y1="453.07" x2="1352.25" y2="455.07"/>
+  </g>
+  <g id="LWPOLYLINE-359" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1348.91" y1="456.07" x2="1342.57" y2="458.07"/>
+  </g>
+  <g id="LWPOLYLINE-360" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1339.57" y1="459.08" x2="1333.23" y2="461.42"/>
+  </g>
+  <g id="LWPOLYLINE-361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1330.23" y1="462.41" x2="1323.89" y2="464.42"/>
+  </g>
+  <g id="LWPOLYLINE-362" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1320.55" y1="465.42" x2="1314.21" y2="467.42"/>
+  </g>
+  <g id="LWPOLYLINE-363" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.21" y1="468.42" x2="1303.54" y2="471.09"/>
+  </g>
+  <g id="LWPOLYLINE-364" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1266.17 477.43 1267.84 482.77 1261.83 484.77"/>
+  </g>
+  <g id="LWPOLYLINE-365" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1258.83" y1="485.77" x2="1252.49" y2="487.77"/>
+  </g>
+  <g id="LWPOLYLINE-366" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1249.49" y1="488.77" x2="1243.15" y2="491.11"/>
+  </g>
+  <g id="LWPOLYLINE-367" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1239.81" y1="492.11" x2="1233.47" y2="494.11"/>
+  </g>
+  <g id="LWPOLYLINE-368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1230.47" y1="495.11" x2="1224.13" y2="497.12"/>
+  </g>
+  <g id="LWPOLYLINE-369" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1221.13" y1="498.11" x2="1214.79" y2="500.45"/>
+  </g>
+  <g id="LWPOLYLINE-370" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1211.45" y1="501.45" x2="1205.11" y2="503.45"/>
+  </g>
+  <g id="LWPOLYLINE-371" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1202.11" y1="504.45" x2="1195.77" y2="506.45"/>
+  </g>
+  <g id="LWPOLYLINE-372" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1192.77" y1="507.46" x2="1186.43" y2="509.46"/>
+  </g>
+  <g id="LWPOLYLINE-373" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1183.09" y1="510.79" x2="1176.75" y2="512.79"/>
+  </g>
+  <g id="LWPOLYLINE-374" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1173.75" y1="513.8" x2="1167.41" y2="515.8"/>
+  </g>
+  <g id="LWPOLYLINE-375" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1164.41" y1="516.8" x2="1158.07" y2="518.8"/>
+  </g>
+  <g id="LWPOLYLINE-376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1154.73" y1="519.8" x2="1148.73" y2="522.14"/>
+  </g>
+  <g id="LWPOLYLINE-377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1145.39" y1="523.14" x2="1139.05" y2="525.14"/>
+  </g>
+  <g id="LWPOLYLINE-378" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1136.05" y1="526.14" x2="1129.71" y2="528.14"/>
+  </g>
+  <g id="LWPOLYLINE-379" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1126.37" y1="529.14" x2="1120.37" y2="531.48"/>
+  </g>
+  <g id="LWPOLYLINE-380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1117.03" y1="532.48" x2="1111.36" y2="534.15"/>
+  </g>
+  <g id="LWPOLYLINE-381" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2186.69 637.91 2190.36 605.21 2196.03 605.88"/>
+  </g>
+  <g id="LWPOLYLINE-382" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2196.36" y1="554.5" x2="2201.04" y2="555.17"/>
+  </g>
+  <g id="LWPOLYLINE-383" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2204.37" y1="603.21" x2="2207.04" y2="581.52"/>
+  </g>
+  <g id="LWPOLYLINE-384" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2201.37 602.88 2189.03 601.54 2188.69 604.88 2200.7 606.21 2201.37 602.88"/>
+  </g>
+  <g id="LWPOLYLINE-385" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2206.37 559.17 2194.03 557.84 2194.36 554.5 2206.71 555.84 2206.37 559.17"/>
+  </g>
+  <g id="LWPOLYLINE-386" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2206.37 559.17 2211.04 559.5 2208.71 581.52 2207.03 581.52"/>
+  </g>
+  <g id="LWPOLYLINE-387" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2225.06 561.17 2284.44 567.84 2277.77 628.89 2218.05 622.23 2220.05 605.21 2207.37 603.54 2205.04 623.9 2280.44 632.57 2288.12 565.18 2212.71 556.5 2212.38 559.84 2225.06 561.17"/>
+  </g>
+  <g id="LWPOLYLINE-388" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2218.05 591.2 2208.71 590.2 2210.38 574.85 2220.05 575.86"/>
+  </g>
+  <g id="LWPOLYLINE-389" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2209.71" y1="582.19" x2="2215.38" y2="582.86"/>
+  </g>
+  <g id="LWPOLYLINE-390" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2224.39 576.52 2222.38 591.87 2231.39 592.87"/>
+  </g>
+  <g id="LWPOLYLINE-391" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2244.41 594.2 2235.06 593.2 2236.73 577.85 2246.41 578.86"/>
+  </g>
+  <g id="LWPOLYLINE-392" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2236.07" y1="585.19" x2="2241.74" y2="585.86"/>
+  </g>
+  <g id="LWPOLYLINE-393" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2250.75 579.52 2254.75 595.54 2262.42 580.86"/>
+  </g>
+  <g id="LWPOLYLINE-394" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2264.43 595.2 2263.76 595.87 2264.43 596.54 2265.09 595.87"/>
+  </g>
+  <g id="LWPOLYLINE-395" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2272.77 585.53 2273.1 584.86 2273.76 583.53 2274.77 582.86 2276.1 582.2 2279.11 582.53 2280.44 583.53 2281.11 584.53 2281.77 585.86 2281.77 587.53 2280.78 588.86 2279.11 590.87 2270.77 597.21 2281.11 598.54"/>
+  </g>
+  <g id="LWPOLYLINE-396" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2211.38" y1="498.11" x2="2267.1" y2="504.45"/>
+  </g>
+  <g id="LWPOLYLINE-397" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2212.38" y1="487.1" x2="2268.43" y2="493.78"/>
+  </g>
+  <g id="LWPOLYLINE-398" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2213.71" y1="476.43" x2="2269.77" y2="482.77"/>
+  </g>
+  <g id="LWPOLYLINE-399" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2233.06" y1="467.75" x2="2238.4" y2="468.42"/>
+  </g>
+  <g id="LWPOLYLINE-400" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2242.07" y1="469.09" x2="2270.77" y2="472.09"/>
+  </g>
+  <g id="LWPOLYLINE-401" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2192.69" y1="632.57" x2="2308.8" y2="645.92"/>
+  </g>
+  <g id="LWPOLYLINE-402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2202.03" y1="546.16" x2="2318.47" y2="559.17"/>
+  </g>
+  <g id="LWPOLYLINE-403" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2324.48 368.33 2227.06 357.32 2227.06 359.99"/>
+  </g>
+  <g id="LWPOLYLINE-404" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2212.71 340.3 2218.72 357.32 2218.72 358.98"/>
+  </g>
+  <g id="LWPOLYLINE-405" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2222.39 399.35 2214.05 398.35 2196.36 554.5"/>
+  </g>
+  <g id="LWPOLYLINE-406" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2084.59 402.69 2159.66 402.69 2156.99 426.72"/>
+  </g>
+  <g id="LWPOLYLINE-407" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2147.98 465.75 2152.66 466.08 2151.65 473.09"/>
+  </g>
+  <g id="LWPOLYLINE-408" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2084.6 406.69 2154.99 406.69 2153.99 413.37"/>
+  </g>
+  <g id="LWPOLYLINE-409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2152.99" y1="423.71" x2="2152.66" y2="426.39"/>
+  </g>
+  <g id="LWPOLYLINE-410" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.99" y1="465.75" x2="2147.65" y2="468.75"/>
+  </g>
+  <g id="LWPOLYLINE-411" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2222.39" y1="399.36" x2="2206.71" y2="538.48"/>
+  </g>
+  <g id="LWPOLYLINE-412" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2218.72" y1="399.02" x2="2201.04" y2="555.17"/>
+  </g>
+  <g id="LWPOLYLINE-413" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2331.49 122.77 2369.52 110.09 2340.16 369"/>
+  </g>
+  <g id="LWPOLYLINE-414" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2338.16" y1="386.01" x2="2307.8" y2="652.59"/>
+  </g>
+  <g id="LWPOLYLINE-415" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2333.83 424.04 2325.82 423.04 2311.14 550.49"/>
+  </g>
+  <g id="LWPOLYLINE-416" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2340.17 368.99 2324.81 366.99 2322.81 384.34"/>
+  </g>
+  <g id="LWPOLYLINE-417" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2307.79 652.59 2293.12 650.92 2291.11 668.6"/>
+  </g>
+  <g id="LWPOLYLINE-418" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2305.8" y1="670.27" x2="2273.1" y2="959.55"/>
+  </g>
+  <g id="LWPOLYLINE-419" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2254.09 972.22 2268.76 973.89 2235.4 1268.16"/>
+  </g>
+  <g id="LWPOLYLINE-420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2255.75" y1="957.54" x2="2254.08" y2="972.21"/>
+  </g>
+  <g id="LWPOLYLINE-421" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2380.53" y1="91.07" x2="2244.74" y2="1286.85"/>
+  </g>
+  <g id="LWPOLYLINE-422" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2189.03 602.21 2184.68 601.54 2180.68 637.24"/>
+  </g>
+  <g id="LWPOLYLINE-423" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2196.03" y1="605.88" x2="2192.7" y2="632.57"/>
+  </g>
+  <g id="LWPOLYLINE-424" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2251.75 391.02 2227.05 359.99 2225.39 360.99 2250.08 392.34"/>
+  </g>
+  <g id="LWPOLYLINE-425" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2252.75 390.35 2248.74 393.02 2244.74 395.35 2240.74 397.35 2236.07 398.68 2231.73 399.35 2227.06 399.69 2222.39 399.35"/>
+  </g>
+  <g id="LWPOLYLINE-426" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2135.97 298.6 2171.67 316.28 2170.67 318.28 2135.31 300.26"/>
+  </g>
+  <g id="LWPOLYLINE-427" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2136.64 297.26 2134.64 301.6 2133.31 305.93 2132.3 310.61 2131.64 315.27 2131.97 319.62 2132.64 324.29 2133.64 328.95"/>
+  </g>
+  <g id="LWPOLYLINE-428" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2206.71" y1="538.48" x2="2319.48" y2="551.5"/>
+  </g>
+  <g id="LWPOLYLINE-429" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2267.09" y1="506.45" x2="2277.1" y2="416.38"/>
+  </g>
+  <g id="LWPOLYLINE-430" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2233.06 486.1 2241.73 479.76 2247.74 488.44"/>
+  </g>
+  <g id="LWPOLYLINE-431" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="398.37 1200.1 388.69 1200.1 388.69 1184.75 398.37 1184.75"/>
+  </g>
+  <g id="LWPOLYLINE-432" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="388.69" y1="1192.09" x2="394.36" y2="1192.09"/>
+  </g>
+  <g id="LWPOLYLINE-433" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="402.71 1184.75 402.71 1200.1 411.38 1200.1"/>
+  </g>
+  <g id="LWPOLYLINE-434" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="424.73 1200.1 415.05 1200.1 415.05 1184.75 424.73 1184.75"/>
+  </g>
+  <g id="LWPOLYLINE-435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.05" y1="1192.09" x2="421.06" y2="1192.09"/>
+  </g>
+  <g id="LWPOLYLINE-436" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="429.06 1184.75 435.07 1200.1 441.07 1184.75"/>
+  </g>
+  <g id="LWPOLYLINE-437" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="444.75 1198.76 443.74 1199.43 444.75 1200.1 445.41 1199.43"/>
+  </g>
+  <g id="LWPOLYLINE-438" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="484.45 826.42 482.78 825.41 480.44 825.41 477.44 826.42 475.78 827.75 474.77 829.75 475.11 831.09 476.44 832.09 477.44 832.76 479.11 833.09 483.78 833.09 485.11 833.09 486.12 833.76 487.45 834.75 488.12 837.09 487.12 838.76 485.11 840.1 482.45 841.09 480.11 841.09 478.11 840.1"/>
+  </g>
+  <g id="LWPOLYLINE-439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="493.12" y1="821.41" x2="497.79" y2="836.09"/>
+  </g>
+  <g id="LWPOLYLINE-440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="488.12" y1="823.08" x2="497.79" y2="819.75"/>
+  </g>
+  <g id="LWPOLYLINE-441" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="505.47 833.42 506.47 817.07 516.81 829.75"/>
+  </g>
+  <g id="LWPOLYLINE-442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="506.13" y1="828.08" x2="513.14" y2="825.75"/>
+  </g>
+  <g id="LWPOLYLINE-443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="520.82" y1="828.42" x2="516.14" y2="813.74"/>
+  </g>
+  <g id="LWPOLYLINE-444" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="526.49 826.75 521.82 812.07 528.16 810.07 530.49 810.07 531.16 810.4 532.49 811.4 532.83 813.07 532.49 814.74 532.16 815.41 530.16 817.07 524.15 819.08"/>
+  </g>
+  <g id="LWPOLYLINE-445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="528.82" y1="817.41" x2="536.16" y2="823.41"/>
+  </g>
+  <g id="LWPOLYLINE-446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="539.17" y1="815.41" x2="551.84" y2="811.4"/>
+  </g>
+  <g id="LWPOLYLINE-447" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="555.51 804.06 556.85 802.73 558.19 800.06 562.85 814.74"/>
+  </g>
+  <g id="LWPOLYLINE-448" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1077 1254.14 1077 1259.48 1084 1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-449" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1087.34" y1="1259.48" x2="1093.68" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-450" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1097.01" y1="1259.48" x2="1103.69" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1107.02" y1="1259.48" x2="1113.7" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1117.03" y1="1259.48" x2="1123.7" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-453" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1127.04" y1="1259.48" x2="1133.71" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1137.05" y1="1259.48" x2="1143.39" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1146.73" y1="1259.48" x2="1153.4" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1156.73" y1="1259.48" x2="1163.41" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1166.74" y1="1259.48" x2="1173.42" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-458" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1176.75" y1="1259.48" x2="1183.43" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-459" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1186.76" y1="1259.48" x2="1193.44" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-460" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1196.44" y1="1259.48" x2="1203.11" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1206.45" y1="1259.48" x2="1213.12" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-462" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1216.46" y1="1259.48" x2="1223.13" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-463" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1226.47" y1="1259.48" x2="1233.14" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-464" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1236.48" y1="1259.48" x2="1243.15" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-465" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1246.15" y1="1259.48" x2="1252.82" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-466" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1256.16" y1="1259.48" x2="1262.83" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-467" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1266.17" y1="1259.48" x2="1273.18" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-468" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1077" y1="1254.15" x2="1084" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-469" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1087.34" y1="1254.15" x2="1093.68" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-470" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1097.01" y1="1254.15" x2="1103.69" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1107.02" y1="1254.15" x2="1113.7" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-472" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1117.03" y1="1254.15" x2="1123.7" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1127.04" y1="1254.15" x2="1133.71" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-474" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1137.05" y1="1254.15" x2="1143.39" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-475" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1146.73" y1="1254.15" x2="1153.4" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-476" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1156.73" y1="1254.15" x2="1163.41" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-477" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1166.74" y1="1254.15" x2="1173.42" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-478" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1176.75" y1="1254.15" x2="1183.43" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-479" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1186.76" y1="1254.15" x2="1193.44" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1196.44" y1="1254.15" x2="1203.11" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1206.45" y1="1254.15" x2="1213.12" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-482" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1216.46" y1="1254.15" x2="1223.13" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-483" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1226.47" y1="1254.15" x2="1233.14" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-484" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1236.48" y1="1254.15" x2="1243.15" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-485" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1246.15" y1="1254.15" x2="1252.82" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-486" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1256.16" y1="1254.15" x2="1262.83" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-487" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1266.17" y1="1254.15" x2="1273.18" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-488" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1273.18" y1="1259.48" x2="1273.18" y2="1254.14"/>
+  </g>
+  <g id="CIRCLE-17" data-name="CIRCLE">
+    <circle class="cls-3" cx="639.09" cy="966.72" r="9.85"/>
+  </g>
+  <g id="LWPOLYLINE-489" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2273.1" y1="959.54" x2="2255.75" y2="957.54"/>
+  </g>
+  <g id="LWPOLYLINE-490" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2291.12" y1="668.6" x2="2305.79" y2="670.27"/>
+  </g>
+  <g id="LWPOLYLINE-491" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="452.42 1079.98 424.39 1108.01 425.73 1109.68 453.75 1081.32"/>
+  </g>
+  <g id="LWPOLYLINE-492" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="451.75 1079.32 454.75 1082.65 457.42 1086.32 459.76 1090.33 461.76 1094.66 463.1 1099 463.76 1103.67 464.1 1108.01"/>
+  </g>
+  <g id="LWPOLYLINE-493" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="399.37" y1="887.14" x2="401.04" y2="892.14"/>
+  </g>
+  <g id="LWPOLYLINE-494" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="703.31 787.05 437.07 874.8 438.74 879.8"/>
+  </g>
+  <g id="LWPOLYLINE-495" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="385.02 890.15 375.68 893.14 378.35 901.49"/>
+  </g>
+  <g id="LWPOLYLINE-496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="337.98" y1="906.16" x2="340.65" y2="914.17"/>
+  </g>
+  <g id="LWPOLYLINE-497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="236.89" y1="811.74" x2="608.22" y2="689.29"/>
+  </g>
+  <g id="LWPOLYLINE-498" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="484.45 791.72 491.79 789.38 631.92 743.01"/>
+  </g>
+  <g id="LWPOLYLINE-499" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="378.35" y1="901.49" x2="401.04" y2="892.14"/>
+  </g>
+  <g id="LWPOLYLINE-500" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="390.7" y1="890.14" x2="399.37" y2="887.14"/>
+  </g>
+  <g id="LWPOLYLINE-501" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="438.74" y1="879.8" x2="704.98" y2="792.05"/>
+  </g>
+  <g id="LWPOLYLINE-502" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="192.18" y1="841.43" x2="206.85" y2="843.1"/>
+  </g>
+  <g id="LWPOLYLINE-503" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="417.39 851.77 399.37 887.14 401.04 888.14 419.05 852.77"/>
+  </g>
+  <g id="LWPOLYLINE-504" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="416.05 851.11 420.39 853.45 424.06 856.11 427.39 859.12 430.73 862.45 433.07 866.45 435.41 870.46 437.07 874.8"/>
+  </g>
+  <g id="LWPOLYLINE-505" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="388.69 1207.43 388.69 1222.78 397.36 1222.78"/>
+  </g>
+  <g id="LWPOLYLINE-506" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="405.71 1207.43 404.04 1208.1 402.71 1209.78 402.04 1211.11 401.04 1213.44 401.04 1217.11 402.04 1219.11 402.71 1220.78 404.04 1222.11 405.71 1222.78 408.38 1222.78 410.05 1222.11 411.38 1220.78 412.05 1219.11 413.05 1217.11 413.05 1213.44 412.05 1211.11 411.38 1209.78 410.05 1208.1 408.38 1207.43 405.71 1207.43"/>
+  </g>
+  <g id="LWPOLYLINE-507" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="424.06 1214.78 426.06 1215.44 427.06 1216.44 427.73 1217.77 427.73 1220.11 427.06 1221.45 426.06 1222.12 424.06 1222.79 417.39 1222.79 417.39 1207.43 424.06 1207.43 426.06 1208.1 427.06 1208.77 427.73 1210.44 427.73 1211.78 427.06 1213.44 426.06 1214.11 424.06 1214.78 417.39 1214.78"/>
+  </g>
+  <g id="LWPOLYLINE-508" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="439.41 1214.78 441.75 1215.44 442.4 1216.44 443.08 1217.77 443.08 1220.11 442.4 1221.45 441.75 1222.12 439.41 1222.79 432.73 1222.79 432.73 1207.43 439.41 1207.43 441.75 1208.1 442.4 1208.77 443.08 1210.44 443.08 1211.78 442.4 1213.44 441.75 1214.11 439.41 1214.78 432.73 1214.78"/>
+  </g>
+  <g id="LWPOLYLINE-509" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="448.41 1207.43 454.09 1214.78 460.09 1207.43"/>
+  </g>
+  <g id="LWPOLYLINE-510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="454.09" y1="1214.78" x2="454.09" y2="1222.79"/>
+  </g>
+  <g id="LWPOLYLINE-511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="418.39" y1="1282.5" x2="603.22" y2="1282.5"/>
+  </g>
+  <g id="LWPOLYLINE-512" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="418.39" y="1273.16" width="1.33" height="1.67"/>
+  </g>
+  <g id="LWPOLYLINE-513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="421.72" y1="1274.5" x2="508.8" y2="1274.5"/>
+  </g>
+  <g id="LWPOLYLINE-514" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="421.72" y1="1273.5" x2="508.8" y2="1273.5"/>
+  </g>
+  <g id="LWPOLYLINE-515" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="419.72" y="1273.16" width="2" height="1.67"/>
+  </g>
+  <g id="LWPOLYLINE-516" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="508.8" y="1268.16" width="4" height="6.67"/>
+  </g>
+  <g id="LWPOLYLINE-517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="418.39" y1="1268.16" x2="603.22" y2="1268.16"/>
+  </g>
+  <g id="LWPOLYLINE-518" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="513.14" y1="1046.29" x2="514.48" y2="1046.29"/>
+  </g>
+  <g id="LWPOLYLINE-519" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="863.13 1041.95 863.13 1046.29 867.13 1046.29"/>
+  </g>
+  <g id="LWPOLYLINE-520" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="508.47" y1="1041.95" x2="514.48" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="420.05" y1="1108.01" x2="424.39" y2="1108.01"/>
+  </g>
+  <g id="LWPOLYLINE-522" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="503.8" y1="1108.01" x2="508.47" y2="1108.01"/>
+  </g>
+  <g id="LWPOLYLINE-523" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="420.05" y1="1112.68" x2="424.39" y2="1112.68"/>
+  </g>
+  <g id="LWPOLYLINE-524" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="503.8 1108.01 503.8 1112.68 508.47 1112.68"/>
+  </g>
+  <g id="LWPOLYLINE-525" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="863.13" y1="1041.95" x2="871.48" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-526" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="601.89" y="1273.16" width="1.33" height="1.67"/>
+  </g>
+  <g id="LWPOLYLINE-527" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="599.89" y1="1274.5" x2="512.81" y2="1274.5"/>
+  </g>
+  <g id="LWPOLYLINE-528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="599.89" y1="1273.5" x2="512.81" y2="1273.5"/>
+  </g>
+  <g id="LWPOLYLINE-529" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="599.89" y="1273.16" width="2" height="1.67"/>
+  </g>
+  <g id="LWPOLYLINE-530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1706.24" y1="500.12" x2="1706.24" y2="328.29"/>
+  </g>
+  <g id="LWPOLYLINE-531" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1710.58" y1="504.79" x2="1710.58" y2="326.62"/>
+  </g>
+  <g id="LWPOLYLINE-532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1916.1" y1="448.4" x2="1916.1" y2="259.23"/>
+  </g>
+  <g id="LWPOLYLINE-533" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1920.77" y1="448.4" x2="1920.77" y2="257.89"/>
+  </g>
+  <g id="LWPOLYLINE-534" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1655.53 472.09 1683.56 500.12 1682.22 501.79 1654.2 473.42"/>
+  </g>
+  <g id="LWPOLYLINE-535" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1656.2 471.42 1653.2 474.76 1650.53 478.43 1648.19 482.43 1646.18 486.77 1644.85 491.1 1644.19 495.78 1643.85 500.12"/>
+  </g>
+  <g id="LWPOLYLINE-536" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2114.29" y1="179.15" x2="1954.81" y2="231.54"/>
+  </g>
+  <g id="LWPOLYLINE-537" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2118.96" y1="192.5" x2="1959.14" y2="245.21"/>
+  </g>
+  <g id="LWPOLYLINE-538" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2332.83 320.61 2203.04 305.93 2171.68 316.28"/>
+  </g>
+  <g id="LWPOLYLINE-539" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2194.69" y1="173.48" x2="2124.97" y2="196.5"/>
+  </g>
+  <g id="LWPOLYLINE-540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2133.64" y1="328.96" x2="2086.93" y2="344.31"/>
+  </g>
+  <g id="LWPOLYLINE-541" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2080.26 477.43 2080.26 356.31 2035.21 220.19"/>
+  </g>
+  <g id="LWPOLYLINE-542" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2104.94" y1="402.69" x2="2086.93" y2="348.65"/>
+  </g>
+  <g id="LWPOLYLINE-543" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2100.27" y1="402.69" x2="2084.59" y2="355.65"/>
+  </g>
+  <g id="LWPOLYLINE-544" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2086.93" y1="344.31" x2="2045.22" y2="216.85"/>
+  </g>
+  <g id="LWPOLYLINE-545" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2208.04 313.95 2204.04 315.28 2202.37 310.94"/>
+  </g>
+  <g id="LWPOLYLINE-546" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2340.83 363.66 2220.72 349.98 2216.72 338.97"/>
+  </g>
+  <g id="LWPOLYLINE-547" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2208.04" y1="313.94" x2="2207.04" y2="310.95"/>
+  </g>
+  <g id="LWPOLYLINE-548" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2129.97" y1="225.53" x2="2118.96" y2="192.5"/>
+  </g>
+  <g id="LWPOLYLINE-549" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2129.96 225.52 2134.31 224.19 2123.3 191.16"/>
+  </g>
+  <g id="LWPOLYLINE-550" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2208.04 199.51 2203.7 200.84 2193.02 168.14"/>
+  </g>
+  <g id="LWPOLYLINE-551" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2204.37" y1="188.49" x2="2197.36" y2="166.8"/>
+  </g>
+  <g id="LWPOLYLINE-552" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2202.37" y1="310.94" x2="2173.01" y2="320.62"/>
+  </g>
+  <g id="LWPOLYLINE-553" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2133.64 328.96 2134.97 332.96 2086.93 348.64"/>
+  </g>
+  <g id="LWPOLYLINE-554" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2120.96 602.21 2089.93 626.9 2090.93 628.57 2121.96 603.88"/>
+  </g>
+  <g id="LWPOLYLINE-555" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2120.29 601.21 2122.97 604.88 2125.3 608.88 2126.96 613.22 2128.31 617.56 2129.3 622.23 2129.64 626.89 2129.3 631.57"/>
+  </g>
+  <g id="LWPOLYLINE-556" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1942.46" y1="1282.5" x2="1756.96" y2="1282.5"/>
+  </g>
+  <g id="LWPOLYLINE-557" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1941.46" y="1272.49" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-558" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1939.46" y1="1274.16" x2="1851.71" y2="1274.16"/>
+  </g>
+  <g id="LWPOLYLINE-559" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1939.46" y1="1272.83" x2="1851.71" y2="1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-560" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1939.46" y="1272.49" width="2" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-561" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1756.96" y="1272.49" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-562" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1757.96" y="1272.49" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1760.29" y1="1274.16" x2="1847.7" y2="1274.16"/>
+  </g>
+  <g id="LWPOLYLINE-564" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1760.29" y1="1272.83" x2="1847.7" y2="1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-565" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="820.09" y1="604.54" x2="657.28" y2="658.26"/>
+  </g>
+  <g id="LWPOLYLINE-566" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="822.43 611.55 822.76 613.22 821.76 613.55 821.43 611.88 822.43 611.55"/>
+  </g>
+  <g id="LWPOLYLINE-567" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="819.42" y1="612.89" x2="743.02" y2="637.9"/>
+  </g>
+  <g id="LWPOLYLINE-568" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="819.76" y1="613.89" x2="743.36" y2="639.24"/>
+  </g>
+  <g id="LWPOLYLINE-569" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="821.43 611.88 821.76 613.55 819.76 614.22 819.09 612.55 821.43 611.88"/>
+  </g>
+  <g id="LWPOLYLINE-570" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="659.92" y="664.71" width="1.06" height="2.11" transform="translate(-176.34 242.41) rotate(-18.39)"/>
+  </g>
+  <g id="LWPOLYLINE-571" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="660.61 664.6 661.28 666.61 663.28 665.93 662.61 663.94 660.61 664.6"/>
+  </g>
+  <g id="LWPOLYLINE-572" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="742.69 637.58 745.03 644.25 741.35 645.59 739.02 638.91 742.69 637.58"/>
+  </g>
+  <g id="LWPOLYLINE-573" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="662.95" y1="664.27" x2="739.35" y2="639.25"/>
+  </g>
+  <g id="LWPOLYLINE-574" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="663.28" y1="665.27" x2="739.68" y2="640.24"/>
+  </g>
+  <g id="LWPOLYLINE-575" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="746.02" y="1263.49" width="4" height="6.67"/>
+  </g>
+  <g id="LWPOLYLINE-576" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="962.22" y="1263.49" width="3.67" height="6.67"/>
+  </g>
+  <g id="LWPOLYLINE-577" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1096.01" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-578" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1099.35" y1="1269.49" x2="1178.09" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-579" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1099.35" y1="1268.49" x2="1178.09" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-580" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1097.01" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-581" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1263.17" y="1268.16" width="1.33" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-582" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1261.17" y="1268.16" width="2" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-583" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1261.16" y1="1269.49" x2="1182.09" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-584" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1261.16" y1="1268.49" x2="1182.09" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-585" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1096.01" y1="1263.49" x2="1264.5" y2="1263.49"/>
+  </g>
+  <g id="LWPOLYLINE-586" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1095.35" y1="1249.14" x2="1121.37" y2="1249.14"/>
+  </g>
+  <g id="LWPOLYLINE-587" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1091.01" y1="1244.47" x2="1117.03" y2="1244.47"/>
+  </g>
+  <g id="LWPOLYLINE-588" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1178.09" y="1263.49" width="4" height="6.67"/>
+  </g>
+  <g id="LWPOLYLINE-589" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1479.37" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-590" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1477.03" y1="1269.49" x2="1397.96" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-591" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1477.03" y1="1268.49" x2="1397.96" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-592" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1477.03" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-593" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1311.88" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-594" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1312.88" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-595" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1315.21" y1="1269.49" x2="1394.29" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-596" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1315.21" y1="1268.49" x2="1394.29" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1480.37" y1="1263.49" x2="1311.88" y2="1263.49"/>
+  </g>
+  <g id="LWPOLYLINE-598" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1394.29" y="1263.49" width="3.67" height="6.67"/>
+  </g>
+  <g id="LWPOLYLINE-599" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1528.08" y="1268.16" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-600" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1531.41" y1="1269.49" x2="1610.16" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-601" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1531.41" y1="1268.49" x2="1610.16" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-602" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1529.08" y="1268.16" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-603" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1695.24" y="1268.16" width="1.33" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-604" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1693.23" y="1268.16" width="2" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-605" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1693.23" y1="1269.49" x2="1614.16" y2="1269.49"/>
+  </g>
+  <g id="LWPOLYLINE-606" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1693.23" y1="1268.49" x2="1614.16" y2="1268.49"/>
+  </g>
+  <g id="LWPOLYLINE-607" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1528.08" y1="1263.49" x2="1696.57" y2="1263.49"/>
+  </g>
+  <g id="LWPOLYLINE-608" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1666.21 1092.33 1666.21 1235.46 1697.56 1235.46"/>
+  </g>
+  <g id="LWPOLYLINE-609" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1670.54 1092.33 1670.54 1230.79 1701.9 1230.79"/>
+  </g>
+  <g id="LWPOLYLINE-610" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1610.15" y="1263.49" width="4" height="6.67"/>
+  </g>
+  <g id="LWPOLYLINE-611" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1942.46" y1="1268.16" x2="1756.96" y2="1268.16"/>
+  </g>
+  <g id="LWPOLYLINE-612" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1469.69 1254.14 1469.69 1259.48 1464.35 1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-613" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1461.02" y1="1259.48" x2="1454.34" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-614" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1451.01" y1="1259.48" x2="1444.34" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-615" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1441" y1="1259.48" x2="1434.32" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-616" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1430.99" y1="1259.48" x2="1424.65" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-617" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1421.31" y1="1259.48" x2="1414.64" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-618" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1411.3" y1="1259.48" x2="1404.63" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1401.29" y1="1259.48" x2="1394.62" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-620" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1391.29" y1="1259.48" x2="1384.61" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-621" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1381.28" y1="1259.48" x2="1374.94" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-622" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.6" y1="1259.48" x2="1364.93" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-623" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1361.59" y1="1259.48" x2="1354.92" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-624" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1351.58" y1="1259.48" x2="1344.91" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-625" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1341.57" y1="1259.48" x2="1334.9" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-626" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1331.56" y1="1259.48" x2="1324.89" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-627" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1321.89" y1="1259.48" x2="1315.22" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-628" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.88" y1="1259.48" x2="1306.54" y2="1259.48"/>
+  </g>
+  <g id="LWPOLYLINE-629" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1469.69" y1="1254.15" x2="1464.35" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-630" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1461.02" y1="1254.15" x2="1454.34" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-631" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1451.01" y1="1254.15" x2="1444.34" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-632" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1441" y1="1254.15" x2="1434.32" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-633" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1430.99" y1="1254.15" x2="1424.65" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-634" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1421.31" y1="1254.15" x2="1414.64" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1411.3" y1="1254.15" x2="1404.63" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-636" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1401.29" y1="1254.15" x2="1394.62" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-637" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1391.29" y1="1254.15" x2="1384.61" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-638" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1381.28" y1="1254.15" x2="1374.94" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-639" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.6" y1="1254.15" x2="1364.93" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-640" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1361.59" y1="1254.15" x2="1354.92" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-641" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1351.58" y1="1254.15" x2="1344.91" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-642" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1341.57" y1="1254.15" x2="1334.9" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-643" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1331.56" y1="1254.15" x2="1324.89" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-644" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1321.89" y1="1254.15" x2="1315.22" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-645" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.88" y1="1254.15" x2="1306.54" y2="1254.15"/>
+  </g>
+  <g id="LWPOLYLINE-646" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1306.54" y1="1259.48" x2="1306.54" y2="1254.14"/>
+  </g>
+  <g id="LWPOLYLINE-647" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1847.71" y="1268.16" width="4" height="6.34"/>
+  </g>
+  <g id="LWPOLYLINE-648" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1998.85" y="1272.49" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-649" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2001.85" y1="1274.16" x2="2089.6" y2="1274.16"/>
+  </g>
+  <g id="LWPOLYLINE-650" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2001.85" y1="1272.83" x2="2089.6" y2="1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-651" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1999.85" y="1272.49" width="2" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-652" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2183.35" y="1272.49" width="1" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-653" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2181.01" y="1272.49" width="2.34" height="2"/>
+  </g>
+  <g id="LWPOLYLINE-654" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2181.02" y1="1274.16" x2="2093.6" y2="1274.16"/>
+  </g>
+  <g id="LWPOLYLINE-655" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2181.02" y1="1272.83" x2="2093.6" y2="1272.83"/>
+  </g>
+  <g id="LWPOLYLINE-656" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1998.85" y1="1268.16" x2="2042.89" y2="1268.16"/>
+  </g>
+  <g id="LWPOLYLINE-657" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2047.23" y1="1268.16" x2="2184.35" y2="1268.16"/>
+  </g>
+  <g id="LWPOLYLINE-658" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2089.6" y="1268.16" width="4" height="6.34"/>
+  </g>
+  <g id="LWPOLYLINE-659" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M262.04,1093.99c9.57-4.58,20.56-5.18,30.57-1.65l-13.01,37.7v8.01"/>
+  </g>
+  <g id="LWPOLYLINE-660" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="279.59 1130.03 278.59 1130.03 278.59 1138.04"/>
+  </g>
+  <g id="LWPOLYLINE-661" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="209.19 820.74 212.2 832.09 206.85 843.1"/>
+  </g>
+  <g id="LWPOLYLINE-662" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="630.92 720.65 626.58 707.97 630.92 706.64 632.92 706.64 634.59 707.64 635.59 708.64 636.59 710.31 637.59 713.31 637.59 715.31 637.59 716.65 636.59 717.98 634.92 719.32 630.92 720.65"/>
+  </g>
+  <g id="LWPOLYLINE-663" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="643.59 716.65 639.26 703.97 651.93 713.98 647.6 701.3"/>
+  </g>
+  <g id="LWPOLYLINE-664" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="434.4" y1="816.41" x2="413.71" y2="753.35"/>
+  </g>
+  <g id="LWPOLYLINE-665" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="445.41" y1="812.74" x2="424.73" y2="749.68"/>
+  </g>
+  <g id="LWPOLYLINE-666" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="456.42" y1="809.07" x2="435.74" y2="746.01"/>
+  </g>
+  <g id="LWPOLYLINE-667" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="467.43" y1="805.4" x2="446.75" y2="742.34"/>
+  </g>
+  <g id="LWPOLYLINE-668" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="478.44" y1="801.73" x2="458.76" y2="742.68"/>
+  </g>
+  <g id="LWPOLYLINE-669" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="489.45" y1="798.06" x2="481.78" y2="775.37"/>
+  </g>
+  <g id="LWPOLYLINE-670" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="480.44" y1="771.03" x2="479.44" y2="768.03"/>
+  </g>
+  <g id="LWPOLYLINE-671" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="415.05 788.38 414.38 787.05 413.05 786.38 411.38 787.05 410.71 788.38 411.38 790.05 413.05 790.72 414.38 790.05 415.05 788.38"/>
+  </g>
+  <g id="LWPOLYLINE-672" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="384.69 791.05 387.36 800.05 388.69 801.73 390.36 802.4 392.36 802.4 393.36 802.06 395.03 801.06 396.03 799.39 396.03 797.39 393.04 788.38"/>
+  </g>
+  <g id="LWPOLYLINE-673" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="401.71 799.39 397.7 786.71 403.04 785.05 405.04 785.05 406.04 785.38 407.04 786.38 407.38 788.38 407.38 789.72 407.04 790.39 405.38 791.72 400.04 793.39"/>
+  </g>
+  <g id="LWPOLYLINE-674" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="413.05 788.38 468.1 770.36 463.43 780.04"/>
+  </g>
+  <g id="LWPOLYLINE-675" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="468.1" y1="770.36" x2="458.42" y2="765.69"/>
+  </g>
+  <g id="LWPOLYLINE-676" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="496.46 796.06 479.78 772.37 482.12 767.69 471.43 768.7 473.77 763.69 456.42 739.34"/>
+  </g>
+  <g id="LWPOLYLINE-677" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1003.93" y="763.69" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-678" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="940.2 766.03 1003.93 766.03 940.2 766.03"/>
+  </g>
+  <g id="LWPOLYLINE-679" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="938.53" y="763.69" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-680" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="873.14" y="763.69" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-681" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="938.53 766.03 874.81 766.03 938.53 766.03"/>
+  </g>
+  <g id="LWPOLYLINE-682" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1431.32" y="581.86" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-683" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1362.59 584.19 1431.32 584.19 1362.59 584.19"/>
+  </g>
+  <g id="LWPOLYLINE-684" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1360.92" y="581.86" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-685" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1290.53" y="581.86" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-686" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1360.92 584.19 1292.19 584.19 1360.92 584.19"/>
+  </g>
+  <g id="LWPOLYLINE-687" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1571.45" y="500.11" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-688" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1500.72" y="500.11" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-689" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1571.45 502.45 1502.39 502.45 1571.45 502.45"/>
+  </g>
+  <g id="LWPOLYLINE-690" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="164.82" y1="1079.98" x2="142.8" y2="1077.65"/>
+  </g>
+  <g id="LWPOLYLINE-691" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="154.14" y1="1126.69" x2="159.48" y2="1079.32"/>
+  </g>
+  <g id="LWPOLYLINE-692" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.47" y1="1081.99" x2="150.14" y2="1080.65"/>
+  </g>
+  <g id="LWPOLYLINE-693" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.14" y1="1085.66" x2="150.14" y2="1083.99"/>
+  </g>
+  <g id="LWPOLYLINE-694" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.47" y1="1089.66" x2="149.81" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-695" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.14" y1="1093.66" x2="149.48" y2="1091.66"/>
+  </g>
+  <g id="LWPOLYLINE-696" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.8" y1="1097.33" x2="148.8" y2="1095.67"/>
+  </g>
+  <g id="LWPOLYLINE-697" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.47" y1="1101.34" x2="148.47" y2="1099.67"/>
+  </g>
+  <g id="LWPOLYLINE-698" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.8" y1="1105.34" x2="148.14" y2="1103.34"/>
+  </g>
+  <g id="LWPOLYLINE-699" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.47" y1="1109.01" x2="147.47" y2="1107.34"/>
+  </g>
+  <g id="LWPOLYLINE-700" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="145.13" y1="1113.01" x2="147.14" y2="1111.35"/>
+  </g>
+  <g id="LWPOLYLINE-701" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="144.47" y1="1116.68" x2="146.81" y2="1115.02"/>
+  </g>
+  <g id="LWPOLYLINE-702" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="145.13 1123.36 145.8 1123.02 144.13 1120.68 146.13 1119.02 144.47 1116.68"/>
+  </g>
+  <g id="LWPOLYLINE-703" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="146.8" y1="1115.02" x2="145.13" y2="1113.02"/>
+  </g>
+  <g id="LWPOLYLINE-704" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.14" y1="1111.35" x2="145.47" y2="1109.01"/>
+  </g>
+  <g id="LWPOLYLINE-705" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.47" y1="1107.34" x2="145.8" y2="1105.34"/>
+  </g>
+  <g id="LWPOLYLINE-706" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.14" y1="1103.34" x2="146.47" y2="1101.34"/>
+  </g>
+  <g id="LWPOLYLINE-707" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.47" y1="1099.67" x2="146.8" y2="1097.33"/>
+  </g>
+  <g id="LWPOLYLINE-708" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="148.8" y1="1095.67" x2="147.14" y2="1093.66"/>
+  </g>
+  <g id="LWPOLYLINE-709" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="149.47" y1="1091.66" x2="147.47" y2="1089.66"/>
+  </g>
+  <g id="LWPOLYLINE-710" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="149.81" y1="1087.99" x2="148.14" y2="1085.66"/>
+  </g>
+  <g id="LWPOLYLINE-711" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="150.14" y1="1083.99" x2="148.47" y2="1081.99"/>
+  </g>
+  <g id="LWPOLYLINE-712" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="147.47" y1="1077.98" x2="141.8" y2="1125.36"/>
+  </g>
+  <g id="LWPOLYLINE-713" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="152.81 1078.65 152.47 1080.99 147.14 1080.32 147.47 1077.98 152.81 1078.65"/>
+  </g>
+  <g id="LWPOLYLINE-714" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="147.8 1123.69 147.47 1126.03 141.8 1125.36 142.13 1123.02 147.8 1123.69"/>
+  </g>
+  <g id="LWPOLYLINE-715" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="152.47" y1="1080.98" x2="147.47" y2="1126.03"/>
+  </g>
+  <g id="LWPOLYLINE-716" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="141.8" y1="1125.36" x2="159.48" y2="1127.36"/>
+  </g>
+  <g id="LWPOLYLINE-717" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="171.16" y1="1023.93" x2="149.47" y2="1021.26"/>
+  </g>
+  <g id="LWPOLYLINE-718" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.82" y1="1023.27" x2="183.17" y2="870.12"/>
+  </g>
+  <g id="LWPOLYLINE-719" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="188.84 870.79 171.16 868.79 166.82 868.13"/>
+  </g>
+  <g id="LWPOLYLINE-720" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="172.49" y1="872.46" x2="174.16" y2="871.12"/>
+  </g>
+  <g id="LWPOLYLINE-721" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="172.16" y1="876.46" x2="174.5" y2="874.79"/>
+  </g>
+  <g id="LWPOLYLINE-722" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="171.83" y1="880.13" x2="173.83" y2="878.46"/>
+  </g>
+  <g id="LWPOLYLINE-723" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="171.16" y1="884.14" x2="173.5" y2="882.47"/>
+  </g>
+  <g id="LWPOLYLINE-724" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="170.82" y1="888.14" x2="173.17" y2="886.47"/>
+  </g>
+  <g id="LWPOLYLINE-725" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="170.49" y1="891.81" x2="172.49" y2="890.14"/>
+  </g>
+  <g id="LWPOLYLINE-726" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="169.82" y1="895.81" x2="172.16" y2="894.14"/>
+  </g>
+  <g id="LWPOLYLINE-727" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="169.49" y1="899.82" x2="171.83" y2="897.82"/>
+  </g>
+  <g id="LWPOLYLINE-728" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="169.16" y1="903.49" x2="171.16" y2="901.82"/>
+  </g>
+  <g id="LWPOLYLINE-729" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="168.49" y1="907.49" x2="170.83" y2="905.82"/>
+  </g>
+  <g id="LWPOLYLINE-730" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="168.16" y1="911.16" x2="170.5" y2="909.49"/>
+  </g>
+  <g id="LWPOLYLINE-731" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="167.82" y1="915.17" x2="169.82" y2="913.5"/>
+  </g>
+  <g id="LWPOLYLINE-732" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="167.15" y1="919.17" x2="169.49" y2="917.5"/>
+  </g>
+  <g id="LWPOLYLINE-733" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="166.82" y1="922.84" x2="169.16" y2="921.17"/>
+  </g>
+  <g id="LWPOLYLINE-734" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="166.49" y1="926.84" x2="168.49" y2="925.17"/>
+  </g>
+  <g id="LWPOLYLINE-735" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.82" y1="930.85" x2="168.16" y2="928.84"/>
+  </g>
+  <g id="LWPOLYLINE-736" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.49" y1="934.52" x2="167.83" y2="932.85"/>
+  </g>
+  <g id="LWPOLYLINE-737" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.15" y1="938.52" x2="167.16" y2="936.85"/>
+  </g>
+  <g id="LWPOLYLINE-738" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="164.82" y1="942.52" x2="166.82" y2="940.52"/>
+  </g>
+  <g id="LWPOLYLINE-739" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="166.49" y1="944.53" x2="166.49" y2="944.53"/>
+  </g>
+  <g id="LWPOLYLINE-740" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="163.82" y1="950.2" x2="165.82" y2="948.53"/>
+  </g>
+  <g id="LWPOLYLINE-741" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="163.49" y1="953.87" x2="165.49" y2="952.2"/>
+  </g>
+  <g id="LWPOLYLINE-742" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="162.82" y1="957.87" x2="165.16" y2="956.2"/>
+  </g>
+  <g id="LWPOLYLINE-743" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="162.48" y1="961.87" x2="164.49" y2="960.21"/>
+  </g>
+  <g id="LWPOLYLINE-744" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="162.15" y1="965.54" x2="164.15" y2="963.88"/>
+  </g>
+  <g id="LWPOLYLINE-745" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="161.48" y1="969.55" x2="163.82" y2="967.88"/>
+  </g>
+  <g id="LWPOLYLINE-746" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="161.15" y1="973.55" x2="163.15" y2="971.55"/>
+  </g>
+  <g id="LWPOLYLINE-747" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="160.82" y1="977.22" x2="162.82" y2="975.55"/>
+  </g>
+  <g id="LWPOLYLINE-748" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="160.15" y1="981.23" x2="162.49" y2="979.56"/>
+  </g>
+  <g id="LWPOLYLINE-749" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="159.81" y1="984.9" x2="161.82" y2="983.23"/>
+  </g>
+  <g id="LWPOLYLINE-750" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="159.48" y1="988.9" x2="161.48" y2="987.23"/>
+  </g>
+  <g id="LWPOLYLINE-751" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="158.81" y1="992.9" x2="161.15" y2="991.24"/>
+  </g>
+  <g id="LWPOLYLINE-752" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="158.48" y1="996.57" x2="160.48" y2="994.91"/>
+  </g>
+  <g id="LWPOLYLINE-753" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="158.15" y1="1000.58" x2="160.15" y2="998.91"/>
+  </g>
+  <g id="LWPOLYLINE-754" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="157.48" y1="1004.58" x2="159.82" y2="1002.91"/>
+  </g>
+  <g id="LWPOLYLINE-755" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="157.15" y1="1008.25" x2="159.15" y2="1006.58"/>
+  </g>
+  <g id="LWPOLYLINE-756" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="156.81" y1="1012.26" x2="158.81" y2="1010.59"/>
+  </g>
+  <g id="LWPOLYLINE-757" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="156.14 1019.93 157.81 1018.26 156.14 1016.26 158.48 1014.26 156.81 1012.25"/>
+  </g>
+  <g id="LWPOLYLINE-758" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="158.81" y1="1010.59" x2="157.14" y2="1008.25"/>
+  </g>
+  <g id="LWPOLYLINE-759" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="159.15" y1="1006.58" x2="157.48" y2="1004.58"/>
+  </g>
+  <g id="LWPOLYLINE-760" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="159.81" y1="1002.91" x2="158.15" y2="1000.58"/>
+  </g>
+  <g id="LWPOLYLINE-761" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="160.15" y1="998.91" x2="158.48" y2="996.57"/>
+  </g>
+  <g id="LWPOLYLINE-762" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="160.48" y1="994.9" x2="158.81" y2="992.9"/>
+  </g>
+  <g id="LWPOLYLINE-763" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="161.15" y1="991.24" x2="159.48" y2="988.9"/>
+  </g>
+  <g id="LWPOLYLINE-764" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="161.48" y1="987.23" x2="159.81" y2="984.9"/>
+  </g>
+  <g id="LWPOLYLINE-765" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="161.82" y1="983.23" x2="160.15" y2="981.23"/>
+  </g>
+  <g id="LWPOLYLINE-766" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="162.48" y1="979.56" x2="160.82" y2="977.22"/>
+  </g>
+  <g id="LWPOLYLINE-767" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="162.82" y1="975.55" x2="161.15" y2="973.55"/>
+  </g>
+  <g id="LWPOLYLINE-768" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="163.15" y1="971.55" x2="161.48" y2="969.55"/>
+  </g>
+  <g id="LWPOLYLINE-769" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="163.82" y1="967.88" x2="162.15" y2="965.54"/>
+  </g>
+  <g id="LWPOLYLINE-770" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="164.15" y1="963.88" x2="162.48" y2="961.88"/>
+  </g>
+  <g id="LWPOLYLINE-771" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="164.49" y1="960.21" x2="162.82" y2="957.87"/>
+  </g>
+  <g id="LWPOLYLINE-772" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.15" y1="956.2" x2="163.49" y2="953.87"/>
+  </g>
+  <g id="LWPOLYLINE-773" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.49" y1="952.2" x2="163.82" y2="950.2"/>
+  </g>
+  <g id="LWPOLYLINE-774" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="165.82" y1="948.53" x2="164.49" y2="946.53"/>
+  </g>
+  <g id="LWPOLYLINE-775" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="166.49" y1="944.53" x2="164.82" y2="942.52"/>
+  </g>
+  <g id="LWPOLYLINE-776" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="166.82" y1="940.52" x2="165.15" y2="938.52"/>
+  </g>
+  <g id="LWPOLYLINE-777" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="167.15" y1="936.85" x2="165.49" y2="934.51"/>
+  </g>
+  <g id="LWPOLYLINE-778" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="167.82" y1="932.85" x2="165.82" y2="930.85"/>
+  </g>
+  <g id="LWPOLYLINE-779" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="168.16" y1="928.84" x2="166.49" y2="926.84"/>
+  </g>
+  <g id="LWPOLYLINE-780" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="168.49" y1="925.17" x2="166.82" y2="922.84"/>
+  </g>
+  <g id="LWPOLYLINE-781" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="169.16" y1="921.17" x2="167.16" y2="919.17"/>
+  </g>
+  <g id="LWPOLYLINE-782" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="169.49" y1="917.5" x2="167.82" y2="915.17"/>
+  </g>
+  <g id="LWPOLYLINE-783" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="169.82" y1="913.5" x2="168.15" y2="911.16"/>
+  </g>
+  <g id="LWPOLYLINE-784" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="170.49" y1="909.49" x2="168.49" y2="907.49"/>
+  </g>
+  <g id="LWPOLYLINE-785" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="170.82" y1="905.82" x2="169.16" y2="903.49"/>
+  </g>
+  <g id="LWPOLYLINE-786" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="171.16" y1="901.82" x2="169.49" y2="899.82"/>
+  </g>
+  <g id="LWPOLYLINE-787" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="171.83" y1="897.82" x2="169.82" y2="895.81"/>
+  </g>
+  <g id="LWPOLYLINE-788" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="172.16" y1="894.15" x2="170.49" y2="891.81"/>
+  </g>
+  <g id="LWPOLYLINE-789" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="172.49" y1="890.14" x2="170.82" y2="888.14"/>
+  </g>
+  <g id="LWPOLYLINE-790" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="173.16" y1="886.47" x2="171.16" y2="884.14"/>
+  </g>
+  <g id="LWPOLYLINE-791" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="173.49" y1="882.47" x2="171.83" y2="880.13"/>
+  </g>
+  <g id="LWPOLYLINE-792" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="173.83" y1="878.46" x2="172.16" y2="876.46"/>
+  </g>
+  <g id="LWPOLYLINE-793" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="174.5" y1="874.8" x2="172.49" y2="872.46"/>
+  </g>
+  <g id="LWPOLYLINE-794" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="171.16" y1="868.79" x2="153.81" y2="1021.93"/>
+  </g>
+  <g id="LWPOLYLINE-795" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="176.83 869.12 176.5 871.46 170.82 870.79 171.16 868.79 176.83 869.12"/>
+  </g>
+  <g id="LWPOLYLINE-796" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="159.48 1020.26 159.15 1022.6 153.81 1021.93 154.14 1019.59 159.48 1020.26"/>
+  </g>
+  <g id="LWPOLYLINE-797" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="176.5" y1="871.46" x2="159.48" y2="1021.26"/>
+  </g>
+  <g id="LWPOLYLINE-798" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="168.16 944.86 167.82 946.86 162.48 946.19 162.48 944.19 168.16 944.86"/>
+  </g>
+  <g id="LWPOLYLINE-799" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="308.62" y1="1142.37" x2="403.04" y2="1142.37"/>
+  </g>
+  <g id="LWPOLYLINE-800" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="413.72" y1="1142.37" x2="420.06" y2="1142.37"/>
+  </g>
+  <g id="LWPOLYLINE-801" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="403.04" y1="1149.05" x2="413.72" y2="1149.05"/>
+  </g>
+  <g id="LWPOLYLINE-802" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M308.62,1242.3c.04,11.01,9.01,19.9,20.01,19.85,0,0,0,0,0,0h84.41v6.01"/>
+  </g>
+  <g id="LWPOLYLINE-803" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M308.5,1255.35c4.46,6.77,12.03,10.84,20.14,10.81h80.41v2"/>
+  </g>
+  <g id="LWPOLYLINE-804" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="158.15" y1="1138.04" x2="415.39" y2="1138.04"/>
+  </g>
+  <g id="LWPOLYLINE-805" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.87" y1="897.15" x2="219.87" y2="898.82"/>
+  </g>
+  <g id="LWPOLYLINE-806" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="222.54" y1="900.48" x2="228.21" y2="903.82"/>
+  </g>
+  <g id="LWPOLYLINE-807" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="231.21" y1="905.49" x2="236.89" y2="908.82"/>
+  </g>
+  <g id="LWPOLYLINE-808" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="239.89" y1="910.49" x2="245.56" y2="913.83"/>
+  </g>
+  <g id="LWPOLYLINE-809" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="248.56" y1="915.5" x2="254.24" y2="918.83"/>
+  </g>
+  <g id="LWPOLYLINE-810" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="256.9" y1="920.5" x2="262.91" y2="923.83"/>
+  </g>
+  <g id="LWPOLYLINE-811" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="265.58" y1="925.51" x2="271.25" y2="928.84"/>
+  </g>
+  <g id="LWPOLYLINE-812" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="274.25" y1="930.51" x2="279.93" y2="933.85"/>
+  </g>
+  <g id="LWPOLYLINE-813" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="282.93" y1="935.52" x2="288.6" y2="938.85"/>
+  </g>
+  <g id="LWPOLYLINE-814" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="291.6" y1="940.52" x2="297.28" y2="943.85"/>
+  </g>
+  <g id="LWPOLYLINE-815" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="300.28" y1="945.53" x2="302.95" y2="947.2"/>
+  </g>
+  <g id="LWPOLYLINE-816" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="211.19" y1="945.86" x2="216.2" y2="943.52"/>
+  </g>
+  <g id="LWPOLYLINE-817" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="219.2" y1="941.86" x2="224.87" y2="938.86"/>
+  </g>
+  <g id="LWPOLYLINE-818" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="227.88" y1="937.19" x2="233.88" y2="934.19"/>
+  </g>
+  <g id="LWPOLYLINE-819" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="236.89" y1="932.85" x2="242.56" y2="929.85"/>
+  </g>
+  <g id="LWPOLYLINE-820" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="245.56" y1="928.18" x2="251.57" y2="925.18"/>
+  </g>
+  <g id="LWPOLYLINE-821" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="254.57" y1="923.51" x2="260.24" y2="920.51"/>
+  </g>
+  <g id="LWPOLYLINE-822" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="263.24" y1="919.17" x2="269.25" y2="916.17"/>
+  </g>
+  <g id="LWPOLYLINE-823" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="272.25" y1="914.5" x2="277.92" y2="911.5"/>
+  </g>
+  <g id="LWPOLYLINE-824" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="280.93" y1="910.16" x2="286.93" y2="907.16"/>
+  </g>
+  <g id="LWPOLYLINE-825" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="289.93" y1="905.49" x2="295.61" y2="902.49"/>
+  </g>
+  <g id="LWPOLYLINE-826" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="298.61" y1="900.82" x2="303.61" y2="898.48"/>
+  </g>
+  <g id="LWPOLYLINE-827" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="301.95 1072.31 305.62 1087.99 309.29 1072.31 312.96 1087.99 316.62 1072.31"/>
+  </g>
+  <g id="LWPOLYLINE-828" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="323.97 1072.31 322.3 1072.98 320.97 1074.65 320.3 1075.98 319.63 1078.32 319.63 1081.99 320.3 1084.32 320.97 1085.66 322.3 1086.99 323.97 1087.99 326.97 1087.99 328.3 1086.99 329.64 1085.66 330.64 1084.32 331.31 1081.99 331.31 1078.32 330.64 1075.98 329.64 1074.65 328.3 1072.98 326.97 1072.31 323.97 1072.31"/>
+  </g>
+  <g id="LWPOLYLINE-829" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="335.64 1087.99 335.64 1072.31 341.65 1087.99 347.32 1072.31 347.32 1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-830" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="363 1087.99 353.33 1087.99 353.33 1072.31 363 1072.31"/>
+  </g>
+  <g id="LWPOLYLINE-831" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="353.33" y1="1079.65" x2="359.33" y2="1079.65"/>
+  </g>
+  <g id="LWPOLYLINE-832" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="367.34 1087.99 367.34 1072.31 377.68 1087.99 377.68 1072.31"/>
+  </g>
+  <g id="LWPOLYLINE-833" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1279.52 665.6 1260.16 665.6 1260.16 660.93"/>
+  </g>
+  <g id="LWPOLYLINE-834" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1218.79" y="660.93" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-835" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1153.73 663.27 1218.79 663.27 1153.73 663.27"/>
+  </g>
+  <g id="LWPOLYLINE-836" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1152.06" y="660.93" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-837" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1085" y="660.93" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-838" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1152.06 663.27 1086.67 663.27 1152.06 663.27"/>
+  </g>
+  <g id="LWPOLYLINE-839" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1260.16" y1="660.93" x2="1278.18" y2="660.93"/>
+  </g>
+  <g id="LWPOLYLINE-840" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1111.36" y1="534.15" x2="1109.36" y2="529.14"/>
+  </g>
+  <g id="LWPOLYLINE-841" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1519.4 642.25 1519.74 642.25 1519.74 650.92 1485.71 650.92 1485.71 642.25 1486.04 642.25 1514.73 625.56 1516.73 629.57 1518.07 633.58 1519.07 637.91 1519.4 642.25"/>
+  </g>
+  <g id="LWPOLYLINE-842" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="664.28" y1="670.61" x2="824.43" y2="618.22"/>
+  </g>
+  <g id="LWPOLYLINE-843" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2039.55 211.51 2041.55 217.85 2037.88 219.19 2035.88 212.51 2039.55 211.51"/>
+  </g>
+  <g id="LWPOLYLINE-844" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2084.59" y1="626.57" x2="2089.93" y2="626.9"/>
+  </g>
+  <g id="LWPOLYLINE-845" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2128.97 635.57 2129.3 631.57 2308.13 651.92"/>
+  </g>
+  <g id="LWPOLYLINE-846" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.26" y1="630.24" x2="2089.26" y2="631.23"/>
+  </g>
+  <g id="LWPOLYLINE-847" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2128.97" y1="635.57" x2="2292.79" y2="654.26"/>
+  </g>
+  <g id="LWPOLYLINE-848" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2201.37" y1="602.88" x2="2204.36" y2="603.21"/>
+  </g>
+  <g id="LWPOLYLINE-849" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2194.36 557.17 2189.69 556.5 2193.03 527.14 2199.37 528.14"/>
+  </g>
+  <g id="LWPOLYLINE-850" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2202.37 501.45 2196.02 500.78 2194.69 514.13 2201.03 514.79"/>
+  </g>
+  <g id="LWPOLYLINE-851" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2325.82" y1="423.04" x2="2277.1" y2="417.7"/>
+  </g>
+  <g id="LWPOLYLINE-852" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2324.48" y1="433.05" x2="2276.11" y2="427.38"/>
+  </g>
+  <g id="LWPOLYLINE-853" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2323.48" y1="442.73" x2="2274.76" y2="437.39"/>
+  </g>
+  <g id="LWPOLYLINE-854" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2322.15" y1="452.74" x2="2273.77" y2="447.07"/>
+  </g>
+  <g id="LWPOLYLINE-855" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2321.14" y1="462.75" x2="2272.44" y2="457.07"/>
+  </g>
+  <g id="LWPOLYLINE-856" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2320.14" y1="472.42" x2="2271.43" y2="467.09"/>
+  </g>
+  <g id="LWPOLYLINE-857" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2318.81" y1="482.43" x2="2270.43" y2="476.76"/>
+  </g>
+  <g id="LWPOLYLINE-858" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2317.81" y1="492.11" x2="2269.09" y2="486.77"/>
+  </g>
+  <g id="LWPOLYLINE-859" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2316.81" y1="502.12" x2="2268.09" y2="496.45"/>
+  </g>
+  <g id="LWPOLYLINE-860" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2315.47" y1="512.13" x2="2267.1" y2="506.45"/>
+  </g>
+  <g id="LWPOLYLINE-861" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2277.1" y1="416.37" x2="2221.05" y2="410.03"/>
+  </g>
+  <g id="LWPOLYLINE-862" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2277.44" y1="414.37" x2="2221.38" y2="408.03"/>
+  </g>
+  <g id="LWPOLYLINE-863" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2277.44 414.37 2277.77 412.7 2221.72 406.36"/>
+  </g>
+  <g id="LWPOLYLINE-864" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2214.38 469.75 2237.73 467.41 2240.73 471.75 2245.07 462.08 2248.08 466.42 2271.77 463.75"/>
+  </g>
+  <g id="LWPOLYLINE-865" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2236.73" y1="522.47" x2="2241.74" y2="480.44"/>
+  </g>
+  <g id="LWPOLYLINE-866" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2301.46" y1="420.37" x2="2289.12" y2="528.48"/>
+  </g>
+  <g id="LWPOLYLINE-867" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2303.46 420.37 2302.79 418.71 2301.46 418.03 2299.79 418.71 2299.12 420.37 2299.79 422.04 2301.46 422.38 2302.79 422.04 2303.46 420.37"/>
+  </g>
+  <g id="LWPOLYLINE-868" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2292.45 414.04 2293.78 400.69 2298.12 401.36 2300.13 402.03 2301.12 403.36 2301.79 404.7 2302.13 406.7 2301.79 410.03 2300.79 411.7 2300.13 413.04 2298.79 414.04 2296.79 414.37 2292.45 414.04"/>
+  </g>
+  <g id="LWPOLYLINE-869" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2305.46 415.37 2307.13 402.02 2314.47 416.37 2315.81 403.03"/>
+  </g>
+  <g id="LWPOLYLINE-870" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2192.69 339.3 2204.04 315.28 2205.37 315.95 2193.69 339.63"/>
+  </g>
+  <g id="LWPOLYLINE-871" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2191.69 338.97 2194.69 339.96 2197.7 340.97 2200.69 341.64 2203.7 341.64 2206.7 341.64 2209.7 340.97 2212.71 340.3"/>
+  </g>
+  <g id="LWPOLYLINE-872" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2356.18" y1="114.42" x2="2332.82" y2="320.62"/>
+  </g>
+  <g id="LWPOLYLINE-873" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2337.15 283.58 2310.8 280.58 2310.47 281.91"/>
+  </g>
+  <g id="LWPOLYLINE-874" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2281.78" y1="202.51" x2="2281.11" y2="209.18"/>
+  </g>
+  <g id="LWPOLYLINE-875" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2279.11 235.54 2278.1 235.54 2277.44 240.88"/>
+  </g>
+  <g id="LWPOLYLINE-876" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2282.77" y1="202.51" x2="2282.11" y2="209.18"/>
+  </g>
+  <g id="LWPOLYLINE-877" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2299.79 218.86 2279.11 235.54 2278.77 239.88"/>
+  </g>
+  <g id="LWPOLYLINE-878" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2360.85" y1="113.09" x2="2336.82" y2="325.62"/>
+  </g>
+  <g id="LWPOLYLINE-879" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2277.44" y1="240.88" x2="2341.16" y2="247.88"/>
+  </g>
+  <g id="LWPOLYLINE-880" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2278.77" y1="239.87" x2="2341.16" y2="246.88"/>
+  </g>
+  <g id="LWPOLYLINE-881" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2281.11" y1="209.18" x2="2282.1" y2="209.18"/>
+  </g>
+  <g id="LWPOLYLINE-882" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2208.04" y1="196.5" x2="2220.72" y2="195.17"/>
+  </g>
+  <g id="LWPOLYLINE-883" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2208.37" y1="195.5" x2="2220.72" y2="193.83"/>
+  </g>
+  <g id="LWPOLYLINE-884" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2260.09 198.84 2260.09 199.84 2345.5 209.51"/>
+  </g>
+  <g id="LWPOLYLINE-885" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2260.09" y1="198.84" x2="2345.5" y2="208.51"/>
+  </g>
+  <g id="LWPOLYLINE-886" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2322.81" y1="384.34" x2="2338.16" y2="386.01"/>
+  </g>
+  <g id="LWPOLYLINE-887" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2218.72" y1="358.98" x2="2227.05" y2="359.98"/>
+  </g>
+  <g id="LWPOLYLINE-888" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2194.36 511.46 2189.36 556.5 2187.02 556.17 2192.02 511.46"/>
+  </g>
+  <g id="LWPOLYLINE-889" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2195.7 511.79 2190.36 511.46 2185.35 511.46 2180.01 512.12 2175.01 513.46 2170.01 515.46 2165.33 518.13 2161 521.13"/>
+  </g>
+  <g id="ARC">
+    <path class="cls-3" d="M2160.88,520.82c-19.61,15.44-22.99,43.86-7.55,63.47,7.64,9.7,18.9,15.85,31.19,17.03"/>
+  </g>
+  <g id="LWPOLYLINE-890" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2286.11,340.3l-.67,6.01c-.14,1.6-1.55,2.79-3.16,2.65"/>
+  </g>
+  <g id="CIRCLE-18" data-name="CIRCLE">
+    <circle class="cls-3" cx="2278.94" cy="338.13" r="1.5"/>
+  </g>
+  <g id="LWPOLYLINE-891" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2288.11" y1="337.97" x2="2287.78" y2="340.64"/>
+  </g>
+  <g id="SPLINE">
+    <path class="cls-3" d="M2288.11,341.56c.05-.46-.28-.87-.73-.92"/>
+  </g>
+  <g id="ARC-2" data-name="ARC">
+    <path class="cls-3" d="M2287.38,340.64c-.46-.06-.87.27-.93.73s.27.87.73.93.87-.27.93-.73c0,0,0,0,0,0"/>
+  </g>
+  <g id="SPLINE-2" data-name="SPLINE">
+    <path class="cls-3" d="M2288.44,336.89c.05-.46-.28-.87-.73-.92"/>
+  </g>
+  <g id="ARC-3" data-name="ARC">
+    <path class="cls-3" d="M2287.71,335.97c-.46-.06-.87.27-.93.73s.27.87.73.93.87-.27.93-.73c0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-892" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2287.45 337.97 2281.78 338.3 2281.78 338.97 2287.11 340.64"/>
+  </g>
+  <g id="LWPOLYLINE-893" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2288.78" y1="349.64" x2="2290.78" y2="329.63"/>
+  </g>
+  <g id="LWPOLYLINE-894" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2270.43,348.64l16.68,2c.83.09,1.57-.51,1.66-1.33"/>
+  </g>
+  <g id="ARC-4" data-name="ARC">
+    <path class="cls-3" d="M2268.77,346.97c-.09.83.5,1.57,1.32,1.66"/>
+  </g>
+  <g id="LWPOLYLINE-895" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2271.43" y1="327.29" x2="2269.09" y2="347.3"/>
+  </g>
+  <g id="ARC-5" data-name="ARC">
+    <path class="cls-3" d="M2272.77,325.96c-.82-.1-1.57.49-1.66,1.31,0,0,0,0,0,.01"/>
+  </g>
+  <g id="LWPOLYLINE-896" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2289.78" y1="328.29" x2="2273.1" y2="326.29"/>
+  </g>
+  <g id="ARC-6" data-name="ARC">
+    <path class="cls-3" d="M2291.11,329.63c.1-.82-.49-1.57-1.31-1.66,0,0,0,0-.01,0"/>
+  </g>
+  <g id="LWPOLYLINE-897" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2282.44,348.64l-9.34-1s0,0,0,0c-1.6-.14-2.79-1.55-2.65-3.16"/>
+  </g>
+  <g id="LWPOLYLINE-898" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2270.77" y1="344.64" x2="2272.43" y2="330.29"/>
+  </g>
+  <g id="ARC-7" data-name="ARC">
+    <path class="cls-3" d="M2275.26,327.64c-1.55-.17-2.96.94-3.14,2.5"/>
+  </g>
+  <g id="LWPOLYLINE-899" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2275.44" y1="327.95" x2="2284.78" y2="328.95"/>
+  </g>
+  <g id="LWPOLYLINE-900" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2284.6,328.64c1.61.22,2.73,1.71,2.51,3.32l-.67,6.01"/>
+  </g>
+  <g id="LWPOLYLINE-901" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2228.39 321.95 2227.06 333.63 2226.05 335.64 2225.06 336.29 2223.72 336.96 2222.05 336.63 2220.71 335.97 2220.05 334.96 2219.72 332.63 2219.72 331.29"/>
+  </g>
+  <g id="LWPOLYLINE-902" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2231.06 337.63 2238.74 322.96 2242.74 338.97"/>
+  </g>
+  <g id="LWPOLYLINE-903" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2233.73" y1="332.96" x2="2241.07" y2="333.62"/>
+  </g>
+  <g id="LWPOLYLINE-904" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2247.08 339.63 2248.74 324.28 2257.42 340.63 2259.09 325.29"/>
+  </g>
+  <g id="LWPOLYLINE-905" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2264.09 339.97 2263.42 340.63 2263.76 341.63 2264.76 340.97"/>
+  </g>
+  <g id="LWPOLYLINE-906" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2310.47" y1="281.91" x2="2336.83" y2="284.91"/>
+  </g>
+  <g id="LWPOLYLINE-907" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2220.72,193.83v1.33l24.36,31.36c8.35-6.53,13.76-16.11,15.04-26.63"/>
+  </g>
+  <g id="LWPOLYLINE-908" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2301.8,202.28s0-.01,0-.02c.06-.3.36-.49.65-.42l33.7,4"/>
+  </g>
+  <g id="LWPOLYLINE-909" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2336.16" y1="204.17" x2="2302.79" y2="200.17"/>
+  </g>
+  <g id="LWPOLYLINE-910" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2338.49 191.5 2340.16 191.83 2340.83 184.16 2339.16 183.82"/>
+  </g>
+  <g id="ARC-8" data-name="ARC">
+    <path class="cls-3" d="M2338.95,183.7c-.38-.62-.84-1.18-1.37-1.68"/>
+  </g>
+  <g id="SPLINE-3" data-name="SPLINE">
+    <path class="cls-3" d="M2322.34,181.26c-.14.11-.21.29-.19.45"/>
+  </g>
+  <g id="SPLINE-4" data-name="SPLINE">
+    <path class="cls-3" d="M2322.15,181.71c.02.17.13.32.29.4"/>
+  </g>
+  <g id="LWPOLYLINE-911" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2322.48" y1="182.15" x2="2324.82" y2="183.48"/>
+  </g>
+  <g id="ARC-9" data-name="ARC">
+    <path class="cls-3" d="M2324.77,183.11c.15.06.31.06.45-.02"/>
+  </g>
+  <g id="ARC-10" data-name="ARC">
+    <path class="cls-3" d="M2327.33,182.61c-.76.14-1.49.41-2.16.78"/>
+  </g>
+  <g id="ARC-11" data-name="ARC">
+    <path class="cls-3" d="M2336.11,185.46c-.22-.36-.5-.7-.81-.99"/>
+  </g>
+  <g id="ARC-12" data-name="ARC">
+    <path class="cls-3" d="M2335.97,189.16c.95-1.02,1.13-2.55.43-3.76"/>
+  </g>
+  <g id="ARC-13" data-name="ARC">
+    <path class="cls-3" d="M2324.52,188.65c.57.52,1.22.94,1.92,1.24"/>
+  </g>
+  <g id="ARC-14" data-name="ARC">
+    <path class="cls-3" d="M2324.31,188.96c-.12-.1-.28-.15-.44-.12"/>
+  </g>
+  <g id="LWPOLYLINE-912" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2324.15" y1="188.83" x2="2321.81" y2="189.49"/>
+  </g>
+  <g id="SPLINE-5" data-name="SPLINE">
+    <path class="cls-3" d="M2321.54,189.17c-.17.04-.31.16-.37.31"/>
+  </g>
+  <g id="SPLINE-6" data-name="SPLINE">
+    <path class="cls-3" d="M2321.18,189.49c-.05.16-.03.34.07.48"/>
+  </g>
+  <g id="ARC-15" data-name="ARC">
+    <path class="cls-3" d="M2332.41,178.94c-1.6-.19-3.22-.16-4.81.08"/>
+  </g>
+  <g id="ARC-16" data-name="ARC">
+    <path class="cls-3" d="M2319.76,188.38c.33.67.74,1.29,1.22,1.87"/>
+  </g>
+  <g id="ARC-17" data-name="ARC">
+    <path class="cls-3" d="M2321.25,187.65c.28.57.64,1.1,1.04,1.58"/>
+  </g>
+  <g id="LWPOLYLINE-913" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2324.48" y1="188.83" x2="2324.48" y2="188.83"/>
+  </g>
+  <g id="LWPOLYLINE-914" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2321.14" y1="189.83" x2="2321.14" y2="189.83"/>
+  </g>
+  <g id="ARC-18" data-name="ARC">
+    <path class="cls-3" d="M2323.11,182.35c-.47.36-.9.77-1.27,1.23"/>
+  </g>
+  <g id="LWPOLYLINE-915" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2300.46" y1="202.51" x2="2302.13" y2="202.84"/>
+  </g>
+  <g id="LWPOLYLINE-916" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2299.79 202.51 2299.46 202.84 2299.46 203.17 2302.79 203.5 2302.79 203.17 2302.47 202.84 2302.13 202.84 2302.13 202.51"/>
+  </g>
+  <g id="LWPOLYLINE-917" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2300.46 202.17 2300.46 202.51 2299.79 202.51"/>
+  </g>
+  <g id="ARC-19" data-name="ARC">
+    <path class="cls-3" d="M2302.54,200.19c-1.19-.14-2.27.72-2.4,1.91"/>
+  </g>
+  <g id="LWPOLYLINE-918" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2345.17" y1="197.84" x2="2348.83" y2="164.47"/>
+  </g>
+  <g id="LWPOLYLINE-919" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2347.5,164.14l-4,33.37c-.1,1.17.76,2.21,1.93,2.33"/>
+  </g>
+  <g id="LWPOLYLINE-920" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2348.84,164.25c.06-.3.36-.5.66-.44h.33v.66l.33.33h.33l.33-3.34h-.33l-.33.34v.33h-.33"/>
+  </g>
+  <g id="LWPOLYLINE-921" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2349.84" y1="163.81" x2="2350.17" y2="162.14"/>
+  </g>
+  <g id="ARC-20" data-name="ARC">
+    <path class="cls-3" d="M2349.58,162.15c-1.19-.14-2.27.72-2.4,1.91,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-21" data-name="ARC">
+    <path class="cls-3" d="M2328.91,194.12c.55.11,1.1.2,1.66.27"/>
+  </g>
+  <g id="LWPOLYLINE-922" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2330.82" y1="194.5" x2="2343.83" y2="196.17"/>
+  </g>
+  <g id="LWPOLYLINE-923" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2345.5" y1="180.49" x2="2332.49" y2="179.15"/>
+  </g>
+  <g id="LWPOLYLINE-924" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2345.5 196.17 2347.17 196.5 2347.5 192.16 2347.84 188.83 2348.18 185.49 2348.83 181.16 2347.17 180.81"/>
+  </g>
+  <g id="LWPOLYLINE-925" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2345.84" y1="200.17" x2="2345.84" y2="198.5"/>
+  </g>
+  <g id="LWPOLYLINE-926" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2346.5" y1="201.17" x2="2345.84" y2="200.84"/>
+  </g>
+  <g id="LWPOLYLINE-927" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2345.84" y1="198.5" x2="2345.84" y2="198.5"/>
+  </g>
+  <g id="LWPOLYLINE-928" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2345.5 200.17 2345.83 200.17 2345.83 200.84"/>
+  </g>
+  <g id="LWPOLYLINE-929" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2345.84 198.5 2346.16 197.84 2346.83 197.84 2346.5 201.18"/>
+  </g>
+  <g id="ARC-22" data-name="ARC">
+    <path class="cls-3" d="M2345.17,197.61c-.03.27.16.52.44.56,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-930" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2338.16 206.84 2336.49 206.51 2335.82 206.51 2335.82 206.84 2335.49 207.51 2338.83 207.84 2338.83 207.18 2338.83 206.84 2338.16 206.84 2338.16 206.51"/>
+  </g>
+  <g id="ARC-23" data-name="ARC">
+    <path class="cls-3" d="M2336.49,206.07c.03-.27-.17-.52-.44-.56"/>
+  </g>
+  <g id="ARC-24" data-name="ARC">
+    <path class="cls-3" d="M2338.15,206.25c.14-1.19-.72-2.27-1.91-2.4"/>
+  </g>
+  <g id="ARC-25" data-name="ARC">
+    <path class="cls-3" d="M2299.62,218.76c-4.41-5.48-10.81-8.99-17.8-9.76"/>
+  </g>
+  <g id="LWPOLYLINE-931" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2324.24,236.15c.52.15,1.05.28,1.58.38l16.35,2,.67-4.34.33-3.34.33-3.33.33-4.34-16.01-2"/>
+  </g>
+  <g id="LWPOLYLINE-932" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2316.47" y1="231.87" x2="2316.47" y2="231.87"/>
+  </g>
+  <g id="LWPOLYLINE-933" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2319.81" y1="230.87" x2="2319.81" y2="230.87"/>
+  </g>
+  <g id="ARC-26" data-name="ARC">
+    <path class="cls-3" d="M2318.58,222.14c-1.18.58-2.21,1.4-3.05,2.42"/>
+  </g>
+  <g id="ARC-27" data-name="ARC">
+    <path class="cls-3" d="M2322.71,221c-1.35.2-2.67.61-3.89,1.22"/>
+  </g>
+  <g id="ARC-28" data-name="ARC">
+    <path class="cls-3" d="M2327.41,221.31c-1.6-.19-3.22-.16-4.81.08"/>
+  </g>
+  <g id="SPLINE-7" data-name="SPLINE">
+    <path class="cls-3" d="M2317.33,223.3c-.14.11-.21.29-.19.45"/>
+  </g>
+  <g id="SPLINE-8" data-name="SPLINE">
+    <path class="cls-3" d="M2317.15,223.75c.02.17.13.32.29.4"/>
+  </g>
+  <g id="LWPOLYLINE-934" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2317.81" y1="224.53" x2="2320.15" y2="225.52"/>
+  </g>
+  <g id="ARC-29" data-name="ARC">
+    <path class="cls-3" d="M2319.77,225.15c.15.06.31.06.45-.02"/>
+  </g>
+  <g id="ARC-30" data-name="ARC">
+    <path class="cls-3" d="M2322.65,224.65c-.75.14-1.48.41-2.15.78"/>
+  </g>
+  <g id="ARC-31" data-name="ARC">
+    <path class="cls-3" d="M2331.3,231.2c.95-1.02,1.13-2.55.43-3.76"/>
+  </g>
+  <g id="ARC-32" data-name="ARC">
+    <path class="cls-3" d="M2319.85,230.69c.57.51,1.22.93,1.92,1.24"/>
+  </g>
+  <g id="ARC-33" data-name="ARC">
+    <path class="cls-3" d="M2319.64,231c-.12-.1-.28-.15-.44-.12"/>
+  </g>
+  <g id="LWPOLYLINE-935" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2319.48" y1="230.87" x2="2316.8" y2="231.53"/>
+  </g>
+  <g id="SPLINE-9" data-name="SPLINE">
+    <path class="cls-3" d="M2316.87,231.21c-.17.04-.31.16-.37.31"/>
+  </g>
+  <g id="LWPOLYLINE-936" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2328.26,236.02c1.23-.22,2.41-.65,3.5-1.26.63-.33,1.21-.74,1.73-1.23l1.67.33,1.01-7.67-1.67-.33"/>
+  </g>
+  <g id="ARC-34" data-name="ARC">
+    <path class="cls-3" d="M2318.11,224.39c-.47.36-.9.77-1.27,1.23"/>
+  </g>
+  <g id="LWPOLYLINE-937" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2203.7" y1="200.17" x2="2133.64" y2="222.86"/>
+  </g>
+  <g id="LWPOLYLINE-938" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2142.31" y1="200.17" x2="2143.98" y2="199.51"/>
+  </g>
+  <g id="LWPOLYLINE-939" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2141.65" y1="198.17" x2="2146.65" y2="196.5"/>
+  </g>
+  <g id="LWPOLYLINE-940" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2152.32 194.16 2143.98 196.84 2135.63 199.83"/>
+  </g>
+  <g id="SPLINE-10" data-name="SPLINE">
+    <path class="cls-3" d="M2141.65,200.06c.03.09.12.14.21.11"/>
+  </g>
+  <g id="LWPOLYLINE-941" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2141.98,200.17l-.67-1.67c-.05-.12,0-.26.11-.32"/>
+  </g>
+  <g id="ARC-35" data-name="ARC">
+    <path class="cls-3" d="M2135.31,199.46c-1.2.63-1.68,2.1-1.08,3.32"/>
+  </g>
+  <g id="LWPOLYLINE-942" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2145.32" y1="202.51" x2="2143.65" y2="198.84"/>
+  </g>
+  <g id="LWPOLYLINE-943" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2145.65" y1="199.17" x2="2147.32" y2="198.5"/>
+  </g>
+  <g id="SPLINE-11" data-name="SPLINE">
+    <path class="cls-3" d="M2146.64,196.62c-.03-.09-.12-.14-.21-.11"/>
+  </g>
+  <g id="SPLINE-12" data-name="SPLINE">
+    <path class="cls-3" d="M2147.2,198.16c.09-.03.13-.12.11-.21"/>
+  </g>
+  <g id="LWPOLYLINE-944" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.65" y1="198.17" x2="2146.98" y2="196.5"/>
+  </g>
+  <g id="ARC-36" data-name="ARC">
+    <path class="cls-3" d="M2143.36,198.6c.02.06.05.12.08.17"/>
+  </g>
+  <g id="SPLINE-13" data-name="SPLINE">
+    <path class="cls-3" d="M2143.32,198.27c0,.11,0,.21.04.32"/>
+  </g>
+  <g id="ARC-37" data-name="ARC">
+    <path class="cls-3" d="M2143.4,197.96c-.05.1-.08.2-.09.31"/>
+  </g>
+  <g id="SPLINE-14" data-name="SPLINE">
+    <path class="cls-3" d="M2143.6,197.7c-.08.07-.15.16-.2.26"/>
+  </g>
+  <g id="ARC-38" data-name="ARC">
+    <path class="cls-3" d="M2143.89,197.54c-.11.03-.2.09-.29.16"/>
+  </g>
+  <g id="SPLINE-15" data-name="SPLINE">
+    <path class="cls-3" d="M2144.21,197.5c-.11,0-.22,0-.32.04"/>
+  </g>
+  <g id="ARC-39" data-name="ARC">
+    <path class="cls-3" d="M2144.52,197.59c-.1-.05-.2-.08-.31-.09"/>
+  </g>
+  <g id="SPLINE-16" data-name="SPLINE">
+    <path class="cls-3" d="M2144.78,197.79c-.07-.08-.16-.15-.26-.2"/>
+  </g>
+  <g id="ARC-40" data-name="ARC">
+    <path class="cls-3" d="M2144.94,198.08c-.03-.11-.09-.2-.16-.29"/>
+  </g>
+  <g id="SPLINE-17" data-name="SPLINE">
+    <path class="cls-3" d="M2143.11,197.81c-.07.14-.11.29-.12.44"/>
+  </g>
+  <g id="ARC-41" data-name="ARC">
+    <path class="cls-3" d="M2143.39,197.45c-.12.1-.21.22-.29.36"/>
+  </g>
+  <g id="SPLINE-18" data-name="SPLINE">
+    <path class="cls-3" d="M2143.78,197.23c-.15.05-.29.13-.4.23"/>
+  </g>
+  <g id="ARC-42" data-name="ARC">
+    <path class="cls-3" d="M2144.24,197.17c-.15-.02-.31,0-.45.06"/>
+  </g>
+  <g id="SPLINE-19" data-name="SPLINE">
+    <path class="cls-3" d="M2144.67,197.29c-.14-.07-.29-.11-.44-.12"/>
+  </g>
+  <g id="SPLINE-20" data-name="SPLINE">
+    <path class="cls-3" d="M2145.01,202.5c.09.26.37.4.64.31"/>
+  </g>
+  <g id="ARC-43" data-name="ARC">
+    <path class="cls-3" d="M2145.64,202.81c.26-.08.4-.36.32-.62,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-945" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2146.32" y1="202.17" x2="2145.32" y2="198.17"/>
+  </g>
+  <g id="LWPOLYLINE-946" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2183.02" y1="187.16" x2="2181.01" y2="187.83"/>
+  </g>
+  <g id="ARC-44" data-name="ARC">
+    <path class="cls-3" d="M2180.98,188.11c2.33-.79,4.63-1.7,6.87-2.72"/>
+  </g>
+  <g id="LWPOLYLINE-947" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2182.35" y1="185.16" x2="2177.01" y2="186.83"/>
+  </g>
+  <g id="LWPOLYLINE-948" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2171.01 188.49 2179.68 185.49 2188.02 182.82"/>
+  </g>
+  <g id="ARC-45" data-name="ARC">
+    <path class="cls-3" d="M2187.92,199.2c1.11-1.19,1.96-2.6,2.48-4.13"/>
+  </g>
+  <g id="ARC-46" data-name="ARC">
+    <path class="cls-3" d="M2190.89,195.14c.56-1.62.83-3.32.8-5.02"/>
+  </g>
+  <g id="ARC-47" data-name="ARC">
+    <path class="cls-3" d="M2191.35,190.06c-.02-1.91-.34-3.81-.94-5.62"/>
+  </g>
+  <g id="SPLINE-21" data-name="SPLINE">
+    <path class="cls-3" d="M2182.9,187.15c.09-.03.14-.12.11-.21"/>
+  </g>
+  <g id="SPLINE-22" data-name="SPLINE">
+    <path class="cls-3" d="M2182.34,185.27c-.02-.09-.12-.14-.21-.11"/>
+  </g>
+  <g id="LWPOLYLINE-949" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2183.02" y1="186.83" x2="2182.68" y2="185.5"/>
+  </g>
+  <g id="ARC-48" data-name="ARC">
+    <path class="cls-3" d="M2190.65,184.54c-.25-1.33-1.5-2.23-2.84-2.03"/>
+  </g>
+  <g id="LWPOLYLINE-950" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2182.01,191.16l-1-4c.03-.18,0-.37-.07-.53"/>
+  </g>
+  <g id="LWPOLYLINE-951" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2179.68" y1="188.49" x2="2177.68" y2="188.83"/>
+  </g>
+  <g id="ARC-49" data-name="ARC">
+    <path class="cls-3" d="M2172.48,190.55c-.61.2-.94.86-.74,1.47"/>
+  </g>
+  <g id="ARC-50" data-name="ARC">
+    <path class="cls-3" d="M2172.28,190.5c2.41-.51,4.79-1.14,7.13-1.89"/>
+  </g>
+  <g id="SPLINE-23" data-name="SPLINE">
+    <path class="cls-3" d="M2176.79,186.83c-.09.03-.14.13-.11.21"/>
+  </g>
+  <g id="SPLINE-24" data-name="SPLINE">
+    <path class="cls-3" d="M2177.35,188.71c.03.09.13.14.21.11"/>
+  </g>
+  <g id="LWPOLYLINE-952" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2177.34" y1="188.83" x2="2177.01" y2="187.16"/>
+  </g>
+  <g id="SPLINE-25" data-name="SPLINE">
+    <path class="cls-3" d="M2180.68,186.92c0-.06-.02-.13-.04-.19"/>
+  </g>
+  <g id="SPLINE-26" data-name="SPLINE">
+    <path class="cls-3" d="M2180.64,186.73c-.04-.11-.09-.2-.16-.29"/>
+  </g>
+  <g id="SPLINE-27" data-name="SPLINE">
+    <path class="cls-3" d="M2180.48,186.45c-.07-.08-.16-.15-.26-.19"/>
+  </g>
+  <g id="SPLINE-28" data-name="SPLINE">
+    <path class="cls-3" d="M2180.22,186.25c-.1-.05-.2-.08-.31-.09"/>
+  </g>
+  <g id="SPLINE-29" data-name="SPLINE">
+    <path class="cls-3" d="M2179.91,186.16c-.11,0-.22,0-.32.04"/>
+  </g>
+  <g id="SPLINE-30" data-name="SPLINE">
+    <path class="cls-3" d="M2179.1,186.62c-.05.1-.08.2-.09.31"/>
+  </g>
+  <g id="SPLINE-31" data-name="SPLINE">
+    <path class="cls-3" d="M2179.01,186.93c0,.11,0,.21.04.32"/>
+  </g>
+  <g id="SPLINE-32" data-name="SPLINE">
+    <path class="cls-3" d="M2180.96,186.63c-.05-.15-.12-.29-.22-.4"/>
+  </g>
+  <g id="ARC-51" data-name="ARC">
+    <path class="cls-3" d="M2180.73,186.23c-.1-.12-.22-.21-.36-.29"/>
+  </g>
+  <g id="SPLINE-33" data-name="SPLINE">
+    <path class="cls-3" d="M2180.37,185.95c-.14-.07-.29-.11-.44-.12"/>
+  </g>
+  <g id="ARC-52" data-name="ARC">
+    <path class="cls-3" d="M2179.93,185.83c-.15-.01-.31,0-.45.06"/>
+  </g>
+  <g id="SPLINE-34" data-name="SPLINE">
+    <path class="cls-3" d="M2179.48,185.88c-.15.05-.29.13-.4.23"/>
+  </g>
+  <g id="SPLINE-35" data-name="SPLINE">
+    <path class="cls-3" d="M2179.08,186.11c-.12.1-.21.22-.29.36"/>
+  </g>
+  <g id="SPLINE-36" data-name="SPLINE">
+    <path class="cls-3" d="M2178.81,186.47c-.07.14-.11.29-.12.44"/>
+  </g>
+  <g id="ARC-53" data-name="ARC">
+    <path class="cls-3" d="M2178.68,186.9c-.03.38.13.75.42.99"/>
+  </g>
+  <g id="SPLINE-37" data-name="SPLINE">
+    <path class="cls-3" d="M2180.71,191.15c.09.27.37.4.64.31"/>
+  </g>
+  <g id="ARC-54" data-name="ARC">
+    <path class="cls-3" d="M2181.34,191.47c.26-.08.4-.36.32-.62,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-953" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2180.68" y1="191.5" x2="2179.01" y2="187.49"/>
+  </g>
+  <g id="ARC-55" data-name="ARC">
+    <path class="cls-3" d="M2171.01,188.11c-1.2.63-1.68,2.1-1.09,3.32"/>
+  </g>
+  <g id="ARC-56" data-name="ARC">
+    <path class="cls-3" d="M2175.97,199.8c1.34.92,2.86,1.55,4.45,1.85"/>
+  </g>
+  <g id="ARC-57" data-name="ARC">
+    <path class="cls-3" d="M2172.45,196.64c.99,1.39,2.22,2.59,3.62,3.57"/>
+  </g>
+  <g id="ARC-58" data-name="ARC">
+    <path class="cls-3" d="M2169.95,191.21c.6,1.82,1.47,3.53,2.58,5.09"/>
+  </g>
+  <g id="CIRCLE-19" data-name="CIRCLE">
+    <circle class="cls-3" cx="2332.98" cy="302.77" r="1.17"/>
+  </g>
+  <g id="LWPOLYLINE-954" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2335.49" y1="297.93" x2="2332.15" y2="297.59"/>
+  </g>
+  <g id="LWPOLYLINE-955" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2321.14 307.93 2321.82 308.27 2322.81 308.61 2323.81 308.94 2324.81 309.27 2325.82 309.27 2326.82 309.61 2328.48 309.94 2330.49 310.61 2334.16 310.94 2334.82 303.27 2335.82 295.6 2332.15 295.25"/>
+  </g>
+  <g id="LWPOLYLINE-956" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2334.16 308.6 2330.83 308.27 2331.48 302.93"/>
+  </g>
+  <g id="LWPOLYLINE-957" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2331.15 305.6 2331.15 305.93 2330.82 306.27 2330.82 306.6 2330.82 306.93 2330.49 306.93 2330.15 306.93 2329.82 306.93 2329.49 306.93 2329.15 306.93 2328.81 306.93 2328.48 306.93 2328.16 306.93 2327.82 306.93 2327.48 306.93 2327.15 306.93 2326.81 306.93 2326.48 306.93 2326.15 306.93 2325.82 306.93 2325.48 306.93 2325.15 306.93 2324.81 306.93 2324.48 306.93 2324.15 306.93 2323.81 306.93 2323.48 306.93 2323.14 306.93 2322.82 306.6 2322.48 306.6 2322.15 306.6 2321.81 306.27 2321.48 306.27 2321.48 305.93 2321.14 305.93 2321.14 305.6 2321.14 305.27 2320.81 304.94 2320.81 304.6 2320.81 304.27 2320.81 303.94 2320.81 303.6 2320.81 302.93 2320.81 302.27 2320.81 301.6"/>
+  </g>
+  <g id="LWPOLYLINE-958" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2330.82 308.27 2330.15 308.27 2329.49 308.27 2328.82 308.27 2328.15 308.27 2327.49 308.27 2327.15 308.27 2326.48 308.27 2326.15 308.27 2325.48 308.27 2325.15 308.27 2324.81 308.27 2324.15 308.27 2323.81 308.27 2323.48 307.94 2323.15 307.94 2322.81 307.94 2322.48 307.94 2322.15 307.94 2321.82 307.94 2321.48 307.94 2321.14 307.94 2320.81 307.61 2320.48 307.61 2320.14 307.27 2319.81 306.94 2319.81 306.27 2319.48 305.61 2319.48 304.6 2319.48 303.27 2319.48 301.6 2319.81 299.94 2320.14 298.6 2320.48 297.6 2320.81 296.93 2321.14 296.26 2321.48 296.26 2321.48 295.93 2321.82 295.93 2322.15 295.93 2322.48 295.93 2322.81 295.59 2323.15 295.93 2323.48 295.93 2323.81 295.93 2324.15 295.93 2324.48 295.93 2324.81 295.93 2325.15 295.93 2325.48 296.26 2326.15 296.26 2326.48 296.26 2326.82 296.26 2327.49 296.59 2327.82 296.59 2328.48 296.59 2328.82 296.93 2329.49 296.93 2330.15 297.26 2330.82 297.26 2331.49 297.26 2332.15 297.6"/>
+  </g>
+  <g id="LWPOLYLINE-959" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2332.15 295.26 2330.15 295.26 2328.49 295.26 2327.48 295.26 2326.15 295.26 2325.49 295.26 2324.48 295.59 2323.15 295.59 2322.48 295.59"/>
+  </g>
+  <g id="LWPOLYLINE-960" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2331.82 300.26 2331.82 299.6 2331.82 299.27 2331.49 298.93 2331.49 298.59 2331.15 298.59 2330.82 298.59 2330.49 298.59 2330.49 298.26 2330.15 298.26 2329.82 298.26 2329.48 298.26 2329.15 297.93 2328.82 297.93 2328.49 297.93 2328.16 297.93 2327.82 297.93 2327.48 297.6 2327.15 297.6 2326.81 297.6 2326.48 297.6 2326.15 297.6 2325.82 297.6 2325.82 297.26 2325.48 297.26 2325.15 297.26 2324.82 297.26 2324.48 297.26 2324.15 297.26 2323.81 297.26 2323.48 297.26 2323.15 297.26 2322.82 297.26 2322.48 297.6 2322.15 297.6 2322.15 297.93 2321.81 297.93 2321.81 298.26 2321.47 298.59 2321.47 298.93 2321.47 299.27 2321.14 299.93 2321.14 300.26 2321.14 300.93 2320.81 301.6"/>
+  </g>
+  <g id="LWPOLYLINE-961" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2332.15" y1="297.59" x2="2331.49" y2="302.93"/>
+  </g>
+  <g id="SPLINE-38" data-name="SPLINE">
+    <path class="cls-3" d="M2337.19,267.23c.64.07,1.22-.39,1.3-1.03"/>
+  </g>
+  <g id="SPLINE-39" data-name="SPLINE">
+    <path class="cls-3" d="M2338.49,266.2c.07-.64-.39-1.22-1.03-1.29"/>
+  </g>
+  <g id="LWPOLYLINE-962" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2338.49" y1="271.91" x2="2335.16" y2="271.24"/>
+  </g>
+  <g id="LWPOLYLINE-963" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2326.82 258.89 2327.49 258.89 2328.48 258.56 2329.49 258.56 2330.49 258.56 2331.49 258.56 2332.82 258.56 2334.49 258.56 2336.49 258.56 2339.82 258.89 2339.17 266.57 2338.16 273.91 2334.82 273.57"/>
+  </g>
+  <g id="LWPOLYLINE-964" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2339.5 261.23 2336.16 260.9 2335.49 266.24"/>
+  </g>
+  <g id="LWPOLYLINE-965" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2335.82 263.23 2335.82 262.9 2335.82 262.56 2335.82 262.23 2335.82 261.9 2335.49 261.9 2335.16 261.9 2335.16 261.56 2334.82 261.56 2334.49 261.56 2334.16 261.56 2333.82 261.56 2333.82 261.23 2333.48 261.23 2333.15 261.23 2332.83 261.23 2332.49 261.23 2332.15 260.89 2331.82 260.89 2331.49 260.89 2331.15 260.89 2330.82 260.89 2330.49 260.57 2330.15 260.57 2329.82 260.57 2329.49 260.57 2329.16 260.57 2328.82 260.57 2328.48 260.57 2328.15 260.57 2327.81 260.57 2327.48 260.57 2327.15 260.57 2326.82 260.57 2326.48 260.89 2326.15 261.23 2325.82 261.56 2325.82 261.9 2325.48 262.23 2325.48 262.56 2325.48 262.9 2325.15 263.56 2325.15 264.23 2325.15 264.9"/>
+  </g>
+  <g id="LWPOLYLINE-966" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2336.16 260.89 2335.49 260.56 2334.82 260.56 2334.16 260.23 2333.82 260.23 2333.16 259.89 2332.49 259.89 2332.15 259.89 2331.49 259.89 2331.15 259.56 2330.82 259.56 2330.15 259.56 2329.82 259.23 2329.49 259.23 2328.82 259.23 2328.48 259.23 2328.15 259.23 2327.81 259.23 2327.49 258.89 2327.15 258.89 2326.82 258.89 2326.48 258.89 2326.15 259.23 2325.81 259.23 2325.48 259.23 2325.15 259.56 2324.81 260.23 2324.48 260.89 2324.15 261.89 2324.15 263.24 2323.81 264.9 2323.48 266.57 2323.48 267.9 2323.81 268.91 2323.81 269.56 2324.15 269.9 2324.15 270.57 2324.48 270.57 2324.81 270.9 2325.15 270.9 2325.48 271.24 2325.81 271.24 2326.15 271.24 2326.48 271.24 2326.82 271.24 2327.15 271.24 2327.49 271.24 2328.15 271.24 2328.48 271.24 2328.82 271.24 2329.15 271.24 2329.82 271.24 2330.15 271.57 2330.82 271.57 2331.15 271.57 2331.82 271.57 2332.49 271.57 2333.16 271.57 2333.48 271.57 2334.16 271.24 2335.16 271.24"/>
+  </g>
+  <g id="LWPOLYLINE-967" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2334.82 273.57 2332.82 273.24 2331.15 272.91 2329.82 272.57 2328.82 272.24 2327.82 272.24 2327.14 271.9 2326.15 271.23 2325.48 270.91"/>
+  </g>
+  <g id="LWPOLYLINE-968" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2335.49 268.9 2335.16 269.24 2335.16 269.57 2335.16 269.9 2334.82 269.9 2334.82 270.23 2334.49 270.23 2334.16 270.23 2333.82 270.23 2333.49 270.23 2333.15 270.23 2332.82 270.23 2332.49 270.23 2332.15 270.23 2331.82 270.23 2331.49 270.23 2331.15 270.23 2330.82 270.23 2330.49 270.23 2330.15 270.23 2329.82 270.23 2329.48 270.23 2329.16 270.23 2328.82 270.23 2328.48 270.23 2328.15 270.23 2327.82 270.23 2327.48 269.9 2327.15 269.9 2326.82 269.9 2326.49 269.9 2326.15 269.57 2325.81 269.57 2325.81 269.24 2325.48 269.24 2325.48 268.9 2325.15 268.9 2325.15 268.57 2325.15 268.24 2325.15 267.9 2325.15 267.57 2325.15 267.23 2324.81 266.9 2325.15 266.24 2325.15 265.57 2325.15 264.9"/>
+  </g>
+  <g id="LWPOLYLINE-969" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2335.16" y1="271.24" x2="2335.49" y2="266.23"/>
+  </g>
+  <g id="LWPOLYLINE-970" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1038.63 540.49 1039.29 542.15 1037.96 542.49 1037.63 540.82 1038.63 540.49"/>
+  </g>
+  <g id="LWPOLYLINE-971" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1037.63 540.82 1037.96 542.49 1035.96 543.16 1035.29 541.49 1037.63 540.82"/>
+  </g>
+  <g id="LWPOLYLINE-972" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="955.22 567.84 957.56 574.18 961.22 573.18 958.89 566.51 955.22 567.84"/>
+  </g>
+  <g id="LWPOLYLINE-973" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1035.62" y1="541.82" x2="959.22" y2="566.85"/>
+  </g>
+  <g id="LWPOLYLINE-974" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1035.96" y1="542.82" x2="959.56" y2="568.17"/>
+  </g>
+  <g id="LWPOLYLINE-975" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="876.11" y="593.65" width="1.06" height="2.11" transform="translate(-143.08 307.74) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-976" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="879.15" y1="593.2" x2="955.55" y2="568.18"/>
+  </g>
+  <g id="LWPOLYLINE-977" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="879.48" y1="594.2" x2="955.88" y2="569.18"/>
+  </g>
+  <g id="LWPOLYLINE-978" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="876.81 593.53 877.48 595.54 879.48 594.86 879.15 592.87 876.81 593.53"/>
+  </g>
+  <g id="LWPOLYLINE-979" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="955.22 567.84 957.56 574.18 961.22 573.18 958.89 566.51 955.22 567.84"/>
+  </g>
+  <g id="LWPOLYLINE-980" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.42 495.44 1177.42 502.12 1173.75 503.12 1171.75 496.78 1175.42 495.44"/>
+  </g>
+  <g id="LWPOLYLINE-981" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1254.83 469.42 1255.49 471.09 1254.49 471.43 1253.82 469.75 1254.83 469.42"/>
+  </g>
+  <g id="LWPOLYLINE-982" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1251.82" y1="470.75" x2="1175.42" y2="495.78"/>
+  </g>
+  <g id="LWPOLYLINE-983" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1252.16" y1="471.76" x2="1175.76" y2="496.78"/>
+  </g>
+  <g id="LWPOLYLINE-984" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1253.83 469.75 1254.49 471.42 1252.16 472.09 1251.49 470.42 1253.83 469.75"/>
+  </g>
+  <g id="LWPOLYLINE-985" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.42 495.44 1177.42 502.12 1173.75 503.12 1171.75 496.78 1175.42 495.44"/>
+  </g>
+  <g id="LWPOLYLINE-986" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1092.32" y="522.58" width="1.05" height="2.11" transform="translate(-109.51 372.46) rotate(-18.43)"/>
+  </g>
+  <g id="LWPOLYLINE-987" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1093.01 522.47 1093.68 524.47 1096.01 523.8 1095.35 521.8 1093.01 522.47"/>
+  </g>
+  <g id="LWPOLYLINE-988" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.42 495.44 1177.42 502.12 1173.75 503.12 1171.75 496.78 1175.42 495.44"/>
+  </g>
+  <g id="LWPOLYLINE-989" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1095.35" y1="522.14" x2="1171.75" y2="497.12"/>
+  </g>
+  <g id="LWPOLYLINE-990" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1095.68" y1="523.14" x2="1172.08" y2="498.12"/>
+  </g>
+  <g id="LWPOLYLINE-991" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1175.42 495.44 1177.42 502.12 1173.75 503.12 1171.75 496.78 1175.42 495.44"/>
+  </g>
+  <g id="LWPOLYLINE-992" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1387.95 425.71 1389.95 432.05 1393.62 431.05 1391.62 424.38 1387.95 425.71"/>
+  </g>
+  <g id="LWPOLYLINE-993" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1308.21 451.74 1308.88 453.74 1309.88 453.07 1309.54 451.4 1308.21 451.74"/>
+  </g>
+  <g id="LWPOLYLINE-994" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.54" y1="451.07" x2="1387.95" y2="426.05"/>
+  </g>
+  <g id="LWPOLYLINE-995" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1311.88" y1="452.07" x2="1388.28" y2="427.05"/>
+  </g>
+  <g id="LWPOLYLINE-996" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1309.54 451.4 1309.88 453.07 1312.22 452.4 1311.54 450.74 1309.54 451.4"/>
+  </g>
+  <g id="LWPOLYLINE-997" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1387.95 425.71 1391.62 424.38 1393.62 431.05 1389.95 432.05 1387.95 425.71 1391.62 424.38 1393.62 431.05 1389.95 432.05 1387.95 425.71 1389.95 432.05 1393.62 431.05 1391.62 424.38 1387.95 425.71"/>
+  </g>
+  <g id="LWPOLYLINE-998" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1471.03 398.35 1471.69 400.02 1470.69 400.36 1470.03 398.69 1471.03 398.35"/>
+  </g>
+  <g id="LWPOLYLINE-999" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1470.03 398.69 1470.69 400.36 1468.36 401.03 1468.02 399.36 1470.03 398.69"/>
+  </g>
+  <g id="LWPOLYLINE-1000" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1468.02" y1="399.69" x2="1391.62" y2="424.71"/>
+  </g>
+  <g id="LWPOLYLINE-1001" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1468.36" y1="400.69" x2="1391.96" y2="425.71"/>
+  </g>
+  <g id="LWPOLYLINE-1002" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1607.82 353.31 1609.82 359.98 1606.15 360.99 1604.15 354.65 1607.82 353.31"/>
+  </g>
+  <g id="LWPOLYLINE-1003" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1687.22 327.29 1687.89 328.96 1686.9 329.29 1686.23 327.62 1687.22 327.29"/>
+  </g>
+  <g id="LWPOLYLINE-1004" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1684.22" y1="328.62" x2="1607.82" y2="353.65"/>
+  </g>
+  <g id="LWPOLYLINE-1005" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1684.56" y1="329.62" x2="1608.15" y2="354.65"/>
+  </g>
+  <g id="LWPOLYLINE-1006" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1686.22 327.62 1686.89 329.29 1684.89 329.96 1684.22 328.29 1686.22 327.62"/>
+  </g>
+  <g id="LWPOLYLINE-1007" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1607.82 353.31 1604.15 354.65 1606.15 360.99 1609.82 359.98 1607.82 353.31 1604.15 354.65 1606.15 360.99 1609.82 359.98 1607.82 353.31 1609.82 359.98 1606.15 360.99 1604.15 354.65 1607.82 353.31"/>
+  </g>
+  <g id="LWPOLYLINE-1008" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1524.74 380.67 1525.08 382.34 1526.41 382 1525.74 380.34 1524.74 380.67"/>
+  </g>
+  <g id="LWPOLYLINE-1009" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1525.74 380.34 1526.41 382.01 1528.42 381.34 1527.74 379.67 1525.74 380.34"/>
+  </g>
+  <g id="LWPOLYLINE-1010" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1527.75" y1="380" x2="1604.15" y2="354.99"/>
+  </g>
+  <g id="LWPOLYLINE-1011" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1528.08" y1="381" x2="1604.48" y2="355.99"/>
+  </g>
+  <g id="LWPOLYLINE-1012" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1820.35 283.58 1822.69 289.92 1826.36 288.92 1824.02 282.25 1820.35 283.58"/>
+  </g>
+  <g id="LWPOLYLINE-1013" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1740.94 309.61 1741.61 311.27 1742.61 310.94 1741.94 309.27 1740.94 309.61"/>
+  </g>
+  <g id="LWPOLYLINE-1014" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1744.28" y1="308.94" x2="1820.35" y2="283.91"/>
+  </g>
+  <g id="LWPOLYLINE-1015" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1744.61" y1="309.94" x2="1820.68" y2="284.92"/>
+  </g>
+  <g id="LWPOLYLINE-1016" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1741.94 309.27 1742.61 310.94 1744.62 310.27 1743.95 308.6 1741.94 309.27"/>
+  </g>
+  <g id="LWPOLYLINE-1017" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1820.35 283.58 1824.02 282.25 1826.36 288.92 1822.69 289.92 1820.35 283.58 1824.02 282.25 1826.36 288.92 1822.69 289.92 1820.35 283.58 1822.69 289.92 1826.36 288.92 1824.02 282.25 1820.35 283.58"/>
+  </g>
+  <g id="LWPOLYLINE-1018" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1903.43 256.22 1904.09 257.89 1903.09 258.22 1902.43 256.56 1903.43 256.22"/>
+  </g>
+  <g id="LWPOLYLINE-1019" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1902.42 256.56 1903.09 258.22 1901.09 258.9 1900.42 257.22 1902.42 256.56"/>
+  </g>
+  <g id="LWPOLYLINE-1020" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1900.42" y1="257.56" x2="1824.02" y2="282.58"/>
+  </g>
+  <g id="LWPOLYLINE-1021" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1900.76" y1="258.56" x2="1824.36" y2="283.59"/>
+  </g>
+  <g id="LWPOLYLINE-1022" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1957.14 238.54 1957.81 240.21 1958.81 239.87 1958.14 238.21 1957.14 238.54"/>
+  </g>
+  <g id="LWPOLYLINE-1023" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1958.14 238.21 1958.81 239.87 1960.82 239.2 1960.14 237.54 1958.14 238.21"/>
+  </g>
+  <g id="LWPOLYLINE-1024" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1960.48" y1="237.87" x2="2035.88" y2="212.85"/>
+  </g>
+  <g id="LWPOLYLINE-1025" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1960.81" y1="238.88" x2="2036.21" y2="214.19"/>
+  </g>
+  <g id="LWPOLYLINE-1026" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2116.62 186.16 2117.29 187.82 2116.29 188.16 2115.62 186.49 2116.62 186.16"/>
+  </g>
+  <g id="LWPOLYLINE-1027" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2115.62 186.49 2116.29 188.16 2113.95 188.83 2113.62 187.16 2115.62 186.49"/>
+  </g>
+  <g id="LWPOLYLINE-1028" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.62" y1="187.49" x2="2039.55" y2="211.85"/>
+  </g>
+  <g id="LWPOLYLINE-1029" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2113.95" y1="188.49" x2="2039.88" y2="212.85"/>
+  </g>
+  <g id="CIRCLE-20" data-name="CIRCLE">
+    <circle class="cls-3" cx="2211.55" cy="349.14" r="2.84"/>
+  </g>
+  <g id="LWPOLYLINE-1030" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2210.71" y1="351.98" x2="2208.7" y2="352.65"/>
+  </g>
+  <g id="CIRCLE-21" data-name="CIRCLE">
+    <circle class="cls-3" cx="2211.54" cy="349.14" r="2.17"/>
+  </g>
+  <g id="LWPOLYLINE-1031" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2210.83,347.1c-.04.07-.08.14-.12.21l.67,1.67-2,.67c.06.16.13.32.22.47"/>
+  </g>
+  <g id="LWPOLYLINE-1032" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2209.71,350.31l1.67-.66.67,1.66c.07-.04.14-.07.21-.12"/>
+  </g>
+  <g id="SPLINE-40" data-name="SPLINE">
+    <path class="cls-3" d="M2212.26,351.19c.08-.03.17-.06.25-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1033" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2212.71,351.31l-.66-2,1.66-.66c-.06-.17-.13-.32-.22-.47"/>
+  </g>
+  <g id="LWPOLYLINE-1034" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2213.71 348.31 2211.71 348.97 2211.04 346.98"/>
+  </g>
+  <g id="SPLINE-41" data-name="SPLINE">
+    <path class="cls-3" d="M2211.09,347.02c-.09.02-.17.04-.27.07"/>
+  </g>
+  <g id="LWPOLYLINE-1035" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2208.71 352.65 2207.04 348.64 2209.38 347.64"/>
+  </g>
+  <g id="LWPOLYLINE-1036" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2214.05 350.64 2216.39 349.98 2214.71 345.97 2212.38 346.64"/>
+  </g>
+  <g id="CIRCLE-22" data-name="CIRCLE">
+    <circle class="cls-3" cx="367.17" cy="783.88" r="2.84"/>
+  </g>
+  <g id="LWPOLYLINE-1037" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="370.01" y1="784.71" x2="370.68" y2="787.05"/>
+  </g>
+  <g id="CIRCLE-23" data-name="CIRCLE">
+    <circle class="cls-3" cx="367.17" cy="783.87" r="2.17"/>
+  </g>
+  <g id="LWPOLYLINE-1038" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M365.34,784.71l2-.33.33,1.67c.15-.06.29-.13.43-.21"/>
+  </g>
+  <g id="LWPOLYLINE-1039" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="368.34 786.05 367.67 784.04 369.68 783.38"/>
+  </g>
+  <g id="SPLINE-42" data-name="SPLINE">
+    <path class="cls-3" d="M369.3,783.46c-.02-.09-.04-.17-.07-.27"/>
+  </g>
+  <g id="SPLINE-43" data-name="SPLINE">
+    <path class="cls-3" d="M369.23,783.2c-.02-.08-.06-.17-.1-.25"/>
+  </g>
+  <g id="LWPOLYLINE-1040" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="369.34 783.04 367.67 783.71 367 781.71"/>
+  </g>
+  <g id="LWPOLYLINE-1041" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M366.76,781.75c-.15.08-.29.18-.42.29l.67,1.67-1.67.67"/>
+  </g>
+  <g id="ARC-59" data-name="ARC">
+    <path class="cls-3" d="M365.04,784.29c.02.09.04.17.07.26"/>
+  </g>
+  <g id="SPLINE-44" data-name="SPLINE">
+    <path class="cls-3" d="M365.11,784.55c.02.09.06.17.1.25"/>
+  </g>
+  <g id="LWPOLYLINE-1042" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="370.68 787.05 366.67 788.38 365.67 786.05"/>
+  </g>
+  <g id="LWPOLYLINE-1043" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="369.01" y1="781.71" x2="368.01" y2="778.38"/>
+  </g>
+  <g id="LWPOLYLINE-1044" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="364.67" y1="783.04" x2="363.67" y2="779.71"/>
+  </g>
+  <g id="CIRCLE-24" data-name="CIRCLE">
+    <circle class="cls-3" cx="365.18" cy="777.21" r="2.84"/>
+  </g>
+  <g id="LWPOLYLINE-1045" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="508.47" y1="963.21" x2="508.47" y2="981.23"/>
+  </g>
+  <g id="LWPOLYLINE-1046" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="513.81 1020.93 508.47 1020.93 508.47 1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-1047" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="513.81" y1="961.87" x2="513.81" y2="981.23"/>
+  </g>
+  <g id="LWPOLYLINE-1048" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="513.81" y1="1020.93" x2="513.81" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-1049" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="475.77 1079.98 503.8 1108.01 502.46 1109.68 474.44 1081.32"/>
+  </g>
+  <g id="LWPOLYLINE-1050" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="476.77 1079.32 473.44 1082.65 470.77 1086.32 468.43 1090.33 466.43 1094.66 465.1 1099 464.43 1103.67 464.1 1108.01"/>
+  </g>
+  <g id="LWPOLYLINE-1051" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="480.44 1009.25 508.47 981.23 510.14 982.56 481.78 1010.59"/>
+  </g>
+  <g id="LWPOLYLINE-1052" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="479.78 1008.25 483.11 1011.58 486.78 1014.26 490.79 1016.6 495.12 1018.6 499.46 1019.93 503.8 1020.6 508.47 1020.93"/>
+  </g>
+  <g id="LWPOLYLINE-1053" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="631.92" y1="743.01" x2="613.9" y2="687.29"/>
+  </g>
+  <g id="LWPOLYLINE-1054" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="621.57" y1="746.34" x2="603.22" y2="690.96"/>
+  </g>
+  <g id="LWPOLYLINE-1055" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="610.9" y1="750.01" x2="592.88" y2="694.29"/>
+  </g>
+  <g id="LWPOLYLINE-1056" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="600.55" y1="753.35" x2="582.2" y2="697.63"/>
+  </g>
+  <g id="LWPOLYLINE-1057" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="589.88" y1="756.68" x2="571.86" y2="701.3"/>
+  </g>
+  <g id="LWPOLYLINE-1058" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="579.54" y1="760.36" x2="561.19" y2="704.64"/>
+  </g>
+  <g id="LWPOLYLINE-1059" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="569.19" y1="763.69" x2="550.84" y2="707.97"/>
+  </g>
+  <g id="LWPOLYLINE-1060" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="558.52" y1="767.36" x2="540.17" y2="711.64"/>
+  </g>
+  <g id="LWPOLYLINE-1061" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="625.24 714.98 624.58 713.65 622.9 712.98 621.24 713.65 620.57 714.98 621.24 716.65 622.9 717.32 624.58 716.65 625.24 714.98"/>
+  </g>
+  <g id="LWPOLYLINE-1062" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="622.91 714.98 496.79 756.69 506.47 761.69"/>
+  </g>
+  <g id="LWPOLYLINE-1063" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="496.79" y1="756.68" x2="501.8" y2="747.34"/>
+  </g>
+  <g id="LWPOLYLINE-1064" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="487.45 728.99 506.13 784.38 491.46 763.7 493.79 759.02 483.11 760.02 485.45 755.02 470.77 734.33"/>
+  </g>
+  <g id="LWPOLYLINE-1065" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="548.17" y1="770.7" x2="529.82" y2="714.98"/>
+  </g>
+  <g id="LWPOLYLINE-1066" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="537.5" y1="774.03" x2="519.48" y2="718.65"/>
+  </g>
+  <g id="LWPOLYLINE-1067" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="381.02 772.37 379.35 771.37 377.35 771.37 375.01 772.37 373.34 773.36 372.68 775.04 373.01 776.37 374.01 777.37 375.01 777.71 376.35 778.04 380.35 778.04 381.69 778.04 382.35 778.37 383.36 779.37 384.02 781.37 383.36 783.04 381.69 784.04 379.35 785.05 377.35 785.05 375.68 784.04"/>
+  </g>
+  <g id="LWPOLYLINE-1068" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="388.36 782.04 384.02 769.36 389.36 767.7 391.36 767.7 392.36 768.03 393.36 769.03 394.03 770.7 393.7 772.37 393.36 773.04 391.69 774.03 386.36 776.04"/>
+  </g>
+  <g id="LWPOLYLINE-1069" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="339.98 875.8 375.68 893.15 375.01 895.15 339.31 877.46"/>
+  </g>
+  <g id="LWPOLYLINE-1070" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="340.65 874.8 338.65 878.8 337.32 883.47 336.31 887.81 335.98 892.48 335.98 897.15 336.98 901.82 337.98 906.15"/>
+  </g>
+  <g id="LWPOLYLINE-1071" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="191.51 846.43 215.53 848.78 218.87 817.74"/>
+  </g>
+  <g id="LWPOLYLINE-1072" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M264.81,1025.81c-.16-.52-.35-1.04-.56-1.54l-7.01-15.01-4,2-3,1.33-3.01,1.33-4,2,7.01,15.02"/>
+  </g>
+  <g id="LWPOLYLINE-1073" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="264.91" y1="1034.94" x2="264.91" y2="1034.94"/>
+  </g>
+  <g id="LWPOLYLINE-1074" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.58" y1="1032.61" x2="262.58" y2="1032.61"/>
+  </g>
+  <g id="ARC-60" data-name="ARC">
+    <path class="cls-3" d="M265.7,1032.88c.24-1.17.28-2.37.11-3.56"/>
+  </g>
+  <g id="ARC-61" data-name="ARC">
+    <path class="cls-3" d="M255.53,1037.54c1.11.7,2.36,1.15,3.66,1.32"/>
+  </g>
+  <g id="ARC-62" data-name="ARC">
+    <path class="cls-3" d="M252.65,1034.91c.88,1.05,1.92,1.95,3.08,2.68"/>
+  </g>
+  <g id="ARC-63" data-name="ARC">
+    <path class="cls-3" d="M250.31,1030.61c.69,1.46,1.56,2.82,2.59,4.06"/>
+  </g>
+  <g id="SPLINE-45" data-name="SPLINE">
+    <path class="cls-3" d="M257.71,1037.84c.14-.11.21-.28.19-.45"/>
+  </g>
+  <g id="ARC-64" data-name="ARC">
+    <path class="cls-3" d="M257.23,1037.91c.16.06.35.03.48-.08"/>
+  </g>
+  <g id="LWPOLYLINE-1075" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="258.24" y1="1037.61" x2="257.91" y2="1034.94"/>
+  </g>
+  <g id="SPLINE-46" data-name="SPLINE">
+    <path class="cls-3" d="M257.57,1035.05c-.02-.16-.11-.29-.25-.38"/>
+  </g>
+  <g id="ARC-65" data-name="ARC">
+    <path class="cls-3" d="M255.76,1032.92c.52.57,1.12,1.05,1.79,1.43"/>
+  </g>
+  <g id="ARC-66" data-name="ARC">
+    <path class="cls-3" d="M262.46,1032.07c.14-.76.16-1.53.05-2.29"/>
+  </g>
+  <g id="SPLINE-47" data-name="SPLINE">
+    <path class="cls-3" d="M262.58,1032.02c-.03.16.02.31.13.44"/>
+  </g>
+  <g id="LWPOLYLINE-1076" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="262.91" y1="1032.94" x2="264.58" y2="1034.61"/>
+  </g>
+  <g id="SPLINE-48" data-name="SPLINE">
+    <path class="cls-3" d="M264.38,1034.45c.12.13.29.18.46.15"/>
+  </g>
+  <g id="SPLINE-49" data-name="SPLINE">
+    <path class="cls-3" d="M264.84,1034.6c.17-.02.31-.15.37-.31"/>
+  </g>
+  <g id="LWPOLYLINE-1077" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M262.52,1022.04c-.84-.88-1.83-1.6-2.91-2.14-.65-.3-1.33-.51-2.03-.64l-.67-1.67-7.01,3.34.67,1.66"/>
+  </g>
+  <g id="ARC-67" data-name="ARC">
+    <path class="cls-3" d="M263.09,1035.43c.34-.54.61-1.12.8-1.72"/>
+  </g>
+  <g id="ARC-68" data-name="ARC">
+    <path class="cls-3" d="M257.69,1036.77c.55.22,1.13.36,1.72.44"/>
+  </g>
+  <g id="LWPOLYLINE-1078" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="340.31" y1="792.72" x2="342.66" y2="798.39"/>
+  </g>
+  <g id="CIRCLE-25" data-name="CIRCLE">
+    <circle class="cls-3" cx="333.14" cy="794.22" r="1.51"/>
+  </g>
+  <g id="LWPOLYLINE-1079" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="340.98" y1="789.71" x2="341.98" y2="792.06"/>
+  </g>
+  <g id="CIRCLE-26" data-name="CIRCLE">
+    <circle class="cls-3" cx="341.82" cy="792.87" r=".82"/>
+  </g>
+  <g id="SPLINE-50" data-name="SPLINE">
+    <path class="cls-3" d="M339.83,788.11c-.43.18-.63.67-.45,1.09"/>
+  </g>
+  <g id="SPLINE-51" data-name="SPLINE">
+    <path class="cls-3" d="M340.47,789.65c.43-.17.62-.66.45-1.09"/>
+  </g>
+  <g id="ARC-69" data-name="ARC">
+    <path class="cls-3" d="M340.92,788.56c-.18-.42-.66-.62-1.09-.45"/>
+  </g>
+  <g id="ARC-70" data-name="ARC">
+    <path class="cls-3" d="M339.38,789.2c.17.42.65.62,1.07.45,0,0,.01,0,.02,0"/>
+  </g>
+  <g id="LWPOLYLINE-1080" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="340.31 790.05 335.64 793.05 335.98 793.72 341.32 792.72"/>
+  </g>
+  <g id="LWPOLYLINE-1081" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="346.99" y1="799.39" x2="339.31" y2="781.04"/>
+  </g>
+  <g id="LWPOLYLINE-1082" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M330.64,807.73l15.68-6.34c.82-.33,1.21-1.27.88-2.09"/>
+  </g>
+  <g id="ARC-71" data-name="ARC">
+    <path class="cls-3" d="M328.75,807.15c.32.76,1.2,1.12,1.97.81"/>
+  </g>
+  <g id="LWPOLYLINE-1083" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="321.3" y1="788.72" x2="328.97" y2="807.07"/>
+  </g>
+  <g id="ARC-72" data-name="ARC">
+    <path class="cls-3" d="M321.88,786.5c-.76.32-1.12,1.2-.8,1.97"/>
+  </g>
+  <g id="LWPOLYLINE-1084" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="337.65" y1="780.37" x2="321.96" y2="787.04"/>
+  </g>
+  <g id="ARC-73" data-name="ARC">
+    <path class="cls-3" d="M339.53,780.96c-.32-.76-1.2-1.12-1.97-.81"/>
+  </g>
+  <g id="ARC-74" data-name="ARC">
+    <path class="cls-3" d="M341.25,801.84c1.44-.61,2.12-2.27,1.51-3.71,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1085" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M341.32,802.06l-8.67,3.34s0,0,0,0c-1.43.66-3.13.03-3.79-1.4"/>
+  </g>
+  <g id="LWPOLYLINE-1086" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="329.31" y1="804.06" x2="323.63" y2="790.72"/>
+  </g>
+  <g id="ARC-75" data-name="ARC">
+    <path class="cls-3" d="M324.7,786.93c-1.44.61-2.12,2.27-1.51,3.71"/>
+  </g>
+  <g id="LWPOLYLINE-1087" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="324.97" y1="787.05" x2="333.64" y2="783.38"/>
+  </g>
+  <g id="LWPOLYLINE-1088" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="336.98" y1="785.04" x2="339.65" y2="790.72"/>
+  </g>
+  <g id="ARC-76" data-name="ARC">
+    <path class="cls-3" d="M337.09,784.78c-.61-1.44-2.27-2.12-3.71-1.51,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1089" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1301.87" y1="465.75" x2="1303.54" y2="471.09"/>
+  </g>
+  <g id="LWPOLYLINE-1090" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="293.6 888.47 295.94 888.47 295.94 893.81 280.25 893.81 280.59 888.14 282.59 888.14 293.27 885.47"/>
+  </g>
+  <g id="ARC-77" data-name="ARC">
+    <path class="cls-3" d="M293.6,888.13c.01-.98-.1-1.95-.34-2.9"/>
+  </g>
+  <g id="LWPOLYLINE-1091" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="633.92" y1="749.34" x2="634.92" y2="751.35"/>
+  </g>
+  <g id="LWPOLYLINE-1092" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="873.14" y1="880.13" x2="873.14" y2="602.21"/>
+  </g>
+  <g id="LWPOLYLINE-1093" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="751.36" y1="880.13" x2="751.36" y2="875.8"/>
+  </g>
+  <g id="LWPOLYLINE-1094" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.26" y1="581.86" x2="1828.7" y2="581.86"/>
+  </g>
+  <g id="LWPOLYLINE-1095" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.26" y1="586.53" x2="1828.7" y2="586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1096" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="868.8" y1="875.8" x2="868.8" y2="603.55"/>
+  </g>
+  <g id="LWPOLYLINE-1097" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.71" y1="1066.31" x2="406.71" y2="1067.97"/>
+  </g>
+  <g id="ARC-78" data-name="ARC">
+    <path class="cls-3" d="M406.49,1060.62c-.27,2.45-.41,4.91-.44,7.37"/>
+  </g>
+  <g id="LWPOLYLINE-1098" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="408.71" y1="1066.31" x2="408.71" y2="1071.64"/>
+  </g>
+  <g id="LWPOLYLINE-1099" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M409.38,1077.98v-18.01c-.25-1.32-1.52-2.2-2.84-1.98-1.91,0-3.81.27-5.63.84"/>
+  </g>
+  <g id="ARC-79" data-name="ARC">
+    <path class="cls-3" d="M396.26,1061.3c-1.3.98-2.37,2.23-3.15,3.65"/>
+  </g>
+  <g id="ARC-80" data-name="ARC">
+    <path class="cls-3" d="M400.77,1058.64c-1.63.51-3.16,1.3-4.52,2.33"/>
+  </g>
+  <g id="ARC-81" data-name="ARC">
+    <path class="cls-3" d="M406.38,1060.8c0-.64-.52-1.17-1.17-1.17"/>
+  </g>
+  <g id="SPLINE-52" data-name="SPLINE">
+    <path class="cls-3" d="M406.88,1065.97c-.1,0-.16.08-.16.16"/>
+  </g>
+  <g id="SPLINE-53" data-name="SPLINE">
+    <path class="cls-3" d="M408.71,1066.14c0-.1-.07-.16-.16-.16"/>
+  </g>
+  <g id="LWPOLYLINE-1100" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="407.04" y1="1065.97" x2="408.71" y2="1065.97"/>
+  </g>
+  <g id="LWPOLYLINE-1101" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M403.21,1069.31s0,0,0,0c-.28-.04-.46-.3-.42-.58s.3-.46.58-.42l4-.33c.17-.01.33,0,.49.06.1.04.19.1.27.18.08.08.14.17.18.27.04.1.06.21.06.32,0,.11-.02.22-.06.32-.04.1-.1.19-.18.27-.08.08-.17.14-.27.18"/>
+  </g>
+  <g id="LWPOLYLINE-1102" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.71" y1="1069.97" x2="406.71" y2="1071.64"/>
+  </g>
+  <g id="SPLINE-54" data-name="SPLINE">
+    <path class="cls-3" d="M408.55,1071.64c.1,0,.17-.08.17-.16"/>
+  </g>
+  <g id="SPLINE-55" data-name="SPLINE">
+    <path class="cls-3" d="M406.71,1071.48c0,.1.08.16.16.16"/>
+  </g>
+  <g id="LWPOLYLINE-1103" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="407.04" y1="1071.98" x2="408.71" y2="1071.98"/>
+  </g>
+  <g id="SPLINE-56" data-name="SPLINE">
+    <path class="cls-3" d="M407.54,1067.97c-.06,0-.13,0-.19.02"/>
+  </g>
+  <g id="SPLINE-57" data-name="SPLINE">
+    <path class="cls-3" d="M407.54,1069.64c.11,0,.22-.02.32-.06"/>
+  </g>
+  <g id="SPLINE-58" data-name="SPLINE">
+    <path class="cls-3" d="M408.71,1068.81c0-.15-.03-.31-.09-.45"/>
+  </g>
+  <g id="LWPOLYLINE-1104" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="403.37" y1="1069.64" x2="407.71" y2="1069.97"/>
+  </g>
+  <g id="ARC-82" data-name="ARC">
+    <path class="cls-3" d="M393.11,1072.67c.78,1.43,1.85,2.67,3.15,3.65"/>
+  </g>
+  <g id="ARC-83" data-name="ARC">
+    <path class="cls-3" d="M396.25,1076.64c1.36,1.03,2.89,1.82,4.52,2.33"/>
+  </g>
+  <g id="LWPOLYLINE-1105" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="386.69" y1="1138.04" x2="386.69" y2="1046.28"/>
+  </g>
+  <g id="LWPOLYLINE-1106" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.38" y1="1109.01" x2="406.38" y2="1107.01"/>
+  </g>
+  <g id="ARC-84" data-name="ARC">
+    <path class="cls-3" d="M405.71,1107c.03,2.46.17,4.92.44,7.37"/>
+  </g>
+  <g id="LWPOLYLINE-1107" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="408.38" y1="1109.01" x2="408.38" y2="1103.67"/>
+  </g>
+  <g id="LWPOLYLINE-1108" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M409.04,1097.34v17.67c-.25,1.32-1.52,2.2-2.85,1.98-1.91,0-3.8-.27-5.63-.84"/>
+  </g>
+  <g id="ARC-85" data-name="ARC">
+    <path class="cls-3" d="M392.78,1110.03c.78,1.43,1.85,2.67,3.15,3.65"/>
+  </g>
+  <g id="ARC-86" data-name="ARC">
+    <path class="cls-3" d="M395.92,1114.01c1.36,1.03,2.89,1.82,4.52,2.33"/>
+  </g>
+  <g id="ARC-87" data-name="ARC">
+    <path class="cls-3" d="M404.87,1115.35c.64,0,1.17-.52,1.17-1.17"/>
+  </g>
+  <g id="SPLINE-59" data-name="SPLINE">
+    <path class="cls-3" d="M406.04,1108.84c0,.1.08.16.16.16"/>
+  </g>
+  <g id="SPLINE-60" data-name="SPLINE">
+    <path class="cls-3" d="M407.88,1109.01c.1,0,.17-.08.17-.16"/>
+  </g>
+  <g id="LWPOLYLINE-1109" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.38" y1="1109.34" x2="408.04" y2="1109.34"/>
+  </g>
+  <g id="LWPOLYLINE-1110" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M407.98,1105.86c-.04-.1-.1-.19-.18-.27-.12-.11-.27-.19-.42-.24l-4.5.33c-.28.05-.46.31-.41.59s.31.46.58.41l4,.67c-.17-.02-.33-.08-.46-.19"/>
+  </g>
+  <g id="LWPOLYLINE-1111" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.38" y1="1105.34" x2="406.38" y2="1103.67"/>
+  </g>
+  <g id="SPLINE-61" data-name="SPLINE">
+    <path class="cls-3" d="M408.04,1103.51c0-.1-.08-.16-.16-.16"/>
+  </g>
+  <g id="SPLINE-62" data-name="SPLINE">
+    <path class="cls-3" d="M406.21,1103.34c-.1,0-.16.08-.16.16"/>
+  </g>
+  <g id="LWPOLYLINE-1112" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="406.38" y1="1103.34" x2="408.04" y2="1103.34"/>
+  </g>
+  <g id="SPLINE-63" data-name="SPLINE">
+    <path class="cls-3" d="M407.02,1106.99c.06.01.13.02.19.02"/>
+  </g>
+  <g id="SPLINE-64" data-name="SPLINE">
+    <path class="cls-3" d="M407.21,1107.01c.11,0,.21-.02.32-.06"/>
+  </g>
+  <g id="SPLINE-65" data-name="SPLINE">
+    <path class="cls-3" d="M408.04,1106.17c0-.11-.02-.21-.06-.32"/>
+  </g>
+  <g id="ARC-88" data-name="ARC">
+    <path class="cls-3" d="M407.53,1105.4c-.1-.04-.21-.06-.32-.06"/>
+  </g>
+  <g id="SPLINE-66" data-name="SPLINE">
+    <path class="cls-3" d="M407.21,1107.34c.15,0,.31-.03.45-.09"/>
+  </g>
+  <g id="SPLINE-67" data-name="SPLINE">
+    <path class="cls-3" d="M408.38,1106.17c0-.15-.03-.31-.09-.45"/>
+  </g>
+  <g id="ARC-89" data-name="ARC">
+    <path class="cls-3" d="M409.01,1097.09c-.22-1.34-1.47-2.25-2.81-2.06"/>
+  </g>
+  <g id="ARC-90" data-name="ARC">
+    <path class="cls-3" d="M395.93,1098.66c-1.3.98-2.37,2.23-3.15,3.65"/>
+  </g>
+  <g id="ARC-91" data-name="ARC">
+    <path class="cls-3" d="M400.43,1096.01c-1.63.51-3.16,1.3-4.52,2.33"/>
+  </g>
+  <g id="ARC-92" data-name="ARC">
+    <path class="cls-3" d="M406.21,1095.33c-1.91,0-3.81.29-5.64.87"/>
+  </g>
+  <g id="LWPOLYLINE-1113" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="300.95 1056.96 289.93 1062.3 264.92 1053.63"/>
+  </g>
+  <g id="LWPOLYLINE-1114" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="288.27 878.46 288.27 862.78 294.94 862.78 297.27 863.79 297.94 864.46 298.61 865.79 298.61 868.12 297.94 869.46 297.27 870.13 294.94 871.12 288.27 871.12"/>
+  </g>
+  <g id="LWPOLYLINE-1115" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="303.61" y1="878.46" x2="303.61" y2="862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1116" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="313.96" y1="862.78" x2="313.96" y2="878.46"/>
+  </g>
+  <g id="LWPOLYLINE-1117" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="303.61" y1="870.12" x2="313.96" y2="870.12"/>
+  </g>
+  <g id="LWPOLYLINE-1118" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="324.3 862.78 322.96 863.78 321.3 865.12 320.63 866.45 319.96 868.79 319.96 872.46 320.63 874.79 321.3 876.13 322.96 877.8 324.3 878.46 327.3 878.46 328.97 877.8 330.3 876.13 330.97 874.79 331.64 872.46 331.64 868.79 330.97 866.45 330.3 865.12 328.97 863.78 327.3 862.78 324.3 862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1119" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="336.31 878.46 336.31 862.78 346.65 878.46 346.65 862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1120" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="362 878.46 352.33 878.46 352.33 862.78 362 862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1121" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="352.33" y1="870.12" x2="358.33" y2="870.12"/>
+  </g>
+  <g id="LWPOLYLINE-1122" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="227.21" y1="1023.6" x2="261.24" y2="1094.66"/>
+  </g>
+  <g id="LWPOLYLINE-1123" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="228.21" y1="1023.27" x2="262.24" y2="1093.99"/>
+  </g>
+  <g id="LWPOLYLINE-1124" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="342.98" y1="776.7" x2="390.69" y2="890.14"/>
+  </g>
+  <g id="LWPOLYLINE-1125" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="307.29" y1="951.53" x2="307.95" y2="894.14"/>
+  </g>
+  <g id="LWPOLYLINE-1126" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="302.95" y1="947.2" x2="303.61" y2="898.49"/>
+  </g>
+  <g id="LWPOLYLINE-1127" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="261.24" y1="1094.66" x2="262.24" y2="1094"/>
+  </g>
+  <g id="LWPOLYLINE-1128" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2173.01" y1="320.62" x2="2171.67" y2="316.28"/>
+  </g>
+  <g id="LWPOLYLINE-1129" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2301.79 132.45 2303.13 135.78 2353.18 141.45"/>
+  </g>
+  <g id="LWPOLYLINE-1130" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2304.46" y1="131.44" x2="2353.85" y2="137.11"/>
+  </g>
+  <g id="LWPOLYLINE-1131" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2207.04" y1="310.94" x2="2336.83" y2="325.62"/>
+  </g>
+  <g id="LWPOLYLINE-1132" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2289.12" y1="528.47" x2="2236.73" y2="522.47"/>
+  </g>
+  <g id="LWPOLYLINE-1133" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="508.47" y1="1268.16" x2="508.47" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-1134" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="420.05" y1="1142.37" x2="420.05" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-1135" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.38" y1="1138.04" x2="415.38" y2="1046.28"/>
+  </g>
+  <g id="LWPOLYLINE-1136" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="513.14" y1="1268.16" x2="513.14" y2="1046.29"/>
+  </g>
+  <g id="LWPOLYLINE-1137" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="871.47" y1="1263.49" x2="871.47" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-1138" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1117.03" y1="1244.47" x2="1117.03" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1139" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1125.04 1092.33 1113.7 1092.33 1113.7 1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1140" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1121.37" y1="1249.14" x2="1121.37" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1141" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1125.04" y1="1092.33" x2="1125.04" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1142" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="867.14" y1="1263.49" x2="867.14" y2="1046.29"/>
+  </g>
+  <g id="LWPOLYLINE-1143" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="835.11 1074.31 863.13 1046.29 861.8 1044.95 833.77 1072.98"/>
+  </g>
+  <g id="LWPOLYLINE-1144" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="836.11 1075.31 832.77 1071.98 830.1 1067.97 827.76 1063.97 825.76 1059.96 824.43 1055.3 823.76 1050.96 823.43 1046.28"/>
+  </g>
+  <g id="LWPOLYLINE-1145" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1095.35" y1="1263.49" x2="1095.35" y2="1249.14"/>
+  </g>
+  <g id="LWPOLYLINE-1146" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1091.01" y1="1263.49" x2="1091.01" y2="1244.47"/>
+  </g>
+  <g id="LWPOLYLINE-1147" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="873.14" y1="1087.99" x2="1071.99" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1148" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1113.7" y1="1087.99" x2="1125.04" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1149" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1165.74" y1="1087.99" x2="1437.99" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1150" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1479.37" y1="1087.99" x2="1491.38" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1151" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1531.41" y1="1087.99" x2="1803.67" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1152" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1618.83 914.83 1618.83 1021.26 1671.88 1021.26"/>
+  </g>
+  <g id="LWPOLYLINE-1153" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1711.58 1016.93 1711.58 1021.26 1762.29 1021.26"/>
+  </g>
+  <g id="LWPOLYLINE-1154" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1742.61" y1="1007.92" x2="1762.29" y2="1007.92"/>
+  </g>
+  <g id="LWPOLYLINE-1155" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1623.17 914.83 1623.17 1016.92 1671.88 1016.92"/>
+  </g>
+  <g id="LWPOLYLINE-1156" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="1016.92" x2="1738.27" y2="1016.92"/>
+  </g>
+  <g id="LWPOLYLINE-1157" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="931.85" x2="1738.27" y2="931.85"/>
+  </g>
+  <g id="LWPOLYLINE-1158" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="927.18" x2="1742.61" y2="927.18"/>
+  </g>
+  <g id="LWPOLYLINE-1159" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="862.78" x2="1645.19" y2="862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1160" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1618.83" y1="858.45" x2="1645.18" y2="858.45"/>
+  </g>
+  <g id="LWPOLYLINE-1161" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1845.04" y1="1087.99" x2="1857.05" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1162" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1896.75" y1="1087.99" x2="2047.22" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1163" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2001.51 1087.99 2001.51 1082.65 2005.86 1082.65"/>
+  </g>
+  <g id="LWPOLYLINE-1164" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2001.51" y1="1042.95" x2="2005.86" y2="1042.95"/>
+  </g>
+  <g id="LWPOLYLINE-1165" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2001.51" y1="991.57" x2="2005.86" y2="991.57"/>
+  </g>
+  <g id="LWPOLYLINE-1166" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2001.51 1042.95 2001.51 1031.27 2005.86 1031.27"/>
+  </g>
+  <g id="LWPOLYLINE-1167" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.82" y1="1034.28" x2="2001.52" y2="1034.28"/>
+  </g>
+  <g id="LWPOLYLINE-1168" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.82" y1="1038.95" x2="2001.52" y2="1038.95"/>
+  </g>
+  <g id="LWPOLYLINE-1169" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="873.14" y1="1092.33" x2="1071.99" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1170" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1165.74" y1="1092.33" x2="1437.99" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1171" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1479.37 1087.99 1479.37 1092.33 1491.38 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1172" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1531.41" y1="1092.33" x2="1803.67" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1173" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1845.04 1087.99 1845.04 1092.33 1857.05 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1174" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1896.75" y1="1092.33" x2="2042.89" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1175" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1085.34 1120.36 1113.7 1092.33 1112.03 1090.99 1084 1119.02"/>
+  </g>
+  <g id="LWPOLYLINE-1176" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1086.34 1121.36 1083.01 1118.02 1080.33 1114.35 1077.99 1110.34 1076.33 1106.01 1074.99 1101.67 1073.99 1097 1073.66 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1177" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1153.07 1120.36 1125.04 1092.33 1126.37 1090.99 1154.4 1119.02"/>
+  </g>
+  <g id="LWPOLYLINE-1178" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1152.06 1121.36 1155.4 1118.02 1158.07 1114.35 1160.41 1110.34 1162.41 1106.01 1163.74 1101.67 1164.41 1097 1164.74 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1179" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1483.04" y1="1263.49" x2="1483.04" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1180" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1487.71" y1="1263.49" x2="1487.71" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1181" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1299.87" y1="1263.49" x2="1299.87" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1182" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1304.2" y1="1263.49" x2="1304.2" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1183" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1491.38" y1="1092.33" x2="1491.38" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1184" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1451.34 1120.36 1479.37 1092.33 1478.04 1090.99 1449.67 1119.02"/>
+  </g>
+  <g id="LWPOLYLINE-1185" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1452.01 1121.36 1449.01 1118.02 1446 1114.35 1443.66 1110.34 1442 1106.01 1440.66 1101.67 1439.66 1097 1439.66 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1186" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1519.74 1120.36 1491.38 1092.33 1493.04 1090.99 1521.07 1119.02"/>
+  </g>
+  <g id="LWPOLYLINE-1187" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1518.74 1121.36 1522.07 1118.02 1524.74 1114.35 1527.07 1110.34 1528.75 1106.01 1530.08 1101.67 1531.08 1097 1531.42 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1188" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1847.71" y1="1268.16" x2="1847.71" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1189" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1852.04" y1="1268.16" x2="1852.04" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1190" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1857.05" y1="1092.33" x2="1857.05" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1191" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2042.89" y1="1272.83" x2="2042.89" y2="1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1192" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2047.23" y1="1272.83" x2="2047.23" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1193" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1885.07 1120.36 1857.05 1092.33 1858.38 1090.99 1886.41 1119.02"/>
+  </g>
+  <g id="LWPOLYLINE-1194" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1884.41 1121.36 1887.4 1118.02 1890.08 1114.35 1892.42 1110.34 1894.42 1106.01 1895.75 1101.67 1896.42 1097 1896.75 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1195" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1805.34" y1="1092.33" x2="1805.34" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1196" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1817.01 1120.36 1845.04 1092.33 1843.7 1090.99 1815.68 1119.02"/>
+  </g>
+  <g id="LWPOLYLINE-1197" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1817.68 1121.36 1814.68 1118.02 1812.01 1114.35 1809.67 1110.34 1807.67 1106.01 1806.34 1101.67 1805.67 1097 1805.34 1092.33"/>
+  </g>
+  <g id="LWPOLYLINE-1198" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.82" y1="966.88" x2="1965.82" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1199" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2001.51" y1="957.87" x2="2001.51" y2="991.57"/>
+  </g>
+  <g id="LWPOLYLINE-1200" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2005.85" y1="957.87" x2="2005.85" y2="991.57"/>
+  </g>
+  <g id="LWPOLYLINE-1201" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2005.85" y1="1082.65" x2="2005.85" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1202" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2009.86 953.53 1961.48 953.53 1961.48 1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1203" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2051.56" y1="953.53" x2="2273.77" y2="953.53"/>
+  </g>
+  <g id="LWPOLYLINE-1204" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1979.83" y1="957.87" x2="2009.86" y2="957.87"/>
+  </g>
+  <g id="LWPOLYLINE-1205" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2051.56" y1="957.87" x2="2255.74" y2="957.87"/>
+  </g>
+  <g id="LWPOLYLINE-1206" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2009.86" y1="957.87" x2="2009.86" y2="953.53"/>
+  </g>
+  <g id="LWPOLYLINE-1207" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2114.29" y1="957.87" x2="2114.29" y2="953.53"/>
+  </g>
+  <g id="LWPOLYLINE-1208" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2038.22 985.9 2009.86 957.87 2011.52 956.54 2039.55 984.56"/>
+  </g>
+  <g id="LWPOLYLINE-1209" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2037.22 986.9 2040.55 983.57 2043.22 979.89 2045.55 975.55 2047.23 971.55 2048.56 966.88 2049.56 962.54 2049.9 957.87"/>
+  </g>
+  <g id="LWPOLYLINE-1210" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2033.88 1019.59 2005.85 991.57 2004.52 992.9 2032.55 1020.93"/>
+  </g>
+  <g id="LWPOLYLINE-1211" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2034.88 1018.93 2031.55 1021.93 2027.87 1024.93 2023.87 1026.94 2019.53 1028.94 2015.2 1030.27 2010.52 1030.94 2005.86 1031.27"/>
+  </g>
+  <g id="LWPOLYLINE-1212" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2033.88 1054.63 2005.85 1082.65 2004.52 1081.32 2032.55 1053.29"/>
+  </g>
+  <g id="LWPOLYLINE-1213" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2034.88 1055.3 2031.55 1052.3 2027.87 1049.62 2023.87 1047.28 2019.53 1045.29 2015.2 1043.95 2010.52 1043.28 2005.86 1042.95"/>
+  </g>
+  <g id="LWPOLYLINE-1214" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="424.39" y1="1112.68" x2="424.39" y2="1108.01"/>
+  </g>
+  <g id="LWPOLYLINE-1215" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="334.98 1007.25 347.99 969.89 349.99 970.55 336.98 1007.92"/>
+  </g>
+  <g id="LWPOLYLINE-1216" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="333.98 1006.92 338.31 1008.25 342.65 1009.26 347.32 1009.59 351.99 1009.26 356.66 1008.59 361 1007.25 365.33 1005.58"/>
+  </g>
+  <g id="LWPOLYLINE-1217" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="451.08" y1="875.8" x2="643.27" y2="875.8"/>
+  </g>
+  <g id="LWPOLYLINE-1218" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="682.96 880.13 682.96 875.8 821.09 875.8"/>
+  </g>
+  <g id="LWPOLYLINE-1219" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="862.46 880.13 862.46 875.8 868.8 875.8"/>
+  </g>
+  <g id="LWPOLYLINE-1220" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="513.81 961.87 472.1 880.13 643.26 880.13"/>
+  </g>
+  <g id="LWPOLYLINE-1221" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="682.96" y1="880.13" x2="821.09" y2="880.13"/>
+  </g>
+  <g id="LWPOLYLINE-1222" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="862.46" y1="880.13" x2="873.14" y2="880.13"/>
+  </g>
+  <g id="LWPOLYLINE-1223" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="643.26" y1="875.8" x2="643.26" y2="880.13"/>
+  </g>
+  <g id="LWPOLYLINE-1224" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="834.44 847.44 862.46 875.8 861.13 877.13 833.1 849.1"/>
+  </g>
+  <g id="LWPOLYLINE-1225" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="835.11 846.77 832.11 850.1 829.1 853.78 826.76 857.78 825.1 862.12 823.76 866.45 823.09 871.13 822.76 875.8"/>
+  </g>
+  <g id="LWPOLYLINE-1226" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1712.25" y1="452.74" x2="1847.71" y2="452.74"/>
+  </g>
+  <g id="LWPOLYLINE-1227" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1949.46 448.4 1889.08 448.4 1889.08 452.74 1948.13 452.74"/>
+  </g>
+  <g id="LWPOLYLINE-1228" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1712.25" y1="448.4" x2="1847.71" y2="448.4"/>
+  </g>
+  <g id="LWPOLYLINE-1229" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1779.31" y="448.4" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1230" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1710.58" y="448.4" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1231" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1712.25" y1="450.74" x2="1779.31" y2="450.74"/>
+  </g>
+  <g id="LWPOLYLINE-1232" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1712.25" y1="450.4" x2="1779.31" y2="450.4"/>
+  </g>
+  <g id="LWPOLYLINE-1233" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1861.05 420.04 1889.08 448.4 1887.75 449.73 1859.72 421.71"/>
+  </g>
+  <g id="LWPOLYLINE-1234" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1861.72 419.38 1858.72 422.71 1856.05 426.38 1853.71 430.39 1851.71 434.72 1850.38 439.06 1849.71 443.73 1849.38 448.4"/>
+  </g>
+  <g id="LWPOLYLINE-1235" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2080.26" y1="517.46" x2="2080.26" y2="630.24"/>
+  </g>
+  <g id="LWPOLYLINE-1236" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2084.59" y1="355.65" x2="2084.59" y2="477.43"/>
+  </g>
+  <g id="LWPOLYLINE-1237" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2080.25 517.46 2084.59 517.46 2084.59 626.56"/>
+  </g>
+  <g id="LWPOLYLINE-1238" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="671.29 908.16 643.26 880.13 644.6 878.8 672.62 906.82"/>
+  </g>
+  <g id="LWPOLYLINE-1239" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="670.62 909.16 673.62 905.83 676.29 902.15 678.63 898.15 680.63 893.81 681.96 889.15 682.63 884.8 682.96 880.13"/>
+  </g>
+  <g id="LWPOLYLINE-1240" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="740.68 796.72 722.67 832.09 721 831.42 739.02 795.72"/>
+  </g>
+  <g id="LWPOLYLINE-1241" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="741.69 797.06 737.68 795.05 733.35 793.72 728.67 792.71 724 792.38 719.33 792.38 714.66 793.05 710.33 794.38"/>
+  </g>
+  <g id="LWPOLYLINE-1242" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.82" y1="452.74" x2="2011.86" y2="452.74"/>
+  </g>
+  <g id="LWPOLYLINE-1243" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2080.26 448.4 2053.23 448.4 2053.23 452.74 2080.26 452.74"/>
+  </g>
+  <g id="LWPOLYLINE-1244" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1964.48" y1="448.4" x2="2011.86" y2="448.4"/>
+  </g>
+  <g id="LWPOLYLINE-1245" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2011.86" y="448.4" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1246" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2011.86" y1="450.4" x2="1969.49" y2="450.4"/>
+  </g>
+  <g id="LWPOLYLINE-1247" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2011.86" y1="450.74" x2="1969.49" y2="450.74"/>
+  </g>
+  <g id="LWPOLYLINE-1248" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2025.2 420.04 2053.23 448.4 2051.9 449.73 2023.87 421.71"/>
+  </g>
+  <g id="LWPOLYLINE-1249" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2026.2 419.38 2022.87 422.71 2020.2 426.38 2017.86 430.39 2015.86 434.72 2014.53 439.06 2013.86 443.73 2013.53 448.4"/>
+  </g>
+  <g id="LWPOLYLINE-1250" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1967.82" y="448.4" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1251" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1828.69" y1="586.53" x2="1828.69" y2="581.86"/>
+  </g>
+  <g id="LWPOLYLINE-1252" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1623.16 684.28 1742.61 684.28 1742.61 581.85"/>
+  </g>
+  <g id="LWPOLYLINE-1253" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1623.17 679.95 1738.27 679.95 1738.27 586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1254" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1618.83 875.13 1623.17 875.13 1623.17 862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1255" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="748.01" x2="1623.17" y2="736"/>
+  </g>
+  <g id="LWPOLYLINE-1256" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1618.83 695.96 1623.17 695.96 1623.17 586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1257" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1618.83" y1="875.13" x2="1618.83" y2="858.44"/>
+  </g>
+  <g id="LWPOLYLINE-1258" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1618.83" y1="752.35" x2="1618.83" y2="736"/>
+  </g>
+  <g id="LWPOLYLINE-1259" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1618.83" y1="695.96" x2="1618.83" y2="581.85"/>
+  </g>
+  <g id="LWPOLYLINE-1260" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1645.19" y1="927.18" x2="1645.19" y2="684.29"/>
+  </g>
+  <g id="LWPOLYLINE-1261" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1649.86" y1="927.18" x2="1649.86" y2="684.29"/>
+  </g>
+  <g id="LWPOLYLINE-1262" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1762.29 595.2 1762.29 581.86 1708.58 581.86"/>
+  </g>
+  <g id="LWPOLYLINE-1263" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1762.29" y1="595.2" x2="1742.61" y2="595.2"/>
+  </g>
+  <g id="LWPOLYLINE-1264" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1668.88 586.53 1668.88 581.86 1618.83 581.86"/>
+  </g>
+  <g id="LWPOLYLINE-1265" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1738.27" y1="586.53" x2="1708.58" y2="586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1266" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1668.88" y1="586.53" x2="1623.17" y2="586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1267" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1645.19" y1="748.01" x2="1623.17" y2="748.01"/>
+  </g>
+  <g id="LWPOLYLINE-1268" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="736" x2="1618.83" y2="736"/>
+  </g>
+  <g id="LWPOLYLINE-1269" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1645.19" y1="752.35" x2="1618.83" y2="752.35"/>
+  </g>
+  <g id="LWPOLYLINE-1270" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1715.25" y1="679.95" x2="1715.25" y2="668.27"/>
+  </g>
+  <g id="LWPOLYLINE-1271" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1710.91" y1="679.95" x2="1710.91" y2="648.26"/>
+  </g>
+  <g id="LWPOLYLINE-1272" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1727.6" y1="652.59" x2="1738.27" y2="652.59"/>
+  </g>
+  <g id="LWPOLYLINE-1273" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1710.91" y1="648.25" x2="1738.27" y2="648.25"/>
+  </g>
+  <g id="LWPOLYLINE-1274" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1680.55 614.55 1708.58 586.53 1707.24 584.86 1679.22 613.22"/>
+  </g>
+  <g id="LWPOLYLINE-1275" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1681.55 615.22 1678.22 611.89 1675.55 608.21 1673.22 604.21 1671.21 599.87 1669.88 595.54 1669.21 591.2 1668.87 586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1276" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1742.61" y1="927.18" x2="1742.61" y2="1021.26"/>
+  </g>
+  <g id="LWPOLYLINE-1277" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1738.27" y1="931.85" x2="1738.27" y2="1016.93"/>
+  </g>
+  <g id="LWPOLYLINE-1278" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1738.27 976.89 1710.58 976.89 1710.58 931.85"/>
+  </g>
+  <g id="LWPOLYLINE-1279" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1714.92" y1="959.54" x2="1714.92" y2="931.85"/>
+  </g>
+  <g id="LWPOLYLINE-1280" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1729.93" y1="972.55" x2="1738.27" y2="972.55"/>
+  </g>
+  <g id="LWPOLYLINE-1281" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1671.88" y1="1021.26" x2="1671.88" y2="1016.93"/>
+  </g>
+  <g id="LWPOLYLINE-1282" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="914.83" x2="1618.83" y2="914.83"/>
+  </g>
+  <g id="LWPOLYLINE-1283" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1590.8 707.64 1618.83 736 1620.16 734.33 1592.14 706.31"/>
+  </g>
+  <g id="LWPOLYLINE-1284" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1589.8 708.64 1593.13 705.31 1596.81 702.64 1600.81 700.31 1605.15 698.63 1609.48 697.3 1614.16 696.3 1618.83 695.96"/>
+  </g>
+  <g id="LWPOLYLINE-1285" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1590.8 903.15 1618.83 875.13 1620.16 876.46 1592.14 904.49"/>
+  </g>
+  <g id="LWPOLYLINE-1286" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1589.8 902.49 1593.13 905.49 1596.81 908.16 1600.81 910.5 1605.15 912.5 1609.48 913.83 1614.16 914.5 1618.83 914.83"/>
+  </g>
+  <g id="LWPOLYLINE-1287" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="752.35" x2="1628.84" y2="759.02"/>
+  </g>
+  <g id="LWPOLYLINE-1288" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="762.36" x2="1628.84" y2="769.03"/>
+  </g>
+  <g id="LWPOLYLINE-1289" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="772.37" x2="1628.84" y2="779.04"/>
+  </g>
+  <g id="LWPOLYLINE-1290" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="782.38" x2="1628.84" y2="789.05"/>
+  </g>
+  <g id="LWPOLYLINE-1291" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="792.38" x2="1628.84" y2="798.72"/>
+  </g>
+  <g id="LWPOLYLINE-1292" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="802.06" x2="1628.84" y2="808.73"/>
+  </g>
+  <g id="LWPOLYLINE-1293" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="812.07" x2="1628.84" y2="818.74"/>
+  </g>
+  <g id="LWPOLYLINE-1294" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="822.08" x2="1628.84" y2="828.75"/>
+  </g>
+  <g id="LWPOLYLINE-1295" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="832.09" x2="1628.84" y2="838.76"/>
+  </g>
+  <g id="LWPOLYLINE-1296" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="842.1" x2="1628.84" y2="848.44"/>
+  </g>
+  <g id="LWPOLYLINE-1297" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1628.84" y1="851.77" x2="1628.84" y2="858.45"/>
+  </g>
+  <g id="LWPOLYLINE-1298" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1618.83" y1="858.45" x2="1618.83" y2="752.35"/>
+  </g>
+  <g id="LWPOLYLINE-1299" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1639.18,775.7v6.01c0,1.47-1.19,2.67-2.67,2.67h-9.34c-1.61.04-2.95-1.22-3-2.83"/>
+  </g>
+  <g id="CIRCLE-27" data-name="CIRCLE">
+    <circle class="cls-3" cx="1631.68" cy="774.54" r="1.5"/>
+  </g>
+  <g id="LWPOLYLINE-1300" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1640.85" y1="773.37" x2="1640.85" y2="776.04"/>
+  </g>
+  <g id="CIRCLE-28" data-name="CIRCLE">
+    <circle class="cls-3" cx="1640.34" cy="776.54" r=".84"/>
+  </g>
+  <g id="CIRCLE-29" data-name="CIRCLE">
+    <circle class="cls-3" cx="1640.35" cy="772.2" r=".83"/>
+  </g>
+  <g id="LWPOLYLINE-1301" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1639.85 773.37 1634.51 774.03 1634.51 775.03 1639.85 776.04"/>
+  </g>
+  <g id="LWPOLYLINE-1302" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1622.83,784.21c.04.87.79,1.55,1.66,1.5,0,0,0,0,0,0h16.52c.78.05,1.45-.55,1.5-1.33,0,0,0,0,0,0v-19.68c.05-.87-.62-1.62-1.5-1.67,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1303" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1623.17" y1="764.69" x2="1623.17" y2="784.37"/>
+  </g>
+  <g id="ARC-93" data-name="ARC">
+    <path class="cls-3" d="M1624.34,763.03c-.83,0-1.5.67-1.5,1.5,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1304" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1641.18" y1="763.36" x2="1624.5" y2="763.36"/>
+  </g>
+  <g id="LWPOLYLINE-1305" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.5" y1="781.71" x2="1624.5" y2="767.37"/>
+  </g>
+  <g id="ARC-94" data-name="ARC">
+    <path class="cls-3" d="M1627,764.36c-1.57,0-2.84,1.27-2.84,2.83"/>
+  </g>
+  <g id="LWPOLYLINE-1306" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1627.17" y1="764.69" x2="1636.51" y2="764.69"/>
+  </g>
+  <g id="LWPOLYLINE-1307" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M1636.34,764.36c1.61.05,2.88,1.39,2.84,3v6.01"/>
+  </g>
+  <g id="LWPOLYLINE-1308" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="403.04" y="1138.37" width="10.68" height="10.68"/>
+  </g>
+  <g id="LWPOLYLINE-1309" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="420.05" y1="1041.95" x2="387.69" y2="1041.95"/>
+  </g>
+  <g id="LWPOLYLINE-1310" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="415.38" y1="1046.29" x2="384.69" y2="1046.29"/>
+  </g>
+  <g id="LWPOLYLINE-1311" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="508.47" y1="981.23" x2="513.81" y2="981.23"/>
+  </g>
+  <g id="LWPOLYLINE-1312" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="443.41 878.13 466.1 879.8 508.47 963.21"/>
+  </g>
+  <g id="LWPOLYLINE-1313" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="387.69" y1="1041.95" x2="369.34" y2="1003.58"/>
+  </g>
+  <g id="LWPOLYLINE-1314" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="346.65 966.55 347.99 969.88 351.99 967.88 328.64 918.84"/>
+  </g>
+  <g id="LWPOLYLINE-1315" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="384.69" y1="1046.29" x2="365.34" y2="1005.58"/>
+  </g>
+  <g id="LWPOLYLINE-1316" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="306.62 1058.96 302.61 1060.97 274.25 1001.25"/>
+  </g>
+  <g id="LWPOLYLINE-1317" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.2" y1="1138.04" x2="168.15" y2="1051.96"/>
+  </g>
+  <g id="LWPOLYLINE-1318" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="207.19" y1="1138.04" x2="167.15" y2="1059.96"/>
+  </g>
+  <g id="LWPOLYLINE-1319" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="301.28 1057.96 290.27 1063.3 289.94 1062.3"/>
+  </g>
+  <g id="LWPOLYLINE-1320" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M255.57,1079.98l11.01-5.34-.67-1c-3.06-6.32-3.49-13.6-1.19-20.24"/>
+  </g>
+  <g id="LWPOLYLINE-1321" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="306.62" y1="1058.96" x2="277.92" y2="999.25"/>
+  </g>
+  <g id="LWPOLYLINE-1322" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="369.34" y1="1003.58" x2="365.34" y2="1005.58"/>
+  </g>
+  <g id="LWPOLYLINE-1323" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="244.56" y1="1063.64" x2="229.88" y2="1033.27"/>
+  </g>
+  <g id="LWPOLYLINE-1324" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="228.55" y1="1033.94" x2="242.89" y2="1064.3"/>
+  </g>
+  <g id="LWPOLYLINE-1325" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M216.87,1038.95l-1-1.67-6.67,3.34.67,1.66c-.37.6-.65,1.26-.85,1.94-.21,1.14-.22,2.31-.04,3.45"/>
+  </g>
+  <g id="ARC-95" data-name="ARC">
+    <path class="cls-3" d="M208.68,1047.82c.3,2.03,1.06,3.97,2.2,5.68"/>
+  </g>
+  <g id="SPLINE-68" data-name="SPLINE">
+    <path class="cls-3" d="M216.53,1057.6c.16.06.35.03.48-.08"/>
+  </g>
+  <g id="ARC-96" data-name="ARC">
+    <path class="cls-3" d="M217.01,1057.52c.14-.11.21-.28.18-.45"/>
+  </g>
+  <g id="LWPOLYLINE-1326" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="217.2" y1="1057.3" x2="216.87" y2="1054.62"/>
+  </g>
+  <g id="ARC-97" data-name="ARC">
+    <path class="cls-3" d="M215.97,1041.67c-1.37-.27-2.75.4-3.4,1.63"/>
+  </g>
+  <g id="ARC-98" data-name="ARC">
+    <path class="cls-3" d="M221.43,1051.69c.13-.76.14-1.53.03-2.29"/>
+  </g>
+  <g id="SPLINE-69" data-name="SPLINE">
+    <path class="cls-3" d="M221.55,1051.71c-.02.16.02.31.13.44"/>
+  </g>
+  <g id="LWPOLYLINE-1327" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="221.87" y1="1052.29" x2="223.87" y2="1054.29"/>
+  </g>
+  <g id="ARC-99" data-name="ARC">
+    <path class="cls-3" d="M223.68,1053.81c.2.2.53.2.74,0,.05-.05.09-.11.12-.18"/>
+  </g>
+  <g id="ARC-100" data-name="ARC">
+    <path class="cls-3" d="M209.34,1050.11c.69,1.45,1.58,2.81,2.63,4.03"/>
+  </g>
+  <g id="LWPOLYLINE-1328" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="221.87" y1="1051.96" x2="221.87" y2="1051.96"/>
+  </g>
+  <g id="LWPOLYLINE-1329" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="224.21" y1="1054.29" x2="224.21" y2="1054.29"/>
+  </g>
+  <g id="LWPOLYLINE-1330" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="246.23" y1="1065.3" x2="245.56" y2="1063.64"/>
+  </g>
+  <g id="LWPOLYLINE-1331" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="246.56 1065.64 246.89 1065.97 247.23 1065.64 245.89 1062.64 245.56 1062.97 245.23 1063.3 245.56 1063.63 245.23 1063.97"/>
+  </g>
+  <g id="ARC-101" data-name="ARC">
+    <path class="cls-3" d="M244.28,1063.35c.12.25.42.36.67.24"/>
+  </g>
+  <g id="LWPOLYLINE-1332" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="245.89 1065.3 246.23 1065.3 246.56 1065.64"/>
+  </g>
+  <g id="ARC-102" data-name="ARC">
+    <path class="cls-3" d="M242.77,1064.07c.52,1.08,1.81,1.54,2.89,1.02,0,0,0,0,0,0"/>
+  </g>
+  <g id="LWPOLYLINE-1333" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="218.54" y1="1029.6" x2="188.17" y2="1044.28"/>
+  </g>
+  <g id="LWPOLYLINE-1334" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="188.84" y1="1045.62" x2="219.2" y2="1031.28"/>
+  </g>
+  <g id="LWPOLYLINE-1335" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="185.84 1044.62 185.17 1044.62 184.84 1044.62 184.5 1043.95 187.51 1042.62 187.84 1043.28 187.84 1043.62 187.17 1043.62 187.51 1043.95"/>
+  </g>
+  <g id="LWPOLYLINE-1336" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M187.89,1043.9c-.28.12-.6,0-.72-.28l-1.33,1"/>
+  </g>
+  <g id="ARC-103" data-name="ARC">
+    <path class="cls-3" d="M185.72,1044.39c.52,1.08,1.81,1.54,2.89,1.02,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-104" data-name="ARC">
+    <path class="cls-3" d="M223.71,1045.34c-.2-.52-.41-1.04-.66-1.54"/>
+  </g>
+  <g id="LWPOLYLINE-1337" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="223.21" y1="1043.62" x2="217.53" y2="1031.94"/>
+  </g>
+  <g id="LWPOLYLINE-1338" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="203.86" y1="1038.61" x2="209.53" y2="1050.62"/>
+  </g>
+  <g id="LWPOLYLINE-1339" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="216.87 1030.61 216.2 1028.94 212.2 1030.94 209.19 1032.27 206.19 1033.61 202.19 1035.61 202.86 1037.28"/>
+  </g>
+  <g id="LWPOLYLINE-1340" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="220.2" y1="1027.93" x2="218.53" y2="1028.6"/>
+  </g>
+  <g id="LWPOLYLINE-1341" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="220.54 1027.93 220.87 1027.27 220.54 1026.93"/>
+  </g>
+  <g id="LWPOLYLINE-1342" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="218.54" y1="1028.6" x2="218.87" y2="1028.94"/>
+  </g>
+  <g id="LWPOLYLINE-1343" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="220.2 1028.27 220.2 1027.94 220.54 1027.94"/>
+  </g>
+  <g id="LWPOLYLINE-1344" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="220.54 1026.93 217.54 1028.27 217.86 1028.94 218.2 1028.94 218.54 1028.6"/>
+  </g>
+  <g id="ARC-105" data-name="ARC">
+    <path class="cls-3" d="M218.25,1029.55c.25-.12.35-.41.24-.66,0,0,0,0,0,0"/>
+  </g>
+  <g id="ARC-106" data-name="ARC">
+    <path class="cls-3" d="M218.97,1031.06c1.08-.52,1.54-1.81,1.02-2.89"/>
+  </g>
+  <g id="LWPOLYLINE-1345" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M230.21,1032.61l.33-.33.33.67h.67l-1.33-3.01h-.67v.34l.33.67h-.33c-1.07.45-1.58,1.69-1.12,2.77,0,0,0,0,0,0"/>
+  </g>
+  <g id="SPLINE-70" data-name="SPLINE">
+    <path class="cls-3" d="M230.16,1032.32c-.25.12-.35.42-.23.67"/>
+  </g>
+  <g id="LWPOLYLINE-1346" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="230.55" y1="1032.27" x2="229.88" y2="1030.94"/>
+  </g>
+  <g id="LWPOLYLINE-1347" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1762.29" y1="1021.26" x2="1762.29" y2="1007.92"/>
+  </g>
+  <g id="LWPOLYLINE-1348" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="821.09" y="875.8" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1349" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="821.09" y1="878.13" x2="753.03" y2="878.13"/>
+  </g>
+  <g id="LWPOLYLINE-1350" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="821.09" y1="877.8" x2="753.03" y2="877.8"/>
+  </g>
+  <g id="LWPOLYLINE-1351" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="751.36" y="875.8" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1352" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="667.95" y="1041.95" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1353" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="667.95" y1="1044.29" x2="592.88" y2="1044.29"/>
+  </g>
+  <g id="LWPOLYLINE-1354" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="667.95" y1="1043.95" x2="592.88" y2="1043.95"/>
+  </g>
+  <g id="LWPOLYLINE-1355" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="591.21" y="1041.95" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1356" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="514.48" y="1041.95" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1357" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="516.14" y1="1044.29" x2="591.22" y2="1044.29"/>
+  </g>
+  <g id="LWPOLYLINE-1358" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="516.14" y1="1043.95" x2="591.22" y2="1043.95"/>
+  </g>
+  <g id="LWPOLYLINE-1359" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="821.76" y="1041.95" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1360" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="669.62" y1="1044.29" x2="744.69" y2="1044.29"/>
+  </g>
+  <g id="LWPOLYLINE-1361" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="669.62" y1="1043.95" x2="744.69" y2="1043.95"/>
+  </g>
+  <g id="LWPOLYLINE-1362" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="744.69" y="1041.95" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1363" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="821.76" y1="1044.29" x2="746.36" y2="1044.29"/>
+  </g>
+  <g id="LWPOLYLINE-1364" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="821.76" y1="1043.95" x2="746.36" y2="1043.95"/>
+  </g>
+  <g id="LWPOLYLINE-1365" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1071.99" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1366" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1005.26" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1367" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1071.99" y1="1090.33" x2="1006.93" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1368" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1071.99" y1="1089.99" x2="1006.93" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1369" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1297.87" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1370" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1231.47" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1371" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1297.87" y1="1090.33" x2="1233.14" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1372" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1297.87" y1="1089.99" x2="1233.14" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1373" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1372.94" y1="1092.33" x2="1372.94" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1374" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1371.27" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1375" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1304.87" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1376" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.27" y1="1090.33" x2="1306.54" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1377" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1371.27" y1="1089.99" x2="1306.54" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1378" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1164.74" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1379" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1166.41" y1="1090.33" x2="1231.47" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1380" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1166.41" y1="1089.99" x2="1231.47" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1381" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1438" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1382" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1372.94" y1="1090.33" x2="1437.99" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1383" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1372.94" y1="1089.99" x2="1437.99" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1384" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1738.61" y1="1092.33" x2="1738.61" y2="1087.99"/>
+  </g>
+  <g id="LWPOLYLINE-1385" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1736.94" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1386" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1670.88" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1387" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1736.94" y1="1090.33" x2="1672.55" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1388" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1736.94" y1="1089.99" x2="1672.55" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1389" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1803.67" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1390" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1738.61" y1="1090.33" x2="1803.66" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1391" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1738.61" y1="1089.99" x2="1803.66" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1392" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1664.2" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1393" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1597.81" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1394" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1664.21" y1="1090.33" x2="1599.48" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1395" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1664.21" y1="1089.99" x2="1599.48" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1396" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1531.41" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1397" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1533.08" y1="1090.33" x2="1597.81" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1398" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1533.08" y1="1089.99" x2="1597.81" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1399" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1959.81" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1400" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1896.75" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1401" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1959.81" y1="1090.33" x2="1898.42" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1402" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1959.81" y1="1089.99" x2="1898.42" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1403" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2005.85" y1="1031.27" x2="2005.85" y2="1042.95"/>
+  </g>
+  <g id="LWPOLYLINE-1404" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2114.29 953.53 2114.29 957.87 2114.29 953.53"/>
+  </g>
+  <g id="LWPOLYLINE-1405" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.62" y1="957.87" x2="2112.62" y2="953.53"/>
+  </g>
+  <g id="LWPOLYLINE-1406" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2112.62" y="953.53" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1407" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="2049.89" y="953.53" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1408" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.62" y1="955.87" x2="2051.56" y2="955.87"/>
+  </g>
+  <g id="LWPOLYLINE-1409" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2112.62" y1="955.54" x2="2051.56" y2="955.54"/>
+  </g>
+  <g id="LWPOLYLINE-1410" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1708.58" y1="581.86" x2="1708.58" y2="586.53"/>
+  </g>
+  <g id="LWPOLYLINE-1411" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2112.62 505.79 2084.59 477.43 2083.26 479.09 2111.29 507.12"/>
+  </g>
+  <g id="LWPOLYLINE-1412" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.62 504.79 2110.29 508.12 2106.28 510.79 2102.27 513.12 2098.27 514.8 2093.6 516.13 2089.26 517.13 2084.59 517.47"/>
+  </g>
+  <g id="LWPOLYLINE-1413" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2181.68 457.74 2156.99 426.72 2155.33 428.05 2180.35 459.07"/>
+  </g>
+  <g id="LWPOLYLINE-1414" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2182.68 457.08 2179.01 459.75 2175.01 462.08 2170.68 464.08 2166.33 465.41 2161.66 466.08 2157.33 466.42 2152.65 466.08"/>
+  </g>
+  <g id="LWPOLYLINE-1415" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="328.64" y1="918.84" x2="340.65" y2="914.16"/>
+  </g>
+  <g id="LWPOLYLINE-1416" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="316.96" y1="913.83" x2="337.98" y2="906.16"/>
+  </g>
+  <g id="LWPOLYLINE-1417" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="338.31" y1="778.37" x2="385.02" y2="890.14"/>
+  </g>
+  <g id="LWPOLYLINE-1418" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="342.98" y1="968.21" x2="316.96" y2="913.83"/>
+  </g>
+  <g id="LWPOLYLINE-1419" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="216.87" y1="897.15" x2="303.61" y2="898.48"/>
+  </g>
+  <g id="LWPOLYLINE-1420" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="212.86" y1="892.81" x2="307.95" y2="894.15"/>
+  </g>
+  <g id="LWPOLYLINE-1421" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="254.57 888.14 246.23 888.14 246.23 874.79 254.57 874.79"/>
+  </g>
+  <g id="LWPOLYLINE-1422" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="246.23" y1="881.13" x2="251.23" y2="881.13"/>
+  </g>
+  <g id="LWPOLYLINE-1423" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="258.24 888.14 258.24 874.79 263.91 874.79 265.91 875.46 266.58 876.13 267.24 877.46 267.24 879.47 266.58 880.8 265.91 881.13 263.91 881.8 258.24 881.8"/>
+  </g>
+  <g id="LWPOLYLINE-1424" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="274.59 888.14 276.92 888.14 276.59 893.48 261.24 893.48 261.24 887.81 263.58 887.81 274.25 885.13"/>
+  </g>
+  <g id="ARC-107" data-name="ARC">
+    <path class="cls-3" d="M274.59,887.8c.01-.98-.1-1.95-.34-2.9"/>
+  </g>
+  <g id="LWPOLYLINE-1425" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="334.31" y1="779.71" x2="331.64" y2="771.04"/>
+  </g>
+  <g id="LWPOLYLINE-1426" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="297.94 854.11 288.27 854.11 288.27 838.76 297.94 838.76"/>
+  </g>
+  <g id="LWPOLYLINE-1427" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="288.27" y1="846.1" x2="294.27" y2="846.1"/>
+  </g>
+  <g id="LWPOLYLINE-1428" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="302.28 838.76 302.28 854.11 311.28 854.11"/>
+  </g>
+  <g id="LWPOLYLINE-1429" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="324.3 854.11 314.96 854.11 314.96 838.76 324.3 838.76"/>
+  </g>
+  <g id="LWPOLYLINE-1430" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="314.96" y1="846.1" x2="320.63" y2="846.1"/>
+  </g>
+  <g id="LWPOLYLINE-1431" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="339.98 842.43 338.98 841.1 337.64 839.43 336.31 838.77 333.31 838.77 331.64 839.43 330.3 841.1 329.64 842.43 328.97 844.77 328.97 848.44 329.64 850.44 330.3 852.11 331.64 853.44 333.31 854.11 336.31 854.11 337.64 853.44 338.98 852.11 339.98 850.44"/>
+  </g>
+  <g id="LWPOLYLINE-1432" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="344.99 852.77 344.32 853.44 344.99 854.11 345.65 853.44"/>
+  </g>
+  <g id="LWPOLYLINE-1433" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="365" y1="835.76" x2="351.66" y2="859.45"/>
+  </g>
+  <g id="CIRCLE-30" data-name="CIRCLE">
+    <circle class="cls-3" cx="293.1" cy="822.25" r="14.52"/>
+  </g>
+  <g id="LWPOLYLINE-1434" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="280.59 816.07 283.92 829.09 286.93 816.07 290.27 829.09 293.27 816.07"/>
+  </g>
+  <g id="LWPOLYLINE-1435" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="295.94" y1="829.08" x2="295.94" y2="816.07"/>
+  </g>
+  <g id="LWPOLYLINE-1436" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="304.61" y1="816.07" x2="304.61" y2="829.09"/>
+  </g>
+  <g id="LWPOLYLINE-1437" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="295.94" y1="822.41" x2="304.61" y2="822.41"/>
+  </g>
+  <g id="LWPOLYLINE-1438" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="168.16" y1="1051.96" x2="350.66" y2="964.55"/>
+  </g>
+  <g id="LWPOLYLINE-1439" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="254.9" y1="1078.98" x2="265.91" y2="1073.64"/>
+  </g>
+  <g id="LWPOLYLINE-1440" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="168.82" y1="1046.95" x2="341.32" y2="964.21"/>
+  </g>
+  <g id="LWPOLYLINE-1441" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="612.57" y1="845.77" x2="617.24" y2="844.1"/>
+  </g>
+  <g id="LWPOLYLINE-1442" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="620.57" y1="843.1" x2="626.91" y2="841.1"/>
+  </g>
+  <g id="LWPOLYLINE-1443" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="629.91" y1="840.1" x2="636.25" y2="837.76"/>
+  </g>
+  <g id="LWPOLYLINE-1444" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="639.59" y1="836.76" x2="645.6" y2="834.76"/>
+  </g>
+  <g id="LWPOLYLINE-1445" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="648.93" y1="833.76" x2="655.27" y2="831.75"/>
+  </g>
+  <g id="LWPOLYLINE-1446" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="658.27" y1="830.75" x2="664.61" y2="828.42"/>
+  </g>
+  <g id="LWPOLYLINE-1447" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="667.62" y1="827.42" x2="673.96" y2="825.42"/>
+  </g>
+  <g id="LWPOLYLINE-1448" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="677.29" y1="824.41" x2="681.96" y2="822.75"/>
+  </g>
+  <g id="LWPOLYLINE-1449" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="622.58" y1="875.8" x2="605.89" y2="824.75"/>
+  </g>
+  <g id="LWPOLYLINE-1450" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="699.31" y1="875.8" x2="674.96" y2="801.73"/>
+  </g>
+  <g id="LWPOLYLINE-1451" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="703.98" y1="875.8" x2="679.29" y2="800.4"/>
+  </g>
+  <g id="LWPOLYLINE-1452" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="737.01" y1="875.8" x2="722.67" y2="832.09"/>
+  </g>
+  <g id="LWPOLYLINE-1453" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="705.99 795.72 710.32 794.39 671.95 677.62"/>
+  </g>
+  <g id="LWPOLYLINE-1454" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="868.8" y1="740" x2="829.1" y2="616.56"/>
+  </g>
+  <g id="LWPOLYLINE-1455" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="868.8" y1="725.65" x2="850.12" y2="667.6"/>
+  </g>
+  <g id="LWPOLYLINE-1456" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="847.45" y1="658.6" x2="833.44" y2="615.22"/>
+  </g>
+  <g id="LWPOLYLINE-1457" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="732.68" y1="875.8" x2="718.67" y2="833.43"/>
+  </g>
+  <g id="LWPOLYLINE-1458" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="705.99" y1="795.72" x2="667.62" y2="678.95"/>
+  </g>
+  <g id="LWPOLYLINE-1459" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="617.9" y1="875.8" x2="601.56" y2="826.08"/>
+  </g>
+  <g id="LWPOLYLINE-1460" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="639.26 850.1 637.92 848.77 635.59 848.1 632.59 848.1 630.25 848.77 628.91 850.1 628.91 851.77 629.58 853.11 630.25 853.77 631.92 854.44 636.26 856.11 637.92 856.78 638.59 857.44 639.26 859.11 639.26 861.11 637.92 862.78 635.59 863.45 632.59 863.45 630.25 862.78 628.91 861.11"/>
+  </g>
+  <g id="LWPOLYLINE-1461" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="648.93" y1="848.1" x2="648.93" y2="863.45"/>
+  </g>
+  <g id="LWPOLYLINE-1462" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="643.59" y1="848.1" x2="653.94" y2="848.1"/>
+  </g>
+  <g id="LWPOLYLINE-1463" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="661.28 848.1 659.94 848.77 658.28 850.11 657.61 851.77 656.94 853.78 656.94 857.45 657.61 859.78 658.28 861.12 659.94 862.78 661.28 863.45 664.28 863.45 665.62 862.78 667.28 861.12 667.95 859.78 668.62 857.45 668.62 853.78 667.95 851.77 667.28 850.11 665.62 848.77 664.28 848.1 661.28 848.1"/>
+  </g>
+  <g id="LWPOLYLINE-1464" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="673.29 863.45 673.29 848.1 679.63 848.1 681.96 848.78 682.63 849.44 683.3 850.77 683.3 852.44 682.63 853.78 681.96 854.45 679.63 855.44 673.29 855.44"/>
+  </g>
+  <g id="LWPOLYLINE-1465" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="678.29" y1="855.44" x2="683.3" y2="863.46"/>
+  </g>
+  <g id="LWPOLYLINE-1466" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="689.3 862.12 688.64 862.78 689.3 863.45 689.97 862.78"/>
+  </g>
+  <g id="LWPOLYLINE-1467" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="660.28" y1="666.94" x2="671.95" y2="677.61"/>
+  </g>
+  <g id="LWPOLYLINE-1468" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="661.61" y1="671.61" x2="667.62" y2="678.95"/>
+  </g>
+  <g id="LWPOLYLINE-1469" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="722.67" y1="832.09" x2="718.66" y2="833.42"/>
+  </g>
+  <g id="LWPOLYLINE-1470" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="718" y1="875.8" x2="716.33" y2="870.46"/>
+  </g>
+  <g id="LWPOLYLINE-1471" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="715.33" y1="867.45" x2="713.33" y2="861.12"/>
+  </g>
+  <g id="LWPOLYLINE-1472" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="711.99" y1="858.11" x2="709.99" y2="851.77"/>
+  </g>
+  <g id="LWPOLYLINE-1473" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="708.99" y1="848.44" x2="706.99" y2="842.43"/>
+  </g>
+  <g id="LWPOLYLINE-1474" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="705.99" y1="839.09" x2="703.98" y2="832.76"/>
+  </g>
+  <g id="LWPOLYLINE-1475" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="702.65" y1="829.75" x2="700.65" y2="823.41"/>
+  </g>
+  <g id="LWPOLYLINE-1476" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="699.65" y1="820.41" x2="697.64" y2="814.07"/>
+  </g>
+  <g id="LWPOLYLINE-1477" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="696.64" y1="810.74" x2="694.64" y2="804.4"/>
+  </g>
+  <g id="LWPOLYLINE-1478" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="693.31" y1="801.39" x2="691.64" y2="796.39"/>
+  </g>
+  <g id="LWPOLYLINE-1479" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1068.99" y1="537.82" x2="1068.99" y2="651.26"/>
+  </g>
+  <g id="LWPOLYLINE-1480" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1068.99" y1="670.27" x2="1068.99" y2="763.69"/>
+  </g>
+  <g id="LWPOLYLINE-1481" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1073.32" y1="536.15" x2="1073.32" y2="650.92"/>
+  </g>
+  <g id="LWPOLYLINE-1482" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1073.32" y1="670.61" x2="1073.32" y2="768.36"/>
+  </g>
+  <g id="LWPOLYLINE-1483" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="868.8" y="824.41" width="4.34" height="1.67"/>
+  </g>
+  <g id="LWPOLYLINE-1484" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="868.8" y="769.03" width="4.34" height="1.67"/>
+  </g>
+  <g id="LWPOLYLINE-1485" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="870.8" y1="770.7" x2="870.8" y2="824.41"/>
+  </g>
+  <g id="LWPOLYLINE-1486" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="871.14" y1="770.7" x2="871.14" y2="824.41"/>
+  </g>
+  <g id="LWPOLYLINE-1487" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="938.53" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1488" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="940.2" y1="1090.33" x2="1005.26" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1489" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="940.2" y1="1089.99" x2="1005.26" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1490" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="871.47" y="1087.99" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1491" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="938.53" y1="1090.33" x2="873.14" y2="1090.33"/>
+  </g>
+  <g id="LWPOLYLINE-1492" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="938.53" y1="1089.99" x2="873.14" y2="1089.99"/>
+  </g>
+  <g id="LWPOLYLINE-1493" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1697.57" y1="1263.49" x2="1697.57" y2="1235.46"/>
+  </g>
+  <g id="LWPOLYLINE-1494" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1701.91" y1="1263.49" x2="1701.91" y2="1230.79"/>
+  </g>
+  <g id="LWPOLYLINE-1495" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2089.93" y1="626.9" x2="2089.26" y2="631.24"/>
+  </g>
+  <g id="LWPOLYLINE-1496" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2084.59" y1="477.43" x2="2080.25" y2="477.43"/>
+  </g>
+  <g id="LWPOLYLINE-1497" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2151.65" y1="473.09" x2="2084.59" y2="473.09"/>
+  </g>
+  <g id="LWPOLYLINE-1498" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2147.65" y1="468.75" x2="2084.59" y2="468.75"/>
+  </g>
+  <g id="LWPOLYLINE-1499" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2156.99" y1="426.71" x2="2152.65" y2="426.38"/>
+  </g>
+  <g id="LWPOLYLINE-1500" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2109.29 463.41 2101.27 463.41 2101.27 450.07 2109.29 450.07"/>
+  </g>
+  <g id="LWPOLYLINE-1501" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2101.27" y1="456.41" x2="2106.28" y2="456.41"/>
+  </g>
+  <g id="LWPOLYLINE-1502" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.28 463.41 2113.28 450.07 2118.96 450.07 2120.63 450.74 2121.3 451.4 2121.96 452.74 2121.96 454.74 2121.3 455.74 2120.63 456.41 2118.96 457.08 2113.28 457.08"/>
+  </g>
+  <g id="LWPOLYLINE-1503" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2128.92,458.69c.26,1,.39,2.02.38,3.05h2.34v7.01h-15.35v-7.01h2l10.68-2.66"/>
+  </g>
+  <g id="LWPOLYLINE-1504" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.61" y1="468.75" x2="2099.61" y2="461.75"/>
+  </g>
+  <g id="LWPOLYLINE-1505" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.61" y1="458.41" x2="2099.61" y2="451.74"/>
+  </g>
+  <g id="LWPOLYLINE-1506" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.61" y1="448.4" x2="2099.61" y2="441.73"/>
+  </g>
+  <g id="LWPOLYLINE-1507" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2099.61" y1="438.39" x2="2099.61" y2="432.05"/>
+  </g>
+  <g id="LWPOLYLINE-1508" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2099.61 428.72 2099.61 421.71 2107.28 421.71"/>
+  </g>
+  <g id="LWPOLYLINE-1509" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2110.62" y1="421.71" x2="2117.29" y2="421.71"/>
+  </g>
+  <g id="LWPOLYLINE-1510" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2120.63" y1="421.71" x2="2127.3" y2="421.71"/>
+  </g>
+  <g id="LWPOLYLINE-1511" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2130.64" y1="421.71" x2="2138.65" y2="421.71"/>
+  </g>
+  <g id="LWPOLYLINE-1512" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2113.28 431.72 2111.96 430.39 2110.29 429.72 2107.61 429.72 2105.61 430.39 2104.61 431.72 2104.61 433.05 2104.94 434.39 2105.61 434.72 2106.95 435.39 2110.94 436.72 2111.96 437.39 2112.62 438.06 2113.28 439.4 2113.28 441.06 2111.96 442.39 2110.29 443.06 2107.61 443.06 2105.61 442.39 2104.61 441.06"/>
+  </g>
+  <g id="LWPOLYLINE-1513" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2121.63" y1="429.72" x2="2121.63" y2="443.06"/>
+  </g>
+  <g id="LWPOLYLINE-1514" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2116.96" y1="429.72" x2="2125.96" y2="429.72"/>
+  </g>
+  <g id="LWPOLYLINE-1515" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="2132.3 429.72 2130.97 430.38 2129.63 431.72 2128.97 433.05 2128.3 434.72 2128.3 438.06 2128.97 440.06 2129.63 441.06 2130.97 442.4 2132.3 443.06 2134.64 443.06 2135.97 442.4 2137.31 441.06 2137.97 440.06 2138.64 438.06 2138.64 434.72 2137.97 433.05 2137.31 431.72 2135.97 430.38 2134.64 429.72 2132.3 429.72"/>
+  </g>
+  <g id="LWPOLYLINE-1516" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2142.31 443.06 2142.31 429.72 2147.99 429.72 2149.99 430.38 2150.66 431.05 2151.32 432.39 2151.32 433.72 2150.66 434.72 2149.99 435.39 2147.99 436.06 2142.31 436.06"/>
+  </g>
+  <g id="LWPOLYLINE-1517" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2146.65" y1="436.06" x2="2151.32" y2="443.06"/>
+  </g>
+  <g id="LWPOLYLINE-1518" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2156.33 441.73 2155.66 442.39 2156.33 443.06 2156.99 442.39"/>
+  </g>
+  <g id="LWPOLYLINE-1519" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2212.71" y1="340.3" x2="2216.71" y2="338.97"/>
+  </g>
+  <g id="LWPOLYLINE-1520" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2292.12" y1="320.62" x2="2287.78" y2="357.65"/>
+  </g>
+  <g id="LWPOLYLINE-1521" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2296.45" y1="320.95" x2="2292.12" y2="357.98"/>
+  </g>
+  <g id="LWPOLYLINE-1522" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2210.71" y1="162.47" x2="2208.04" y2="199.5"/>
+  </g>
+  <g id="LWPOLYLINE-1523" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2206.37" y1="163.81" x2="2204.37" y2="188.5"/>
+  </g>
+  <g id="LWPOLYLINE-1524" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1642.18" y="500.11" width="1.67" height="4.67"/>
+  </g>
+  <g id="LWPOLYLINE-1525" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1573.12 502.45 1642.18 502.45 1573.12 502.45"/>
+  </g>
+  <g id="LWPOLYLINE-1526" data-name="LWPOLYLINE">
+    <rect class="cls-3" x="1847.71" y="448.4" width="1.67" height="4.34"/>
+  </g>
+  <g id="LWPOLYLINE-1527" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1847.71" y1="450.74" x2="1780.98" y2="450.74"/>
+  </g>
+  <g id="LWPOLYLINE-1528" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1847.71" y1="450.4" x2="1780.98" y2="450.4"/>
+  </g>
+  <g id="LWPOLYLINE-1529" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="978.89" x2="1988.84" y2="984.9"/>
+  </g>
+  <g id="LWPOLYLINE-1530" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="988.23" x2="1988.84" y2="994.91"/>
+  </g>
+  <g id="LWPOLYLINE-1531" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="998.24" x2="1988.84" y2="1004.91"/>
+  </g>
+  <g id="LWPOLYLINE-1532" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1008.25" x2="1988.84" y2="1014.92"/>
+  </g>
+  <g id="LWPOLYLINE-1533" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1018.26" x2="1988.84" y2="1024.93"/>
+  </g>
+  <g id="LWPOLYLINE-1534" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1028.27" x2="1988.84" y2="1034.27"/>
+  </g>
+  <g id="LWPOLYLINE-1535" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1038.95" x2="1988.84" y2="1046.96"/>
+  </g>
+  <g id="LWPOLYLINE-1536" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1049.96" x2="1988.84" y2="1056.63"/>
+  </g>
+  <g id="LWPOLYLINE-1537" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1059.96" x2="1988.84" y2="1066.64"/>
+  </g>
+  <g id="LWPOLYLINE-1538" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1069.97" x2="1988.84" y2="1076.65"/>
+  </g>
+  <g id="LWPOLYLINE-1539" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1988.84" y1="1079.98" x2="1988.84" y2="1088"/>
+  </g>
+  <g id="LWPOLYLINE-1540" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1965.82" y1="978.89" x2="1988.84" y2="978.89"/>
+  </g>
+  <g id="LWPOLYLINE-1541" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="586.53" x2="1711.58" y2="590.87"/>
+  </g>
+  <g id="LWPOLYLINE-1542" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="594.2" x2="1711.58" y2="600.87"/>
+  </g>
+  <g id="LWPOLYLINE-1543" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="604.21" x2="1711.58" y2="610.88"/>
+  </g>
+  <g id="LWPOLYLINE-1544" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="613.89" x2="1711.58" y2="620.56"/>
+  </g>
+  <g id="LWPOLYLINE-1545" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="623.9" x2="1711.58" y2="630.57"/>
+  </g>
+  <g id="LWPOLYLINE-1546" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="633.9" x2="1711.58" y2="640.58"/>
+  </g>
+  <g id="LWPOLYLINE-1547" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1711.58" y1="643.92" x2="1711.58" y2="648.25"/>
+  </g>
+  <g id="LWPOLYLINE-1548" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1648.86 632.57 1647.53 631.24 1645.52 630.57 1643.18 630.57 1641.18 631.24 1639.85 632.57 1639.85 633.9 1640.52 634.91 1641.18 635.58 1642.52 636.24 1646.19 637.58 1647.53 638.24 1648.19 638.91 1648.86 639.91 1648.86 641.91 1647.53 643.25 1645.52 643.92 1643.18 643.92 1641.18 643.25 1639.85 641.91"/>
+  </g>
+  <g id="LWPOLYLINE-1549" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1656.86" y1="630.57" x2="1656.86" y2="643.92"/>
+  </g>
+  <g id="LWPOLYLINE-1550" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1652.53" y1="630.57" x2="1661.53" y2="630.57"/>
+  </g>
+  <g id="LWPOLYLINE-1551" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1667.87 630.57 1666.54 631.23 1665.2 632.57 1664.54 633.9 1663.87 635.58 1663.87 638.92 1664.54 640.58 1665.2 641.91 1666.54 643.25 1667.87 643.92 1670.21 643.92 1671.54 643.25 1672.88 641.91 1673.55 640.58 1674.21 638.92 1674.21 635.58 1673.55 633.9 1672.88 632.57 1671.54 631.23 1670.21 630.57 1667.87 630.57"/>
+  </g>
+  <g id="LWPOLYLINE-1552" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1677.88 643.92 1677.88 630.57 1683.56 630.57 1685.56 631.24 1686.23 631.9 1686.55 633.24 1686.55 634.24 1686.23 635.57 1685.56 636.24 1683.56 636.91 1677.88 636.91"/>
+  </g>
+  <g id="LWPOLYLINE-1553" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1682.22" y1="636.91" x2="1686.56" y2="643.91"/>
+  </g>
+  <g id="LWPOLYLINE-1554" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1691.9 642.58 1691.23 643.25 1691.9 643.91 1692.23 643.25"/>
+  </g>
+  <g id="LWPOLYLINE-1555" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="748.01" x2="1624.17" y2="742.67"/>
+  </g>
+  <g id="LWPOLYLINE-1556" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="739.34" x2="1624.17" y2="732.66"/>
+  </g>
+  <g id="LWPOLYLINE-1557" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="729.33" x2="1624.17" y2="722.66"/>
+  </g>
+  <g id="LWPOLYLINE-1558" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="719.32" x2="1624.17" y2="712.65"/>
+  </g>
+  <g id="LWPOLYLINE-1559" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="709.64" x2="1624.17" y2="702.97"/>
+  </g>
+  <g id="LWPOLYLINE-1560" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="699.63" x2="1624.17" y2="692.96"/>
+  </g>
+  <g id="LWPOLYLINE-1561" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="689.62" x2="1624.17" y2="684.28"/>
+  </g>
+  <g id="LWPOLYLINE-1562" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="862.78" x2="1624.17" y2="868.46"/>
+  </g>
+  <g id="LWPOLYLINE-1563" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="871.79" x2="1624.17" y2="878.47"/>
+  </g>
+  <g id="LWPOLYLINE-1564" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="881.8" x2="1624.17" y2="888.47"/>
+  </g>
+  <g id="LWPOLYLINE-1565" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="891.81" x2="1624.17" y2="898.48"/>
+  </g>
+  <g id="LWPOLYLINE-1566" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="901.82" x2="1624.17" y2="908.49"/>
+  </g>
+  <g id="LWPOLYLINE-1567" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="911.83" x2="1624.17" y2="918.17"/>
+  </g>
+  <g id="LWPOLYLINE-1568" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="1624.17" y1="921.5" x2="1624.17" y2="927.18"/>
+  </g>
+  <g id="LWPOLYLINE-1569" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1631.84 909.49 1630.51 910.16 1629.18 911.5 1628.51 912.49 1628.51 915.17 1629.18 916.5 1630.51 917.51 1631.84 918.16 1633.51 918.84 1636.85 918.84 1638.85 918.16 1639.85 917.51 1641.18 916.5 1641.85 915.17 1641.85 912.49 1641.18 911.5 1639.85 910.16 1638.85 909.49"/>
+  </g>
+  <g id="LWPOLYLINE-1570" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1628.51 905.49 1641.85 905.49 1641.85 898.15"/>
+  </g>
+  <g id="LWPOLYLINE-1571" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1628.51 891.14 1629.17 892.48 1630.51 893.82 1631.84 894.15 1633.51 894.81 1636.84 894.81 1638.85 894.15 1639.85 893.82 1641.19 892.48 1641.85 891.14 1641.85 888.48 1641.19 887.47 1639.85 886.14 1638.85 885.47 1636.84 884.8 1633.51 884.8 1631.84 885.47 1630.51 886.14 1629.17 887.47 1628.51 888.48 1628.51 891.14"/>
+  </g>
+  <g id="LWPOLYLINE-1572" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1630.51 872.13 1629.17 873.46 1628.51 875.46 1628.51 877.8 1629.17 879.8 1630.51 881.13 1631.84 881.13 1632.84 880.46 1633.5 879.8 1634.17 878.47 1635.51 874.8 1636.18 873.46 1636.85 872.79 1638.18 872.13 1639.85 872.13 1641.18 873.46 1641.85 875.46 1641.85 877.8 1641.18 879.8 1639.85 881.13"/>
+  </g>
+  <g id="LWPOLYLINE-1573" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1640.52 867.79 1641.18 868.46 1641.85 867.79 1641.18 867.12"/>
+  </g>
+  <g id="LWPOLYLINE-1574" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1631.84 730.33 1630.51 731 1629.18 732.33 1628.51 733.33 1628.51 736 1629.18 737.34 1630.51 738.66 1631.84 739.33 1633.51 739.67 1636.85 739.67 1638.85 739.33 1639.85 738.66 1641.18 737.34 1641.85 736 1641.85 733.33 1641.18 732.33 1639.85 731 1638.85 730.33"/>
+  </g>
+  <g id="LWPOLYLINE-1575" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1628.51 726.66 1641.85 726.66 1641.85 718.98"/>
+  </g>
+  <g id="ELLIPSE">
+    <path class="cls-3" d="M1628.51,711.98c.75,2.84,4.36,4.65,8.05,4.03s6.07-3.42,5.32-6.26-4.36-4.65-8.05-4.03-6.07,3.42-5.32,6.26Z"/>
+  </g>
+  <g id="LWPOLYLINE-1576" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1630.51 692.96 1629.17 694.29 1628.51 696.29 1628.51 698.63 1629.17 700.63 1630.51 701.96 1631.84 701.96 1632.84 701.31 1633.5 700.63 1634.17 699.3 1635.51 695.63 1636.18 694.29 1636.85 693.63 1638.18 692.96 1639.85 692.96 1641.18 694.29 1641.85 696.29 1641.85 698.63 1641.18 700.63 1639.85 701.96"/>
+  </g>
+  <g id="LWPOLYLINE-1577" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1640.52 688.62 1641.18 689.29 1641.85 688.62 1641.18 687.96"/>
+  </g>
+  <g id="LWPOLYLINE-1578" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1973.16 1023.6 1972.16 1024.27 1970.82 1025.6 1970.16 1026.6 1970.16 1029.27 1970.82 1030.61 1972.16 1031.61 1973.16 1032.27 1975.16 1032.94 1978.5 1032.94 1980.16 1032.27 1981.49 1031.61 1982.83 1030.61 1983.5 1029.27 1983.5 1026.6 1982.83 1025.6 1981.49 1024.27 1980.16 1023.6"/>
+  </g>
+  <g id="LWPOLYLINE-1579" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1970.15 1019.59 1983.5 1019.59 1983.5 1012.25"/>
+  </g>
+  <g id="LWPOLYLINE-1580" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1970.15 1005.25 1970.82 1006.58 1972.16 1007.92 1973.15 1008.26 1975.16 1008.92 1978.5 1008.92 1980.16 1008.26 1981.5 1007.92 1982.83 1006.58 1983.5 1005.25 1983.5 1002.57 1982.83 1001.58 1981.5 1000.24 1980.16 999.58 1978.5 998.91 1975.16 998.91 1973.15 999.58 1972.16 1000.24 1970.82 1001.58 1970.15 1002.57 1970.15 1005.25"/>
+  </g>
+  <g id="LWPOLYLINE-1581" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1972.16 986.23 1970.82 987.56 1970.15 989.56 1970.15 991.9 1970.82 993.9 1972.16 995.23 1973.16 995.23 1974.5 994.57 1975.15 993.9 1975.83 992.57 1977.16 988.9 1977.83 987.56 1978.49 986.9 1979.5 986.23 1981.5 986.23 1982.83 987.56 1983.5 989.56 1983.5 991.9 1982.83 993.9 1981.5 995.23"/>
+  </g>
+  <g id="LWPOLYLINE-1582" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1982.16 981.89 1982.83 982.56 1983.5 981.89 1982.83 981.23"/>
+  </g>
+  <g id="LWPOLYLINE-1583" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1974.82 1078.32 1973.49 1078.65 1972.15 1079.98 1971.49 1081.32 1971.49 1083.99 1972.15 1084.99 1973.49 1086.33 1974.82 1086.99 1976.49 1087.66 1979.83 1087.66 1981.83 1086.99 1982.83 1086.33 1984.17 1084.99 1984.83 1083.99 1984.83 1081.32 1984.17 1079.98 1982.83 1078.65 1981.83 1078.32"/>
+  </g>
+  <g id="LWPOLYLINE-1584" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1971.49 1074.31 1984.83 1074.31 1984.83 1066.97"/>
+  </g>
+  <g id="LWPOLYLINE-1585" data-name="LWPOLYLINE">
+    <polygon class="cls-3" points="1971.49 1059.96 1972.15 1060.97 1973.49 1062.31 1974.82 1062.97 1976.49 1063.63 1979.82 1063.63 1981.83 1062.97 1982.83 1062.31 1984.17 1060.97 1984.83 1059.96 1984.83 1057.29 1984.17 1055.96 1982.83 1054.96 1981.83 1054.29 1979.82 1053.63 1976.49 1053.63 1974.82 1054.29 1973.49 1054.96 1972.15 1055.96 1971.49 1057.29 1971.49 1059.96"/>
+  </g>
+  <g id="LWPOLYLINE-1586" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1973.49 1040.95 1972.16 1042.28 1971.49 1043.96 1971.49 1046.62 1972.16 1048.62 1973.49 1049.62 1974.82 1049.62 1976.16 1049.29 1976.49 1048.62 1977.15 1047.29 1978.5 1043.29 1979.16 1042.28 1979.83 1041.62 1981.16 1040.95 1982.83 1040.95 1984.17 1042.28 1984.83 1043.96 1984.83 1046.62 1984.17 1048.62 1982.83 1049.62"/>
+  </g>
+  <g id="LWPOLYLINE-1587" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="1983.5 1036.61 1984.17 1037.28 1984.83 1036.61 1984.17 1035.94"/>
+  </g>
+  <g id="LWPOLYLINE-1588" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="436.74" y1="807.4" x2="434.07" y2="800.06"/>
+  </g>
+  <g id="LWPOLYLINE-1589" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="433.07" y1="797.06" x2="431.06" y2="790.72"/>
+  </g>
+  <g id="LWPOLYLINE-1590" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="430.06" y1="787.38" x2="428.06" y2="781.37"/>
+  </g>
+  <g id="LWPOLYLINE-1591" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="427.06" y1="778.04" x2="424.72" y2="771.7"/>
+  </g>
+  <g id="LWPOLYLINE-1592" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="423.73" y1="768.7" x2="421.72" y2="762.36"/>
+  </g>
+  <g id="LWPOLYLINE-1593" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="420.72" y1="759.02" x2="418.38" y2="752.01"/>
+  </g>
+  <g id="LWPOLYLINE-1594" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="481.44" y1="792.72" x2="475.11" y2="794.72"/>
+  </g>
+  <g id="LWPOLYLINE-1595" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="472.1" y1="795.72" x2="465.76" y2="797.72"/>
+  </g>
+  <g id="LWPOLYLINE-1596" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="462.43" y1="798.72" x2="456.42" y2="801.06"/>
+  </g>
+  <g id="LWPOLYLINE-1597" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="453.09" y1="802.06" x2="446.75" y2="804.06"/>
+  </g>
+  <g id="LWPOLYLINE-1598" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="443.74" y1="805.06" x2="436.74" y2="807.4"/>
+  </g>
+  <g id="LWPOLYLINE-1599" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="516.48" y1="781.04" x2="498.13" y2="725.65"/>
+  </g>
+  <g id="LWPOLYLINE-1600" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="527.15" y1="777.71" x2="508.47" y2="721.99"/>
+  </g>
+  <g id="LWPOLYLINE-1601" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="486.12" y1="759.69" x2="484.78" y2="756.36"/>
+  </g>
+  <g id="LWPOLYLINE-1602" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="483.78" y1="752.68" x2="477.11" y2="732.33"/>
+  </g>
+  <g id="LWPOLYLINE-1603" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2288.11" y1="524.8" x2="2288.45" y2="520.8"/>
+  </g>
+  <g id="LWPOLYLINE-1604" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2288.78" y1="517.46" x2="2289.45" y2="511.13"/>
+  </g>
+  <g id="LWPOLYLINE-1605" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2289.78" y1="507.79" x2="2290.78" y2="501.12"/>
+  </g>
+  <g id="LWPOLYLINE-1606" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2291.12" y1="497.78" x2="2291.78" y2="491.11"/>
+  </g>
+  <g id="LWPOLYLINE-1607" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2292.12" y1="487.77" x2="2292.79" y2="481.43"/>
+  </g>
+  <g id="LWPOLYLINE-1608" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2293.12" y1="478.09" x2="2294.12" y2="471.43"/>
+  </g>
+  <g id="LWPOLYLINE-1609" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2294.45" y1="468.09" x2="2295.12" y2="461.41"/>
+  </g>
+  <g id="LWPOLYLINE-1610" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2295.46" y1="458.41" x2="2296.12" y2="451.74"/>
+  </g>
+  <g id="LWPOLYLINE-1611" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2296.79" y1="448.4" x2="2297.46" y2="441.73"/>
+  </g>
+  <g id="LWPOLYLINE-1612" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2297.79 438.39 2298.12 434.73 2293.11 434.05"/>
+  </g>
+  <g id="LWPOLYLINE-1613" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2289.78" y1="433.72" x2="2283.11" y2="433.06"/>
+  </g>
+  <g id="LWPOLYLINE-1614" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2279.77" y1="432.72" x2="2273.1" y2="431.72"/>
+  </g>
+  <g id="LWPOLYLINE-1615" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2270.1" y1="431.38" x2="2263.42" y2="430.72"/>
+  </g>
+  <g id="LWPOLYLINE-1616" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2260.09" y1="430.39" x2="2253.42" y2="429.72"/>
+  </g>
+  <g id="LWPOLYLINE-1617" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2250.08" y1="429.05" x2="2243.74" y2="428.38"/>
+  </g>
+  <g id="LWPOLYLINE-1618" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2240.4 428.05 2235.06 427.38 2234.73 431.38"/>
+  </g>
+  <g id="LWPOLYLINE-1619" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2234.4" y1="434.72" x2="2233.4" y2="441.06"/>
+  </g>
+  <g id="LWPOLYLINE-1620" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2233.06" y1="444.4" x2="2232.4" y2="451.07"/>
+  </g>
+  <g id="LWPOLYLINE-1621" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2232.06" y1="454.41" x2="2231.4" y2="461.08"/>
+  </g>
+  <g id="LWPOLYLINE-1622" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2231.06" y1="464.41" x2="2230.06" y2="470.75"/>
+  </g>
+  <g id="LWPOLYLINE-1623" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2229.73" y1="474.09" x2="2229.06" y2="480.76"/>
+  </g>
+  <g id="LWPOLYLINE-1624" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2228.73" y1="484.1" x2="2228.06" y2="490.77"/>
+  </g>
+  <g id="LWPOLYLINE-1625" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2227.39" y1="493.78" x2="2226.72" y2="500.44"/>
+  </g>
+  <g id="LWPOLYLINE-1626" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2226.39" y1="503.78" x2="2225.73" y2="510.46"/>
+  </g>
+  <g id="LWPOLYLINE-1627" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2225.39 513.8 2224.72 517.47 2230.06 518.13"/>
+  </g>
+  <g id="LWPOLYLINE-1628" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2233.4" y1="518.47" x2="2240.07" y2="519.13"/>
+  </g>
+  <g id="LWPOLYLINE-1629" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2243.07" y1="519.47" x2="2249.74" y2="520.46"/>
+  </g>
+  <g id="LWPOLYLINE-1630" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2253.08" y1="520.8" x2="2259.75" y2="521.47"/>
+  </g>
+  <g id="LWPOLYLINE-1631" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2263.09" y1="521.8" x2="2269.43" y2="522.47"/>
+  </g>
+  <g id="LWPOLYLINE-1632" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2272.77" y1="523.14" x2="2279.44" y2="523.8"/>
+  </g>
+  <g id="LWPOLYLINE-1633" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2282.77" y1="524.14" x2="2288.11" y2="524.8"/>
+  </g>
+  <g id="LWPOLYLINE-1634" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2221.38 524.8 2220.05 523.14 2218.05 522.14 2215.05 521.81 2212.71 522.14 2211.04 523.47 2211.04 525.14 2211.71 526.47 2212.04 527.48 2213.71 528.14 2217.71 530.14 2219.04 531.14 2219.72 531.81 2220.39 533.47 2220.05 535.82 2218.39 536.81 2216.38 537.48 2213.38 537.15 2211.04 536.15 2210.04 534.48"/>
+  </g>
+  <g id="LWPOLYLINE-1635" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2231.06" y1="523.47" x2="2229.39" y2="538.82"/>
+  </g>
+  <g id="LWPOLYLINE-1636" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2226.06" y1="523.14" x2="2236.4" y2="524.14"/>
+  </g>
+  <g id="LWPOLYLINE-1637" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2237.4 539.82 2245.08 525.14 2249.07 541.15"/>
+  </g>
+  <g id="LWPOLYLINE-1638" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2240.4" y1="535.15" x2="2247.41" y2="535.81"/>
+  </g>
+  <g id="LWPOLYLINE-1639" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2253.42" y1="541.82" x2="2255.42" y2="526.47"/>
+  </g>
+  <g id="LWPOLYLINE-1640" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2259.42 542.49 2261.09 527.14 2267.76 527.81 2269.77 528.81 2270.43 529.47 2271.09 531.14 2270.77 532.48 2270.1 533.82 2269.1 534.48 2267.1 535.15 2260.42 534.48"/>
+  </g>
+  <g id="LWPOLYLINE-1641" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2265.43" y1="534.81" x2="2269.77" y2="543.48"/>
+  </g>
+  <g id="LWPOLYLINE-1642" data-name="LWPOLYLINE">
+    <line class="cls-3" x1="2275.44" y1="537.48" x2="2288.78" y2="539.15"/>
+  </g>
+  <g id="LWPOLYLINE-1643" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="2295.79 534.81 2296.12 533.81 2296.79 532.47 2297.79 531.81 2299.12 531.48 2302.12 531.81 2303.46 532.47 2304.13 533.48 2304.79 534.81 2304.46 536.48 2303.8 537.81 2302.12 539.82 2293.79 546.16 2304.13 547.49"/>
+  </g>
+  <g id="LWPOLYLINE-1644" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="712.32 806.07 711.32 805.06 709.98 804.06 708.32 804.06 705.99 804.73 704.98 805.73 704.31 807.4 703.98 808.73 703.98 810.74 704.98 813.74 706.32 815.41 707.32 816.41 708.65 817.08 710.32 817.41 712.66 816.74 713.66 815.74 714.33 814.07 714.66 812.73"/>
+  </g>
+  <g id="LWPOLYLINE-1645" data-name="LWPOLYLINE">
+    <polyline class="cls-3" points="714.99 801.73 719.33 814.41 726.34 812.07"/>
+  </g>
+  <g id="MTEXT">
+    <text class="cls-2" transform="translate(1022.99 1357.97)"><tspan x="0" y="0">Mission Street</tspan></text>
+  </g>
+  <g id="MTEXT-2" data-name="MTEXT">
+    <text class="cls-1" transform="translate(1075.59 486.57) rotate(-18.5)"><tspan x="0" y="0">Otis Street</tspan></text>
+  </g>
+  <g id="LWPOLYLINE-1646" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2325.1,193.34c1.27.55,2.61.92,3.99,1.07,1.37.16,2.76.11,4.12-.15"/>
+  </g>
+  <g id="LWPOLYLINE-1647" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2333.26,193.99c1.18-.22,2.31-.64,3.34-1.24.57-.38,1.09-.83,1.53-1.35"/>
+  </g>
+  <g id="LWPOLYLINE-1648" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2337.84,181.99c-.87-.82-1.88-1.48-2.97-1.96-1.88-.84-3.92-1.26-5.98-1.21"/>
+  </g>
+  <g id="LWPOLYLINE-1649" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2335.56,184.43c-.59-.58-1.28-1.05-2.03-1.4-.96-.42-1.98-.69-3.03-.81-1.04-.12-2.1-.08-3.13.11"/>
+  </g>
+  <g id="LWPOLYLINE-1650" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2332.65,190.71c.75-.16,1.46-.46,2.11-.87.37-.21.71-.48,1.01-.78"/>
+  </g>
+  <g id="LWPOLYLINE-1651" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2326.44,190.28c.96.42,1.98.69,3.03.81,1.04.12,2.1.08,3.13-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1652" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2320.64,182.72c-.63.77-1.02,1.71-1.14,2.69-.11.98.06,1.98.5,2.87"/>
+  </g>
+  <g id="LWPOLYLINE-1653" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2327.38,178.96c-1.32.18-2.6.56-3.8,1.14-1.18.58-2.21,1.41-3.05,2.42"/>
+  </g>
+  <g id="LWPOLYLINE-1654" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2321.93,183.78c-.42.52-.69,1.15-.77,1.82-.08.67.04,1.34.34,1.95"/>
+  </g>
+  <g id="LWPOLYLINE-1655" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2321.12,189.9c.3.39.64.76,1.01,1.09.87.82,1.88,1.48,2.97,1.96"/>
+  </g>
+  <g id="LWPOLYLINE-1656" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2316.51,231.52c-.09.12-.12.28-.06.42.28.38.6.73.94,1.05.9.83,1.92,1.5,3.04,1.99"/>
+  </g>
+  <g id="LWPOLYLINE-1657" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2320.43,235.38c1.27.55,2.61.92,3.99,1.07,1.37.16,2.76.11,4.12-.15"/>
+  </g>
+  <g id="LWPOLYLINE-1658" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2315.64,224.76c-.63.77-1.02,1.71-1.14,2.69-.11.98.07,1.98.51,2.87.35.71.79,1.37,1.3,1.97"/>
+  </g>
+  <g id="LWPOLYLINE-1659" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2331.44,227.49c-.25-.38-.54-.73-.88-1.03-.59-.58-1.28-1.05-2.03-1.39-.96-.42-1.98-.69-3.02-.81-1.04-.12-2.1-.08-3.13.11"/>
+  </g>
+  <g id="LWPOLYLINE-1660" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2327.64,232.74c.86-.15,1.68-.44,2.44-.87.37-.21.71-.48,1.02-.78"/>
+  </g>
+  <g id="LWPOLYLINE-1661" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2321.77,232.32c.96.42,1.98.69,3.02.81,1.04.12,2.1.08,3.13-.11"/>
+  </g>
+  <g id="LWPOLYLINE-1662" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2334.28,225.74c-.38-.62-.84-1.18-1.37-1.68-.89-.83-1.92-1.51-3.04-1.99-1.88-.84-3.92-1.26-5.98-1.22"/>
+  </g>
+  <g id="LWPOLYLINE-1663" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2316.93,225.82c-.42.52-.69,1.15-.77,1.82-.06.71.09,1.42.42,2.05.28.56.64,1.09,1.04,1.58"/>
+  </g>
+  <g id="LWPOLYLINE-1664" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2135.85,203.63c1.08,4.95,5.97,8.09,10.92,7.01.16-.03.31-.07.47-.12,5.02-.99,8.29-5.87,7.29-10.89-.14-.7-.36-1.39-.66-2.04-.2-.58-.84-.89-1.42-.7-2.24.97-4.52,1.82-6.84,2.56"/>
+  </g>
+  <g id="LWPOLYLINE-1665" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2136.03,203.37c-.17-.67.22-1.35.89-1.52,2.41-.51,4.79-1.14,7.13-1.89"/>
+  </g>
+  <g id="LWPOLYLINE-1666" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2140.6,211.14c1.31.94,2.81,1.59,4.39,1.91,1.35.25,2.74.16,4.04-.27,1.3-.43,2.48-1.18,3.42-2.18,1.15-1.2,2.03-2.63,2.58-4.19.6-1.58.92-3.25.96-4.94-.03-1.93-.34-3.84-.94-5.68-.3-1.34-1.6-2.19-2.94-1.93"/>
+  </g>
+  <g id="LWPOLYLINE-1667" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2134.25,202.56c.57,1.81,1.42,3.53,2.5,5.09.99,1.39,2.22,2.59,3.62,3.57"/>
+  </g>
+  <g id="LWPOLYLINE-1668" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2142.98,198.25c-.02.15,0,.31.05.45.07.21.2.4.37.54"/>
+  </g>
+  <g id="LWPOLYLINE-1669" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2145.28,198.62c.1-.37,0-.76-.25-1.04-.1-.12-.22-.21-.36-.29"/>
+  </g>
+  <g id="LWPOLYLINE-1670" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2171.56,192.33c1.1,4.93,6,8.03,10.93,6.93.69-.16,1.36-.39,2-.7,4.72-1.82,7.07-7.13,5.25-11.85-.06-.15-.12-.3-.18-.44-.19-.58-.81-.9-1.4-.72"/>
+  </g>
+  <g id="LWPOLYLINE-1671" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2180.69,201.7c1.35.25,2.74.16,4.04-.27,1.3-.43,2.48-1.18,3.41-2.18"/>
+  </g>
+  <g id="LWPOLYLINE-1672" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2179.59,186.2c-.11.03-.2.09-.29.16-.08.07-.15.15-.19.25"/>
+  </g>
+  <g id="LWPOLYLINE-1673" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M2337.46,264.91c-.64-.08-1.21.38-1.29,1.01,0,0,0,0,0,.01-.07.64.39,1.21,1.03,1.29"/>
+  </g>
+  <g id="LWPOLYLINE-1674" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M264.51,1036.32c.36-.59.64-1.23.84-1.89.17-.44.31-.89.4-1.35"/>
+  </g>
+  <g id="LWPOLYLINE-1675" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M266.11,1029.19c-.19-1.37-.58-2.7-1.17-3.96-.59-1.25-1.36-2.41-2.29-3.43"/>
+  </g>
+  <g id="LWPOLYLINE-1676" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M259.38,1038.9c.98.13,1.99-.02,2.89-.44.9-.42,1.66-1.09,2.18-1.93"/>
+  </g>
+  <g id="LWPOLYLINE-1677" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M260.05,1024.28c-.59-.59-1.27-1.08-2.02-1.44-.42-.23-.86-.41-1.33-.51-1.33-.25-2.66.4-3.28,1.59-.17.34-.3.7-.37,1.07-.16.84-.18,1.71-.05,2.56.15,1.04.45,2.05.89,3,.45.95,1.03,1.83,1.74,2.61"/>
+  </g>
+  <g id="LWPOLYLINE-1678" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M262.81,1029.65c-.15-1.04-.45-2.05-.89-3-.45-.95-1.04-1.83-1.74-2.61"/>
+  </g>
+  <g id="LWPOLYLINE-1679" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M250.44,1022.42c-.33.65-.56,1.33-.71,2.04-.22,1.13-.24,2.29-.07,3.43.29,2.08,1.03,4.06,2.18,5.82"/>
+  </g>
+  <g id="LWPOLYLINE-1680" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M259.61,1037.25c.67.09,1.34-.02,1.95-.3.61-.28,1.12-.74,1.48-1.31"/>
+  </g>
+  <g id="LWPOLYLINE-1681" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M405.15,1059.35c-5.06-.52-9.57,3.16-10.09,8.21-.02.15-.03.31-.04.46-.63,5.02,2.93,9.6,7.95,10.23.71.09,1.43.09,2.14.02.66.04,1.22-.46,1.26-1.11-.23-2.5-.34-5.01-.33-7.52"/>
+  </g>
+  <g id="LWPOLYLINE-1682" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M393.37,1064.88c-.66,1.2-1,2.55-1,3.93,0,1.37.34,2.72,1,3.93"/>
+  </g>
+  <g id="LWPOLYLINE-1683" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M408.62,1068.36c-.06-.14-.14-.27-.25-.38-.11-.11-.24-.2-.38-.25-.14-.06-.29-.09-.45-.09-.22,0-.44.06-.63.18"/>
+  </g>
+  <g id="LWPOLYLINE-1684" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M406.92,1069.8c.32.2.72.24,1.07.09.14-.06.27-.14.38-.25.11-.11.19-.24.25-.38.06-.14.09-.29.09-.44"/>
+  </g>
+  <g id="LWPOLYLINE-1685" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M400.91,1078.79c1.82.57,3.72.85,5.62.84,1.34.19,2.59-.73,2.81-2.06"/>
+  </g>
+  <g id="LWPOLYLINE-1686" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M405.71,1105.36c-.01-2.51.1-5.03.33-7.53-.04-.66-.61-1.16-1.27-1.12-5.04-.53-9.55,3.12-10.08,8.15-.07.7-.07,1.41.02,2.11.25,5.04,4.54,8.93,9.59,8.68.16,0,.32-.02.48-.04"/>
+  </g>
+  <g id="LWPOLYLINE-1687" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M393.03,1102.25c-.66,1.2-1.01,2.55-1,3.93,0,1.37.35,2.72,1,3.93"/>
+  </g>
+  <g id="LWPOLYLINE-1688" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M407.53,1106.95c.1-.04.19-.11.27-.18.08-.08.14-.17.18-.27.04-.1.06-.21.06-.32"/>
+  </g>
+  <g id="LWPOLYLINE-1689" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M407.66,1107.25c.14-.06.27-.14.38-.25.11-.11.19-.24.25-.38.06-.14.09-.29.09-.45"/>
+  </g>
+  <g id="LWPOLYLINE-1690" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M408.29,1105.73c-.06-.14-.14-.27-.25-.38-.11-.11-.24-.2-.38-.25-.35-.15-.75-.11-1.07.09"/>
+  </g>
+  <g id="LWPOLYLINE-1691" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M225.06,1048.76c-.2-1.37-.61-2.7-1.21-3.95-.6-1.25-1.38-2.4-2.32-3.42"/>
+  </g>
+  <g id="LWPOLYLINE-1692" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M221.42,1041.66c-.81-.88-1.77-1.61-2.83-2.17-.67-.32-1.38-.55-2.12-.68"/>
+  </g>
+  <g id="LWPOLYLINE-1693" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M216.86,1054.4c-.02-.16-.12-.29-.26-.37-.68-.36-1.3-.82-1.84-1.37"/>
+  </g>
+  <g id="LWPOLYLINE-1694" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M211.98,1047.33c.16,1.04.47,2.05.92,3,.45.95,1.05,1.82,1.76,2.59"/>
+  </g>
+  <g id="LWPOLYLINE-1695" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M212.7,1043.64c-.17.35-.29.72-.37,1.1-.16.8-.18,1.62-.06,2.43"/>
+  </g>
+  <g id="LWPOLYLINE-1696" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M218.97,1043.92c-.59-.58-1.27-1.06-2.02-1.41-.38-.2-.78-.35-1.2-.44"/>
+  </g>
+  <g id="LWPOLYLINE-1697" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M221.76,1049.25c-.16-1.04-.47-2.05-.92-3-.45-.95-1.05-1.82-1.76-2.59"/>
+  </g>
+  <g id="LWPOLYLINE-1698" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M211.69,1054.35c.93,1.02,2.01,1.9,3.2,2.59,1.06.69,2.25,1.14,3.5,1.32.99.12,1.98-.04,2.88-.46.89-.43,1.64-1.11,2.16-1.96.41-.6.75-1.24,1-1.92"/>
+  </g>
+  <g id="LWPOLYLINE-1699" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M217.05,1056.14c.5.21,1.02.37,1.55.46.67.08,1.34-.03,1.95-.32.62-.25,1.16-.68,1.54-1.22.33-.54.59-1.12.78-1.73"/>
+  </g>
+  <g id="LWPOLYLINE-1700" data-name="LWPOLYLINE">
+    <path class="cls-3" d="M224.33,1053.72c.15-.4.26-.82.35-1.24.23-1.18.26-2.38.08-3.57"/>
+  </g>
+</svg>


### PR DESCRIPTION
- New /floorplans page showing SVG floorplans for all 4 floors
- Floors table in Airtable for per-floor descriptions and photo galleries
- Falls back to static descriptions if Airtable table doesn't exist yet