### PR TITLE
Show staff roles, emails, and contact-for tags on people page

### DIFF
--- a/app/lib/airtable.ts
+++ b/app/lib/airtable.ts
@@ -12,6 +12,7 @@ export const Tables = {
   Rooms: 'Rooms',
   RoomBookings: 'Room Bookings',
   Floors: 'Floors',
+  Staff: 'tblbmm9NRs5ANd6IV',
 } as const
 
 export type TableName = (typeof Tables)[keyof typeof Tables]

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import PeopleGallery from './people-gallery'
 import EventsCardCompact from './components/EventsCardCompact'
 import { getEvents } from './lib/events'
 import DonateBanner from './components/DonateBanner'
-import { getPeople, getOrgs, getPrograms, buildDirectoryData } from './people/people'
+import { getPeople, getOrgs, getPrograms, getStaff, buildDirectoryData } from './people/people'
 import DirectoryClient from './people/DirectoryClient'
 import './people/people.css'
 
@@ -41,14 +41,16 @@ export default async function Component() {
   let people: Awaited<ReturnType<typeof getPeople>> = []
   let orgsMap: Awaited<ReturnType<typeof getOrgs>> = new Map()
   let programsMap: Awaited<ReturnType<typeof getPrograms>> = new Map()
+  let staffEntries: Awaited<ReturnType<typeof getStaff>> = []
   try {
     ;[people, orgsMap, programsMap] = await Promise.all([
       getPeople(), getOrgs(), getPrograms(),
     ])
+    staffEntries = await getStaff(people)
   } catch (e) {
     console.error('Failed to fetch people data:', e)
   }
-  const { sections, orgsLookup, programsLookup } = buildDirectoryData(people, orgsMap, programsMap)
+  const { sections, orgsLookup, programsLookup } = buildDirectoryData(people, orgsMap, programsMap, staffEntries)
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">

--- a/app/people/DirectoryClient.tsx
+++ b/app/people/DirectoryClient.tsx
@@ -2,11 +2,20 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Person, formatUrl } from './people'
+import { Mail } from 'lucide-react'
+import { Person, Staff, formatUrl } from './people'
+
+function hashHue(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) >>> 0
+  }
+  return h % 360
+}
 
 type DirectoryClientProps = {
   sections: {
-    type: 'person-section' | 'grouped-section'
+    type: 'person-section' | 'grouped-section' | 'staff-section'
     title: string
     people?: Person[]
     groups?: {
@@ -15,6 +24,7 @@ type DirectoryClientProps = {
       rooms?: string[]
       people: Person[]
     }[]
+    staff?: Staff[]
     affiliationType?: 'org' | 'both'
   }[]
   orgsLookup: Record<string, { name: string }>
@@ -77,6 +87,26 @@ export default function DirectoryClient({
         </p>
 
       {sections.map((section, idx) => {
+        if (section.type === 'staff-section' && section.staff) {
+          if (section.staff.length === 0) return null
+          return (
+            <div key={idx} className="directory-section">
+              <h2 className="section-title">{section.title}</h2>
+              {collapsed ? (
+                <CollapsedList
+                  people={section.staff.map((s) => s.person!).filter(Boolean)}
+                />
+              ) : (
+                <div className="directory-list staff-list">
+                  {section.staff.map((s) => (
+                    <StaffEntry key={s.id} entry={s} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        }
+
         if (section.type === 'person-section' && section.people) {
           if (section.people.length === 0) return null
           return (
@@ -172,6 +202,117 @@ function CollapsedList({ people }: { people: Person[] }) {
   )
 }
 
+function StaffEntry({ entry }: { entry: Staff }) {
+  const person = entry.person
+  if (!person) return null
+  const { url } = person.photo?.[0]?.thumbnails?.full ?? person.photo?.[0]?.thumbnails?.large ?? { url: null }
+  const initials = person.name
+    .split(' ')
+    .map((n) => n.charAt(0))
+    .join('')
+
+  return (
+    <div className="person-entry staff-entry">
+      <div className="person-photo">
+        {url ? (
+          <Image
+            src={url}
+            alt={person.name}
+            width={180}
+            height={180}
+            sizes="180px"
+            className="photo-img"
+          />
+        ) : (
+          <div className="photo-placeholder">{initials}</div>
+        )}
+      </div>
+      <div className="person-info">
+        {entry.title && <div className="staff-title">{entry.title}</div>}
+        <div className="person-main">
+          <span className="person-name">
+            {person.website ? (
+              <Link href={formatUrl(person.website)} target="_blank">
+                {person.name}
+              </Link>
+            ) : (
+              person.name
+            )}
+          </span>
+
+          {(person.workThing || person.funThing) && (
+            <>
+              <span className="into-text"> is into </span>
+              {person.workThing && (
+                <>
+                  {person.workThingUrl ? (
+                    <Link
+                      href={formatUrl(person.workThingUrl)}
+                      target="_blank"
+                      className="interest work"
+                    >
+                      {person.workThing}
+                    </Link>
+                  ) : (
+                    <span className="interest work">{person.workThing}</span>
+                  )}
+                </>
+              )}
+              {person.workThing && person.funThing && (
+                <span className="and-text"> and </span>
+              )}
+              {person.funThing && (
+                <>
+                  {person.funThingUrl ? (
+                    <Link
+                      href={formatUrl(person.funThingUrl)}
+                      target="_blank"
+                      className="interest fun"
+                    >
+                      {person.funThing}
+                    </Link>
+                  ) : (
+                    <span className="interest fun">{person.funThing}</span>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </div>
+        {entry.contactFor.length > 0 && (
+          <div className="staff-contact-for">
+            <span className="staff-contact-label">contact for:</span>
+            {entry.contactFor.map((tag) => {
+              const hue = hashHue(tag)
+              return (
+                <span
+                  key={tag}
+                  className="staff-contact-tag"
+                  style={{
+                    background: `hsl(${hue} 70% 92%)`,
+                    color: `hsl(${hue} 60% 28%)`,
+                    borderColor: `hsl(${hue} 60% 75%)`,
+                  }}
+                >
+                  {tag}
+                </span>
+              )
+            })}
+          </div>
+        )}
+        {entry.email && (
+          <div className="staff-email-row">
+            <a href={`mailto:${entry.email}`} className="staff-email">
+              <Mail className="staff-email-icon" size={16} aria-hidden="true" />
+              {entry.email}
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function PersonEntry({
   person,
   affiliation,
@@ -179,7 +320,7 @@ function PersonEntry({
   person: Person
   affiliation?: string
 }) {
-  const { url } = person.photo?.[0]?.thumbnails?.large ?? { url: null }
+  const { url } = person.photo?.[0]?.thumbnails?.full ?? person.photo?.[0]?.thumbnails?.large ?? { url: null }
   const hasContent = url || person.workThing || person.funThing
 
   // Get initials from name
@@ -195,9 +336,9 @@ function PersonEntry({
           <Image
             src={url}
             alt={person.name}
-            width={90}
-            height={90}
-            sizes="90px"
+            width={180}
+            height={180}
+            sizes="180px"
             className="photo-img"
           />
         ) : (

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -4,6 +4,7 @@ import {
   getPeople,
   getOrgs,
   getPrograms,
+  getStaff,
   filterPeople,
   buildDirectoryData,
 } from './people'
@@ -18,18 +19,25 @@ export default async function PeoplePage({ searchParams }: { searchParams: Promi
   let people: Awaited<ReturnType<typeof getPeople>> = []
   let orgsMap: Awaited<ReturnType<typeof getOrgs>> = new Map()
   let programsMap: Awaited<ReturnType<typeof getPrograms>> = new Map()
+  let staffEntries: Awaited<ReturnType<typeof getStaff>> = []
 
   try {
     ;[people, orgsMap, programsMap] = await Promise.all([
       getPeople(), getOrgs(), getPrograms(),
     ])
+    staffEntries = await getStaff(people)
   } catch (e) {
     console.error('Failed to fetch people data:', e)
   }
 
   const params = await searchParams
   const filteredPeople = filterPeople(people, params.filter)
-  const { sections, orgsLookup, programsLookup } = buildDirectoryData(filteredPeople, orgsMap, programsMap)
+  const { sections, orgsLookup, programsLookup } = buildDirectoryData(
+    filteredPeople,
+    orgsMap,
+    programsMap,
+    staffEntries
+  )
 
   return (
     <div className="directory-wrapper">

--- a/app/people/people.css
+++ b/app/people/people.css
@@ -295,13 +295,8 @@ a.interest.fun:hover {
   padding: 8px 12px;
 }
 
-/* Homepage directory - breakout to ~70% viewport width */
+/* Homepage directory - sits in the page's natural 4xl gutter */
 .homepage-directory {
-  max-width: none;
-  width: 70vw;
-  position: relative;
-  left: 50%;
-  transform: translateX(-50%);
   padding: 30px 0;
 }
 
@@ -309,9 +304,9 @@ a.interest.fun:hover {
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 }
 
-@media (min-width: 1000px) {
+@media (min-width: 900px) {
   .homepage-directory .directory-list {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -412,4 +407,105 @@ a.collapsed-name:hover {
   text-align: center;
   padding: 50px 20px;
   font-size: 0.95em;
+}
+
+/* Staff card hierarchy: TITLE > name+is-into > contact-for > email */
+.staff-title {
+  font-size: 0.7em;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+}
+
+.staff-entry .person-main {
+  font-size: 1.05em;
+  margin-bottom: 8px;
+}
+
+.staff-contact-for {
+  font-size: 0.85em;
+  margin-bottom: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+
+.staff-contact-label {
+  color: var(--text-secondary);
+  margin-right: 2px;
+}
+
+.staff-contact-tag {
+  display: inline-block;
+  padding: 2px 9px;
+  border-radius: 999px;
+  border: 1px solid;
+  font-size: 0.95em;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.staff-email-row {
+  font-size: 0.8em;
+}
+
+a.staff-email,
+a.staff-email:visited {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+a.staff-email:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.staff-email-icon {
+  display: inline-block;
+  vertical-align: -3px;
+  margin-right: 6px;
+  opacity: 0.8;
+}
+
+/* Staff cards: bigger to accommodate title + name + email + interests + contact-for */
+.staff-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  gap: 12px;
+}
+
+.staff-list .person-entry.staff-entry {
+  aspect-ratio: auto;
+  min-height: 150px;
+}
+
+/* Cap the photo column so narrow cards still leave room for text */
+.staff-list .person-entry.staff-entry .person-photo {
+  width: 150px;
+  height: 150px;
+  flex-shrink: 0;
+}
+
+.staff-list .person-entry.staff-entry .person-info {
+  padding: 12px 15px;
+}
+
+@media (max-width: 600px) {
+  .staff-list {
+    grid-template-columns: 1fr;
+  }
+  .staff-list .person-entry.staff-entry .person-photo {
+    width: 110px;
+    height: 110px;
+  }
+}
+
+/* On homepage, staff cards stack single-column since the page gutter is narrower */
+.homepage-directory .staff-list {
+  grid-template-columns: 1fr;
 }

--- a/app/people/people.ts
+++ b/app/people/people.ts
@@ -27,6 +27,15 @@ export type Program = {
   rooms: string[]
 }
 
+export type Staff = {
+  id: string
+  title: string
+  email: string
+  contactFor: string[]
+  rank: number
+  person: Person | null
+}
+
 interface PersonFields {
   Name?: string
   Tier?: string
@@ -136,6 +145,31 @@ export async function getOrgs(): Promise<Map<string, Org>> {
   return orgsMap
 }
 
+interface StaffFields {
+  Title?: string
+  'Main Record'?: string[]
+  'Staff Email'?: string
+  'Contact for'?: string[]
+  Rank?: number
+}
+
+export async function getStaff(people: Person[]): Promise<Staff[]> {
+  const records = await findRecords<StaffFields>(Tables.Staff, '', {})
+  const peopleById = new Map(people.map((p) => [p.id, p]))
+
+  return records.map((record) => {
+    const personId = record.fields['Main Record']?.[0]
+    return {
+      id: record.id,
+      title: record.fields.Title || '',
+      email: record.fields['Staff Email'] || '',
+      contactFor: record.fields['Contact for'] || [],
+      rank: record.fields.Rank ?? 999,
+      person: personId ? peopleById.get(personId) || null : null,
+    }
+  })
+}
+
 // Fetch all programs with their room numbers
 interface ProgramFields {
   Name?: string
@@ -162,16 +196,30 @@ export async function getPrograms(): Promise<Map<string, Program>> {
 export function buildDirectoryData(
   people: Person[],
   orgsMap: Map<string, Org>,
-  programsMap: Map<string, Program>
+  programsMap: Map<string, Program>,
+  staffEntries: Staff[] = []
 ) {
-  const staff = sortPeopleByCompleteness(
-    people.filter((p) => p.tier === 'Staff')
+  const staffByPersonId = new Map(
+    staffEntries.filter((s) => s.person).map((s) => [s.person!.id, s])
   )
+
+  const staff = [...staffEntries]
+    .filter((s) => s.person)
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank
+      return (a.person?.name || '').localeCompare(b.person?.name || '')
+    })
+
   const privateOffices = sortPeopleByCompleteness(
     people.filter((p) => p.tier === 'Private Office')
   )
   const members = sortPeopleByCompleteness(
-    people.filter((p) => p.tier !== 'Staff' && p.tier !== 'Private Office')
+    people.filter(
+      (p) =>
+        p.tier !== 'Staff' &&
+        p.tier !== 'Private Office' &&
+        !staffByPersonId.has(p.id)
+    )
   )
 
   // Group private offices by org (excluding stealth)
@@ -217,7 +265,7 @@ export function buildDirectoryData(
   programsMap.forEach((program, id) => { programsLookup[id] = { name: program.name } })
 
   const sections = [
-    { type: 'person-section' as const, title: 'Staff', people: staff, affiliationType: 'org' as const },
+    { type: 'staff-section' as const, title: 'Staff', staff },
     { type: 'grouped-section' as const, title: 'Programs', groups: sortedPrograms.map(([id, g]) => ({ id, ...g })) },
     { type: 'grouped-section' as const, title: 'Offices', groups: sortedOrgs.map(([id, g]) => ({ id, ...g })) },
     { type: 'person-section' as const, title: 'Members', people: membersWithoutProgram, affiliationType: 'both' as const },


### PR DESCRIPTION
Closes #66.

## Summary
- Reads a new Airtable Staff table (`tblbmm9NRs5ANd6IV`) that links each staff record to a Person record, with `Title`, `Staff Email`, `Contact for` (multi-select), and `Rank` (numeric for partial ordering).
- Renders a dedicated Staff section at the top of /people with bigger cards: title, name + "is into" line, contact-for pills (deterministic hash → hue, no Airtable color round-trip), and mailto link with a Mail icon.
- Same staff section now also appears on the homepage directory, sized appropriately for the narrower gutter.

## Side fixes
- Bumped person-card image dimensions from 90→180px and prefer the `full` thumbnail over `large`, since rendered photo cells were larger than the asset and looked low-res.
- Dropped the homepage directory's 70vw breakout — it didn't play nicely with the taller staff cards. Directory now sits in the page's natural max-w-4xl gutter, regular member cards go 2-col instead of 3-col on wider viewports.

## Test plan
- [x] /people renders staff section with all 6 entries from the Staff table
- [x] Each staff card shows: title, name, is-into line, contact-for pills (each with its own consistent color), mailto link
- [x] Staff are ordered by Rank ascending, then alphabetically by name
- [x] Members listed in the Staff table are de-duplicated from the regular Members section
- [x] Homepage shows the same staff section, fitting in the narrower gutter
- [x] mailto link works, hover state shows dotted underline
- [ ] Member photos throughout the directory look noticeably sharper

🤖 Generated with [Claude Code](https://claude.com/claude-code)