### PR TITLE
Add /door event-attendee unlock with time-window scoping

### DIFF
--- a/app/day-pass/activate/unlock-api/route.ts
+++ b/app/day-pass/activate/unlock-api/route.ts
@@ -1,4 +1,4 @@
-import { env } from '@/app/lib/env'
+import { adminUnlockDoor } from '@/app/lib/verkada'
 
 export async function POST(request: Request) {
   try {
@@ -8,62 +8,13 @@ export async function POST(request: Request) {
       return Response.json({ success: false, error: 'No payment ID provided' })
     }
 
-    // Simple validation: just check that a payment ID was provided
-    // Anyone with a valid activate link can unlock
-    return await unlockDoor()
+    const result = await adminUnlockDoor()
+    if (result.ok) {
+      return Response.json({ success: true })
+    }
+    return Response.json({ success: false, error: result.error })
   } catch (error) {
     console.error('Error processing door unlock:', error)
     return Response.json({ success: false, error: 'Server error' })
-  }
-}
-
-async function unlockDoor() {
-  try {
-    // Generate Verkada API token
-    const tokenRes = await fetch('https://api.verkada.com/token', {
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        'x-api-key': env.VERKADA_API_KEY,
-      },
-    })
-
-    if (!tokenRes.ok) {
-      console.error('Failed to get Verkada token:', tokenRes.status)
-      return Response.json({
-        success: false,
-        error: 'Failed to authenticate with door system',
-      })
-    }
-
-    const { token } = await tokenRes.json()
-
-    // Unlock door using token
-    const resp = await fetch(
-      'https://api.verkada.com/access/v1/door/admin_unlock',
-      {
-        method: 'POST',
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          'x-verkada-auth': token,
-        },
-        body: JSON.stringify({
-          door_id: 'ffa16025-e120-4094-b6be-29a6ed19b84c',
-        }),
-      }
-    )
-
-    const data = await resp.json()
-
-    if (resp.status === 200) {
-      return Response.json({ success: true })
-    } else {
-      console.error('Verkada unlock failed:', data)
-      return Response.json({ success: false, error: 'Failed to unlock door' })
-    }
-  } catch (error) {
-    console.error('Error unlocking door:', error)
-    return Response.json({ success: false, error: 'Failed to unlock door' })
   }
 }

--- a/app/door/api/unlock/route.ts
+++ b/app/door/api/unlock/route.ts
@@ -1,0 +1,61 @@
+import { getEventByToken } from '@/app/lib/events'
+import { isWithinEventWindow } from '@/app/lib/event-access'
+import { adminUnlockDoor } from '@/app/lib/verkada'
+
+const throttleMap = new Map<string, { count: number; resetAt: number }>()
+const THROTTLE_WINDOW_MS = 30_000
+const THROTTLE_MAX = 10
+
+function checkThrottle(token: string): boolean {
+  const now = Date.now()
+  const entry = throttleMap.get(token)
+  if (!entry || now > entry.resetAt) {
+    throttleMap.set(token, { count: 1, resetAt: now + THROTTLE_WINDOW_MS })
+    return true
+  }
+  if (entry.count >= THROTTLE_MAX) return false
+  entry.count++
+  return true
+}
+
+export async function POST(request: Request) {
+  try {
+    const { token } = await request.json()
+
+    if (!token || typeof token !== 'string' || !/^[A-Za-z0-9]{12}$/.test(token)) {
+      return Response.json({ success: false, reason: 'invalid' })
+    }
+
+    if (!checkThrottle(token)) {
+      return Response.json(
+        { success: false, reason: 'throttled' },
+        { status: 429 }
+      )
+    }
+
+    const event = await getEventByToken(token)
+    if (!event) {
+      return Response.json({ success: false, reason: 'not-found' })
+    }
+
+    if (!isWithinEventWindow(event.startDate, event.endDate)) {
+      console.log(
+        `[door-unlock] event=${event.id} name="${event.name}" ok=false reason=inactive`
+      )
+      return Response.json({ success: false, reason: 'inactive' })
+    }
+
+    const result = await adminUnlockDoor()
+    console.log(
+      `[door-unlock] event=${event.id} name="${event.name}" ok=${result.ok}`
+    )
+
+    if (result.ok) {
+      return Response.json({ success: true })
+    }
+    return Response.json({ success: false, reason: 'verkada-error' })
+  } catch (error) {
+    console.error('Error processing door unlock:', error)
+    return Response.json({ success: false, reason: 'error' }, { status: 500 })
+  }
+}

--- a/app/door/api/validate/route.ts
+++ b/app/door/api/validate/route.ts
@@ -1,0 +1,68 @@
+import { getEventByToken, formatEventTime } from '@/app/lib/events'
+import { isWithinEventWindow, getEffectiveEnd } from '@/app/lib/event-access'
+
+const ipThrottleMap = new Map<string, { count: number; resetAt: number }>()
+const IP_WINDOW_MS = 60_000
+const IP_MAX = 30
+
+function checkIpThrottle(ip: string): boolean {
+  const now = Date.now()
+  const entry = ipThrottleMap.get(ip)
+  if (!entry || now > entry.resetAt) {
+    ipThrottleMap.set(ip, { count: 1, resetAt: now + IP_WINDOW_MS })
+    return true
+  }
+  if (entry.count >= IP_MAX) return false
+  entry.count++
+  return true
+}
+
+function getClientIp(request: Request): string {
+  const xff = request.headers.get('x-forwarded-for')
+  if (xff) return xff.split(',')[0].trim()
+  const real = request.headers.get('x-real-ip')
+  if (real) return real
+  return 'unknown'
+}
+
+export async function POST(request: Request) {
+  try {
+    const ip = getClientIp(request)
+    if (!checkIpThrottle(ip)) {
+      console.warn(`[door-validate] ip=${ip} throttled`)
+      return Response.json(
+        { status: 'not-found' },
+        { status: 429, headers: { 'Cache-Control': 'no-store' } }
+      )
+    }
+
+    const { token } = await request.json()
+
+    if (!token || typeof token !== 'string' || !/^[A-Za-z0-9]{12}$/.test(token)) {
+      return Response.json({ status: 'not-found' }, { headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    const event = await getEventByToken(token)
+    if (!event) {
+      console.log(`[door-validate] ip=${ip} not-found`)
+      return Response.json({ status: 'not-found' }, { headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    const active = isWithinEventWindow(event.startDate, event.endDate)
+    const effectiveEnd = getEffectiveEnd(event.startDate, event.endDate)
+
+    return Response.json(
+      {
+        status: active ? 'active' : 'inactive',
+        eventName: event.name,
+        formattedHours: formatEventTime(event, true),
+        startsAt: event.startDate.toISOString(),
+        endsAt: effectiveEnd.toISOString(),
+      },
+      { headers: { 'Cache-Control': 'no-store' } }
+    )
+  } catch (error) {
+    console.error('Error validating door token:', error)
+    return Response.json({ status: 'error' }, { status: 500 })
+  }
+}

--- a/app/door/page.tsx
+++ b/app/door/page.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+type PageState = 'loading' | 'active' | 'inactive' | 'not-found' | 'error'
+
+interface ValidateResponse {
+  status: PageState
+  eventName?: string
+  formattedHours?: string
+}
+
+function DoorPageContent() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get('evt')
+  const [state, setState] = useState<PageState>('loading')
+  const [eventName, setEventName] = useState('')
+  const [formattedHours, setFormattedHours] = useState('')
+  const [unlocking, setUnlocking] = useState(false)
+  const [unlockedAt, setUnlockedAt] = useState<number | null>(null)
+  const [unlockError, setUnlockError] = useState('')
+
+  useEffect(() => {
+    if (!token) {
+      setState('not-found')
+      return
+    }
+
+    fetch('/door/api/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+      .then((res) => res.json())
+      .then((data: ValidateResponse) => {
+        setState(data.status)
+        if (data.eventName) setEventName(data.eventName)
+        if (data.formattedHours) setFormattedHours(data.formattedHours)
+      })
+      .catch(() => setState('error'))
+  }, [token])
+
+  useEffect(() => {
+    if (unlockedAt === null) return
+    const timer = setTimeout(() => setUnlockedAt(null), 8000)
+    return () => clearTimeout(timer)
+  }, [unlockedAt])
+
+  const handleUnlock = async () => {
+    if (!token) return
+    setUnlocking(true)
+    setUnlockError('')
+    try {
+      const res = await fetch('/door/api/unlock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setUnlockedAt(Date.now())
+      } else if (data.reason === 'inactive') {
+        setUnlockError("This link isn't active right now.")
+        setState('inactive')
+      } else if (data.reason === 'throttled') {
+        setUnlockError('Too many attempts. Wait a moment and try again.')
+      } else {
+        setUnlockError("Couldn't unlock. Try again, or contact us.")
+      }
+    } catch {
+      setUnlockError("Couldn't unlock. Try again, or contact us.")
+    } finally {
+      setUnlocking(false)
+    }
+  }
+
+  if (state === 'loading') {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-amber-800 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'active') {
+    const justUnlocked = unlockedAt !== null
+    return (
+      <div className="min-h-screen bg-slate-50 text-gray-800">
+        <div className="max-w-md mx-auto pt-8 pb-8 px-6">
+          <div className="bg-amber-50 border-2 border-amber-200 p-6 mb-6 text-center">
+            <div className="text-sm text-amber-700 mb-1">Event</div>
+            <div className="text-2xl font-bold text-amber-900 mb-2">
+              {eventName}
+            </div>
+            <div className="text-sm text-amber-800">{formattedHours}</div>
+          </div>
+
+          <button
+            onClick={handleUnlock}
+            disabled={unlocking}
+            className={`w-full py-6 text-xl font-semibold transition-all mb-4 ${
+              justUnlocked
+                ? 'bg-green-600 text-white'
+                : unlocking
+                  ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  : 'bg-amber-800 text-white hover:bg-amber-900'
+            }`}
+          >
+            {unlocking
+              ? 'Unlocking...'
+              : justUnlocked
+                ? '✓ Door open — go on in'
+                : 'Unlock Door'}
+          </button>
+
+          {unlockError && (
+            <p className="text-sm text-red-600 text-center mb-4">
+              {unlockError}
+            </p>
+          )}
+
+          <div className="bg-white border border-slate-200 p-4 mb-6">
+            <div className="flex items-start gap-3">
+              <span className="text-xl">📍</span>
+              <div>
+                <div className="font-semibold text-gray-800">
+                  1680 Mission St
+                </div>
+                <div className="text-sm text-gray-500">
+                  Tap Unlock when you&apos;re at the front door
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="text-center text-sm text-gray-400">
+            Questions?{' '}
+            <a
+              href="mailto:team@moxsf.com"
+              className="text-amber-800 hover:text-amber-600"
+            >
+              team@moxsf.com
+            </a>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'inactive') {
+    return (
+      <div className="min-h-screen bg-slate-50 text-gray-800">
+        <div className="max-w-md mx-auto pt-16 pb-8 px-6 text-center">
+          <div className="text-4xl mb-4">⏰</div>
+          <h1 className="text-2xl font-bold mb-2 text-gray-800">
+            Not active right now
+          </h1>
+          {eventName && (
+            <p className="text-gray-700 mb-1 font-semibold">{eventName}</p>
+          )}
+          {formattedHours && (
+            <p className="text-gray-600 mb-6">{formattedHours}</p>
+          )}
+          <p className="text-sm text-gray-500">
+            This unlock link only works during the event hours above.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'not-found') {
+    return (
+      <div className="min-h-screen bg-slate-50 text-gray-800">
+        <div className="max-w-md mx-auto pt-16 pb-8 px-6 text-center">
+          <div className="text-4xl mb-4">🔍</div>
+          <h1 className="text-2xl font-bold mb-2 text-gray-800">
+            Link not valid
+          </h1>
+          <p className="text-gray-600 mb-6">
+            Check the link you were sent, or contact the event organizer.
+          </p>
+          <a
+            href="mailto:team@moxsf.com"
+            className="inline-block px-6 py-3 bg-amber-800 text-white font-semibold hover:bg-amber-900 transition-all"
+          >
+            Contact Us
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-gray-800">
+      <div className="max-w-md mx-auto pt-16 pb-8 px-6 text-center">
+        <div className="text-4xl mb-4">😕</div>
+        <h1 className="text-2xl font-bold mb-2 text-gray-800">
+          Something went wrong
+        </h1>
+        <p className="text-gray-600 mb-6">
+          Try refreshing, or contact us for help.
+        </p>
+        <div className="space-x-3">
+          <button
+            onClick={() => window.location.reload()}
+            className="inline-block px-6 py-3 bg-gray-200 text-gray-700 font-semibold hover:bg-gray-300 transition-all"
+          >
+            Refresh
+          </button>
+          <a
+            href="mailto:team@moxsf.com"
+            className="inline-block px-6 py-3 bg-amber-800 text-white font-semibold hover:bg-amber-900 transition-all"
+          >
+            Contact Us
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function DoorPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-amber-800 mx-auto mb-4"></div>
+            <p className="text-gray-600">Loading...</p>
+          </div>
+        </div>
+      }
+    >
+      <DoorPageContent />
+    </Suspense>
+  )
+}

--- a/app/lib/automations-manifest.ts
+++ b/app/lib/automations-manifest.ts
@@ -41,6 +41,30 @@ export const AUTOMATIONS: AutomationManifestEntry[] =
     "summary": "Activates a purchased day pass, sets date and reveals door code"
   },
   {
+    "id": "day-pass/activate/unlock-api",
+    "filePath": "app/day-pass/activate/unlock-api/route.ts",
+    "routePath": "/day-pass/activate/unlock-api",
+    "type": "event-action",
+    "httpMethod": "POST",
+    "summary": "Triggers a Verkada admin unlock of the front door from the day-pass activation page"
+  },
+  {
+    "id": "door/unlock",
+    "filePath": "app/door/api/unlock/route.ts",
+    "routePath": "/door/api/unlock",
+    "type": "event-action",
+    "httpMethod": "POST",
+    "summary": "Unlocks the front door for an event attendee with a valid event token, only during the event's hours"
+  },
+  {
+    "id": "door/validate",
+    "filePath": "app/door/api/validate/route.ts",
+    "routePath": "/door/api/validate",
+    "type": "event-action",
+    "httpMethod": "POST",
+    "summary": "Validates an event door token and reports whether the unlock window is currently active"
+  },
+  {
     "id": "eag26/register",
     "filePath": "app/eag26/api/register/route.ts",
     "routePath": "/eag26/api/register",

--- a/app/lib/event-access.test.ts
+++ b/app/lib/event-access.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getEffectiveEnd,
+  isWithinEventWindow,
+  DEFAULT_WINDOW_HOURS,
+} from './event-access'
+
+describe('getEffectiveEnd', () => {
+  it('returns the explicit end when provided', () => {
+    const start = new Date('2026-05-10T18:00:00Z')
+    const end = new Date('2026-05-10T20:00:00Z')
+    expect(getEffectiveEnd(start, end)).toEqual(end)
+  })
+
+  it('falls back to start + 3 hours when end is missing', () => {
+    const start = new Date('2026-05-10T18:00:00Z')
+    expect(getEffectiveEnd(start)).toEqual(new Date('2026-05-10T21:00:00Z'))
+  })
+
+  it('uses DEFAULT_WINDOW_HOURS for the fallback', () => {
+    const start = new Date('2026-05-10T18:00:00Z')
+    const fallback = getEffectiveEnd(start)
+    const expected = new Date(
+      start.getTime() + DEFAULT_WINDOW_HOURS * 60 * 60 * 1000
+    )
+    expect(fallback).toEqual(expected)
+  })
+})
+
+describe('isWithinEventWindow', () => {
+  const start = new Date('2026-05-10T18:00:00Z')
+  const end = new Date('2026-05-10T20:00:00Z')
+
+  it('returns false before the start', () => {
+    const now = new Date('2026-05-10T17:59:59Z')
+    expect(isWithinEventWindow(start, end, now)).toBe(false)
+  })
+
+  it('returns true at the exact start', () => {
+    expect(isWithinEventWindow(start, end, start)).toBe(true)
+  })
+
+  it('returns true mid-window', () => {
+    const now = new Date('2026-05-10T19:00:00Z')
+    expect(isWithinEventWindow(start, end, now)).toBe(true)
+  })
+
+  it('returns true at the exact end', () => {
+    expect(isWithinEventWindow(start, end, end)).toBe(true)
+  })
+
+  it('returns false after the end', () => {
+    const now = new Date('2026-05-10T20:00:01Z')
+    expect(isWithinEventWindow(start, end, now)).toBe(false)
+  })
+
+  it('uses 3-hour fallback when end is missing — within', () => {
+    const now = new Date('2026-05-10T20:30:00Z')
+    expect(isWithinEventWindow(start, undefined, now)).toBe(true)
+  })
+
+  it('uses 3-hour fallback when end is missing — past', () => {
+    const now = new Date('2026-05-10T21:00:01Z')
+    expect(isWithinEventWindow(start, undefined, now)).toBe(false)
+  })
+
+  it('handles spring-forward DST boundary (PT)', () => {
+    // 2026-03-08 02:00 PT springs forward to 03:00. A 6pm PT event on the
+    // prior day should still evaluate cleanly across the gap.
+    const dstStart = new Date('2026-03-07T02:00:00-08:00')
+    const dstEnd = new Date('2026-03-08T05:00:00-07:00')
+    const midDst = new Date('2026-03-08T01:30:00-08:00')
+    expect(isWithinEventWindow(dstStart, dstEnd, midDst)).toBe(true)
+  })
+})

--- a/app/lib/event-access.ts
+++ b/app/lib/event-access.ts
@@ -1,0 +1,16 @@
+import { addHours } from 'date-fns'
+
+export const DEFAULT_WINDOW_HOURS = 3
+
+export function getEffectiveEnd(start: Date, end?: Date): Date {
+  return end ?? addHours(start, DEFAULT_WINDOW_HOURS)
+}
+
+export function isWithinEventWindow(
+  start: Date,
+  end: Date | undefined,
+  now: Date = new Date()
+): boolean {
+  const effectiveEnd = getEffectiveEnd(start, end)
+  return now >= start && now <= effectiveEnd
+}

--- a/app/lib/events.ts
+++ b/app/lib/events.ts
@@ -1,5 +1,11 @@
 import { format, parseISO, isSameDay, startOfDay } from 'date-fns'
-import { getRecords, Tables, AirtableRecord } from './airtable'
+import {
+  getRecords,
+  findRecord,
+  Tables,
+  AirtableRecord,
+  escapeAirtableString,
+} from './airtable'
 
 // The raw event fields from Airtable
 interface EventFields {
@@ -15,6 +21,7 @@ interface EventFields {
   'Host Name'?: string
   Featured?: boolean
   Priority?: string
+  'Door Token'?: string
   'Event Poster'?: {
     id: string
     url: string
@@ -64,6 +71,7 @@ export interface Event {
     }
   }
   retro?: string
+  doorToken?: string
 }
 
 export function parseAirtableEvent(record: AirtableEvent): Event {
@@ -92,6 +100,7 @@ export function parseAirtableEvent(record: AirtableEvent): Event {
         }
       : undefined,
     retro: record.fields['Event Retro'],
+    doorToken: record.fields['Door Token'],
   }
 }
 
@@ -115,6 +124,14 @@ const EVENT_FIELDS = [
   'Event Poster',
   'Event Retro',
 ]
+
+export async function getEventByToken(token: string): Promise<Event | null> {
+  if (!/^[A-Za-z0-9]{12}$/.test(token)) return null
+  const escaped = escapeAirtableString(token)
+  const formula = `AND({Status}='Confirmed', {Door Token}='${escaped}')`
+  const rec = await findRecord<EventFields>(Tables.Events, formula)
+  return rec ? parseAirtableEvent(rec) : null
+}
 
 export async function getEvents(): Promise<Event[]> {
   const records = await getRecords<EventFields>(Tables.Events, {

--- a/app/lib/verkada.ts
+++ b/app/lib/verkada.ts
@@ -1,0 +1,82 @@
+import { env } from './env'
+
+export const MOX_FRONT_DOOR_ID = 'ffa16025-e120-4094-b6be-29a6ed19b84c'
+
+const TOKEN_TTL_MS = 25 * 60 * 1000
+let cachedToken: { token: string; expiresAt: number } | null = null
+let inflight: Promise<string | null> | null = null
+
+async function fetchAdminToken(): Promise<string | null> {
+  const res = await fetch('https://api.verkada.com/token', {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'x-api-key': env.VERKADA_MEMBER_KEY,
+    },
+  })
+
+  if (!res.ok) {
+    console.error('Failed to get Verkada token:', res.status)
+    return null
+  }
+
+  const { token } = await res.json()
+  return token ?? null
+}
+
+async function getAdminToken(): Promise<string | null> {
+  const now = Date.now()
+  if (cachedToken && cachedToken.expiresAt > now) {
+    return cachedToken.token
+  }
+  if (inflight) return inflight
+
+  inflight = (async () => {
+    const token = await fetchAdminToken()
+    if (token) {
+      cachedToken = { token, expiresAt: Date.now() + TOKEN_TTL_MS }
+    }
+    return token
+  })()
+
+  try {
+    return await inflight
+  } finally {
+    inflight = null
+  }
+}
+
+export async function adminUnlockDoor(
+  doorId: string = MOX_FRONT_DOOR_ID
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const token = await getAdminToken()
+    if (!token) {
+      return { ok: false, error: 'Failed to authenticate with door system' }
+    }
+
+    const resp = await fetch(
+      'https://api.verkada.com/access/v1/door/admin_unlock',
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          'x-verkada-auth': token,
+        },
+        body: JSON.stringify({ door_id: doorId }),
+      }
+    )
+
+    if (resp.status === 200) {
+      return { ok: true }
+    }
+
+    const data = await resp.json().catch(() => ({}))
+    console.error('Verkada unlock failed:', data)
+    return { ok: false, error: 'Failed to unlock door' }
+  } catch (error) {
+    console.error('Error unlocking door:', error)
+    return { ok: false, error: 'Failed to unlock door' }
+  }
+}

--- a/docs/airtable-schema.md
+++ b/docs/airtable-schema.md
@@ -81,6 +81,7 @@ Manages events and activities.
 | `Event Retro` | multilineText | Post-event retrospective | |
 | `Revenue` | currency | Event revenue | |
 | `Invoice Status` | singleSelect | Payment status | |
+| `Door Token` | singleLineText | 12-char alphanumeric token gating the `/door?evt=…` unlock link. Populated by an Airtable automation when `Status` becomes `Confirmed`. | ✅ Door unlock |
 
 **Status options:** Idea, Maybe, Confirmed, To invoice, Invoiced, Paid, Cancelled, Recurring, Declined
 

--- a/scripts/scan-automations.ts
+++ b/scripts/scan-automations.ts
@@ -34,6 +34,9 @@ const PORTAL_AUTOMATION_ROUTES = [
 const OTHER_AUTOMATION_ROUTES = [
   'eag26/api/register',
   'day-pass/activate/api',
+  'day-pass/activate/unlock-api',
+  'door/api/validate',
+  'door/api/unlock',
 ]
 
 interface CronConfig {


### PR DESCRIPTION
## Summary
- New `moxsf.com/door?evt=<token>` mobile page unlocks the front door for event attendees, validating both the token and the current time against the event's hours.
- Token-per-event is shared with all attendees via Luma/Partiful blast (no per-attendee auth). 12-char alphanumeric token (~71 bits) + per-IP throttle on validate (30/min) + per-token throttle on unlock (10/30s).
- Token generation is owned by an Airtable automation that fires when `Status` flips to `Confirmed` — no code in this repo runs to mint tokens, no scheduled job, no endpoint to secure.
- Side effect: extracts Verkada admin-unlock into `app/lib/verkada.ts` (now used by both `/door` and the day-pass route) and switches the `/token` call from `VERKADA_API_KEY` to `VERKADA_MEMBER_KEY`. The old key was returning 409 — every other working `/token` caller in the repo uses the member key.

## Test plan
- [x] Unit: 11 new tests in `app/lib/event-access.test.ts` cover the time-window logic (start/end edges, missing endDate fallback, DST boundary)
- [x] Full suite green: `bun run test` — 97 passed
- [x] `bun run tsc --noEmit` clean
- [x] Local: `/door?evt=<token>` during event window → physical door unlocks
- [x] Local: invalid/garbage token → "not-found"
- [x] Local: per-IP throttle returns 429 after 30 rapid validate calls
- [x] Local: day-pass remote-unlock regression — same response shape
- [ ] After merge: verify Airtable automation populates `Door Token` on `Status = Confirmed`
- [ ] After merge: end-to-end with a real event invite via Luma

## Airtable side (not in this PR)
- New `Door Token` singleLineText field on Events table
- Airtable automation: trigger when `Status` changes, condition `Status = 'Confirmed' AND {Door Token} is empty`, script step generates a 12-char alphanumeric token

🤖 Generated with [Claude Code](https://claude.com/claude-code)