### PR TITLE
Show weekly door code in portal and homepage nav

### DIFF
--- a/app/components/PortalNav.tsx
+++ b/app/components/PortalNav.tsx
@@ -13,6 +13,7 @@ export default function PortalNav() {
   const pathname = usePathname()
   const [session, setSession] = useState<SessionData | null>(null)
   const [bannerHeight, setBannerHeight] = useState(0)
+  const [weeklyCode, setWeeklyCode] = useState<string | null>(null)
 
   // Don't render on portal pages
   const isPortalPage = pathname?.startsWith('/portal')
@@ -25,6 +26,17 @@ export default function PortalNav() {
       .then((data) => setSession(data))
       .catch(() => setSession({ isLoggedIn: false }))
   }, [isPortalPage])
+
+  useEffect(() => {
+    if (isPortalPage || !session?.isLoggedIn) return
+
+    fetch('/portal/api/weekly-door-code')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.code) setWeeklyCode(data.code)
+      })
+      .catch(() => {})
+  }, [isPortalPage, session?.isLoggedIn])
 
   // Track banner visibility and adjust nav position on scroll
   useEffect(() => {
@@ -64,28 +76,46 @@ export default function PortalNav() {
       style={{ top: bannerHeight }}
     >
       {session.isLoggedIn ? (
-        <a
-          href="/portal"
-          className="flex items-center gap-2 p-2 sm:px-4 sm:py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors shadow-sm"
-          aria-label="Go to member portal"
-        >
-          <svg
-            className="w-5 h-5 text-gray-600 dark:text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
+        <div className="flex items-center gap-2">
+          {weeklyCode && (
+            <div className="flex items-center gap-2 p-2 sm:px-4 sm:py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 shadow-sm">
+              <svg
+                className="w-4 h-5 text-gray-600 dark:text-gray-400"
+                viewBox="0 0 24 32"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M4 1.5C2.6 1.5 1.5 2.6 1.5 4v24c0 1.4 1.1 2.5 2.5 2.5h16c1.4 0 2.5-1.1 2.5-2.5V4c0-1.4-1.1-2.5-2.5-2.5H4zm3 6a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zm5 0a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zm5 0a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zM7 13.4a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zm5 0a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zm5 0a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zM7 19.3a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zm5 0a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zm5 0a1.6 1.6 0 100 3.2 1.6 1.6 0 000-3.2zM5 25.5a.7.7 0 00-.7.7v1.6c0 .4.3.7.7.7h14a.7.7 0 00.7-.7v-1.6a.7.7 0 00-.7-.7H5z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span className="text-sm font-mono text-gray-900 dark:text-gray-100">
+                {weeklyCode}#
+              </span>
+            </div>
+          )}
+          <a
+            href="/portal"
+            className="flex items-center justify-center p-2 sm:p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors shadow-sm text-gray-600 dark:text-gray-400"
+            aria-label="Go to member portal"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-            />
-          </svg>
-          <span className="sm:inline text-sm text-gray-600 dark:text-gray-400 font-sans">
-            {session.name || session.email}
-          </span>
-        </a>
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
+            </svg>
+          </a>
+        </div>
       ) : (
         <a
           href="/portal"

--- a/app/portal/VerkadaPin.tsx
+++ b/app/portal/VerkadaPin.tsx
@@ -19,6 +19,7 @@ export default function VerkadaPin({
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
   const [guestPin, setGuestPin] = useState<string | null>(null)
   const [showAppInfo, setShowAppInfo] = useState<boolean>(false)
+  const [weeklyCode, setWeeklyCode] = useState<string | null>(null)
 
   const isGuestProgram = tier === 'Program' || tier === 'Guest Program'
 
@@ -44,6 +45,21 @@ export default function VerkadaPin({
     }
 
     fetchPin()
+  }, [])
+
+  useEffect(() => {
+    async function fetchWeeklyCode() {
+      try {
+        const response = await fetch('/portal/api/weekly-door-code')
+        if (!response.ok) return
+        const data = await response.json()
+        if (data.code) setWeeklyCode(data.code)
+      } catch (err) {
+        console.error('Failed to fetch weekly door code:', err)
+      }
+    }
+
+    fetchWeeklyCode()
   }, [])
 
   // Fetch guest PIN for guest program members
@@ -110,12 +126,20 @@ export default function VerkadaPin({
     )
   }
 
+  const weeklyCodeBlock = weeklyCode && (
+    <div style={{ marginBottom: '20px' }}>
+      <p style={{ marginBottom: '5px' }}>this week's shared door code:</p>
+      <div className="pin-display">{weeklyCode}#</div>
+    </div>
+  )
+
   if (!hasAccess || !pin) {
     // Show guest PIN for guest program members even if they don't have personal access
     if (isGuestProgram && guestPin) {
       return (
         <>
           <h3>door code</h3>
+          {weeklyCodeBlock}
           <p>as a guest program member, use this shared PIN code to enter:</p>
           <div className="pin-display">{guestPin}#</div>
         </>
@@ -125,6 +149,7 @@ export default function VerkadaPin({
     return (
       <>
         <h3>front door access</h3>
+        {weeklyCodeBlock}
         <p>
           door access is not available for your account. please contact a staff
           member to set up verkada access.
@@ -137,8 +162,10 @@ export default function VerkadaPin({
     <>
       <h3>door code</h3>
 
+      {weeklyCodeBlock}
+
       <p>
-        your personal PIN code (weekly code is in the Discord). this is for guests or deliveries,{' '}
+        your personal PIN code. this is for guests or deliveries,{' '}
         <span
           onClick={() => setShowAppInfo(!showAppInfo)}
           style={{

--- a/app/portal/api/weekly-door-code/route.ts
+++ b/app/portal/api/weekly-door-code/route.ts
@@ -1,0 +1,99 @@
+import { getSession } from '@/app/lib/session'
+import { env } from '@/app/lib/env'
+
+let cachedToken: string | null = null
+let tokenExpiresAt: number = 0
+const TOKEN_TTL_MS = 25 * 60 * 1000
+
+let cachedCode: string | null = null
+let codeExpiresAt: number = 0
+const CODE_TTL_MS = 5 * 60 * 1000
+
+async function getVerkadaToken(): Promise<string | null> {
+  if (cachedToken && Date.now() < tokenExpiresAt) {
+    return cachedToken
+  }
+
+  try {
+    const tokenRes = await fetch('https://api.verkada.com/token', {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'x-api-key': env.VERKADA_MEMBER_KEY,
+      },
+    })
+
+    if (!tokenRes.ok) {
+      const errorText = await tokenRes.text()
+      console.error(
+        '[Weekly Door Code] Failed to get Verkada token:',
+        tokenRes.status,
+        errorText
+      )
+      return null
+    }
+
+    const { token } = await tokenRes.json()
+    cachedToken = token
+    tokenExpiresAt = Date.now() + TOKEN_TTL_MS
+    return token
+  } catch (error) {
+    console.error('[Weekly Door Code] Error getting token:', error)
+    return null
+  }
+}
+
+export async function GET() {
+  try {
+    const session = await getSession()
+    if (!session.isLoggedIn) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (!env.VERKADA_WEEKLY_ACCESS_USER_ID) {
+      return Response.json({ code: null })
+    }
+
+    if (cachedCode && Date.now() < codeExpiresAt) {
+      return Response.json({ code: cachedCode })
+    }
+
+    const token = await getVerkadaToken()
+    if (!token) {
+      return Response.json({ code: null })
+    }
+
+    const userRes = await fetch(
+      `https://api.verkada.com/access/v1/access_users/user?user_id=${encodeURIComponent(env.VERKADA_WEEKLY_ACCESS_USER_ID)}`,
+      {
+        headers: {
+          accept: 'application/json',
+          'x-verkada-auth': token,
+        },
+      }
+    )
+
+    if (!userRes.ok) {
+      const errorText = await userRes.text()
+      console.error(
+        '[Weekly Door Code] Failed to fetch weekly access user:',
+        userRes.status,
+        errorText
+      )
+      return Response.json({ code: null })
+    }
+
+    const userData = await userRes.json()
+    const code = userData.entry_code || null
+
+    if (code) {
+      cachedCode = code
+      codeExpiresAt = Date.now() + CODE_TTL_MS
+    }
+
+    return Response.json({ code })
+  } catch (error) {
+    console.error('[Weekly Door Code] Error:', error)
+    return Response.json({ code: null })
+  }
+}


### PR DESCRIPTION
## Summary
- New `/portal/api/weekly-door-code` reads the current weekly entry code from the Verkada "Weekly Access" user (5 min code cache, 25 min token cache, auth-gated to logged-in users).
- Portal door-code section now shows this week's shared code above each member's personal PIN (and above the guest-program shared PIN). Removed the now-stale "weekly code is in the Discord" hint.
- Logged-in homepage nav swaps the user's name for a keypad chip showing the weekly code (e.g. `4827#`), with the portal head icon split into its own button next to it. Logged-out state is unchanged.

## Test plan
- [ ] Verify the keypad chip + head button appear on moxsf.com when logged in
- [ ] Verify the weekly code section appears above the personal PIN at /portal
- [ ] Verify guest-program members see the weekly code above their shared PIN
- [ ] Verify members without door access still see the weekly code above the "no access" message
- [ ] Verify logged-out homepage still shows the Login button only
- [ ] Sanity-check that the code shown matches the Discord #door-code channel name

🤖 Generated with [Claude Code](https://claude.com/claude-code)