### PR TITLE
Gate portal door access and guest passes by active membership

### DIFF
--- a/app/lib/automations-manifest.ts
+++ b/app/lib/automations-manifest.ts
@@ -113,6 +113,14 @@ export const AUTOMATIONS: AutomationManifestEntry[] =
     "summary": "Syncs a single member's Discord role to match their Airtable tier"
   },
   {
+    "id": "portal/unlock-door",
+    "filePath": "app/portal/api/unlock-door/route.ts",
+    "routePath": "/portal/api/unlock-door",
+    "type": "portal-action",
+    "httpMethod": "POST",
+    "summary": "Unlocks the front door for an active member from the portal homepage"
+  },
+  {
     "id": "webhooks/discord",
     "filePath": "app/api/webhooks/discord/route.ts",
     "routePath": "/api/webhooks/discord",

--- a/app/lib/membership.test.ts
+++ b/app/lib/membership.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { isActiveMember, canIssueGuestDayPass } from './membership'
+
+describe('isActiveMember', () => {
+  it('lets Staff through regardless of status', () => {
+    expect(isActiveMember({ status: 'Applied', tier: 'Staff' })).toBe(true)
+    expect(isActiveMember({ status: null, tier: 'Staff' })).toBe(true)
+  })
+
+  it('accepts Joined paying tiers', () => {
+    for (const tier of ['Friend', 'Core', 'Resident', 'Private Office']) {
+      expect(isActiveMember({ status: 'Joined', tier })).toBe(true)
+    }
+  })
+
+  it('accepts Joined Program and Guest Program', () => {
+    expect(isActiveMember({ status: 'Joined', tier: 'Program' })).toBe(true)
+    expect(isActiveMember({ status: 'Joined', tier: 'Guest Program' })).toBe(true)
+  })
+
+  it('rejects non-Joined statuses for non-Staff', () => {
+    for (const status of ['Applied', 'Invited', 'Cancelled', 'Paused', null]) {
+      expect(isActiveMember({ status, tier: 'Core' })).toBe(false)
+    }
+  })
+
+  it('rejects inactive tiers even when Joined', () => {
+    for (const tier of ['Volunteer', 'Courtesy', 'Paused', null, undefined]) {
+      expect(isActiveMember({ status: 'Joined', tier })).toBe(false)
+    }
+  })
+})
+
+describe('canIssueGuestDayPass', () => {
+  it('lets Staff through', () => {
+    expect(canIssueGuestDayPass({ status: 'Applied', tier: 'Staff' })).toBe(true)
+  })
+
+  it('accepts Joined paying tiers', () => {
+    for (const tier of ['Friend', 'Core', 'Resident', 'Private Office']) {
+      expect(canIssueGuestDayPass({ status: 'Joined', tier })).toBe(true)
+    }
+  })
+
+  it('rejects Program and Guest Program (non-paying)', () => {
+    expect(canIssueGuestDayPass({ status: 'Joined', tier: 'Program' })).toBe(false)
+    expect(canIssueGuestDayPass({ status: 'Joined', tier: 'Guest Program' })).toBe(false)
+  })
+
+  it('rejects inactive statuses', () => {
+    for (const status of ['Applied', 'Cancelled', 'Paused', null]) {
+      expect(canIssueGuestDayPass({ status, tier: 'Core' })).toBe(false)
+    }
+  })
+
+  it('rejects inactive tiers', () => {
+    for (const tier of ['Volunteer', 'Courtesy', 'Paused']) {
+      expect(canIssueGuestDayPass({ status: 'Joined', tier })).toBe(false)
+    }
+  })
+})

--- a/app/lib/membership.ts
+++ b/app/lib/membership.ts
@@ -1,0 +1,20 @@
+import { ACTIVE_TIERS } from './discord-constants'
+
+export interface MembershipFields {
+  status?: string | null
+  tier?: string | null
+}
+
+const PAYING_TIERS = ['Friend', 'Core', 'Resident', 'Private Office'] as const
+
+export function isActiveMember({ status, tier }: MembershipFields): boolean {
+  if (tier === 'Staff') return true
+  if (status !== 'Joined' || !tier) return false
+  return (ACTIVE_TIERS as readonly string[]).includes(tier)
+}
+
+export function canIssueGuestDayPass({ status, tier }: MembershipFields): boolean {
+  if (tier === 'Staff') return true
+  if (status !== 'Joined' || !tier) return false
+  return (PAYING_TIERS as readonly string[]).includes(tier)
+}

--- a/app/portal/MembershipStatus.tsx
+++ b/app/portal/MembershipStatus.tsx
@@ -35,9 +35,30 @@ export default function MembershipStatus({
   }, [tier, orgId])
 
   const isInvited = status === 'Invited' || status === 'To Invite'
-  const isCancelled = status === 'Cancelled'
-  const hasSubscription = !!stripeCustomerId
   const isPrivateOffice = tier === 'Private Office'
+
+  // Translate Airtable internal statuses to softer user-facing copy.
+  // Statuses not in the map are shown verbatim.
+  const STATUS_DISPLAY: Record<string, string> = {
+    Joined: 'active',
+    Invited: 'invited',
+    'To Invite': 'invited',
+    Applied: 'application received',
+    Evaluating: 'application under review',
+    Waitlisted: 'waitlisted',
+    'Guest Program': 'guest program',
+    'Event Host': 'event host',
+    Paused: 'paused',
+    Cancelled: 'inactive',
+    'Payment Issue': 'payment issue',
+    Visited: 'inactive',
+    Backburner: 'inactive',
+    Rejected: 'inactive',
+    Declined: 'inactive',
+  }
+  const displayStatus = status
+    ? STATUS_DISPLAY[status] || status
+    : 'unknown'
 
   // Format tier display name
   // Tiers: Staff, Volunteer, Private Office, Program, Resident, Core, Friend, Courtesy, Guest Program, Paused
@@ -53,8 +74,8 @@ export default function MembershipStatus({
       <h2>access</h2>
 
       <p>
-        membership status: <strong>{status || 'unknown'}</strong>
-        {tier && !isInvited && (
+        membership status: <strong>{displayStatus}</strong>
+        {tier && !isInvited && displayStatus !== 'inactive' && (
           <>
             {' '}
             · membership type: <strong>{getTierDisplay()}</strong>
@@ -67,18 +88,6 @@ export default function MembershipStatus({
           </>
         )}
       </p>
-
-      {isCancelled && (
-        <div className="alert warning">
-          <p>
-            <strong>your subscription has been cancelled.</strong>
-          </p>
-          <p>
-            we'd love to have you back!{' '}
-            <Link href="/portal/renew">renew membership</Link>
-          </p>
-        </div>
-      )}
 
       {isInvited && (
         <>

--- a/app/portal/VerkadaPin.tsx
+++ b/app/portal/VerkadaPin.tsx
@@ -5,11 +5,13 @@ import { useState, useEffect } from 'react'
 interface VerkadaPinProps {
   isViewingAs?: boolean
   tier?: string | null
+  isActiveMember?: boolean
 }
 
 export default function VerkadaPin({
   isViewingAs = false,
   tier,
+  isActiveMember = false,
 }: VerkadaPinProps) {
   const [pin, setPin] = useState<string | null>(null)
   const [hasAccess, setHasAccess] = useState<boolean>(false)
@@ -20,10 +22,17 @@ export default function VerkadaPin({
   const [guestPin, setGuestPin] = useState<string | null>(null)
   const [showAppInfo, setShowAppInfo] = useState<boolean>(false)
   const [weeklyCode, setWeeklyCode] = useState<string | null>(null)
+  const [unlocking, setUnlocking] = useState<boolean>(false)
+  const [unlockedAt, setUnlockedAt] = useState<number | null>(null)
+  const [unlockError, setUnlockError] = useState<string | null>(null)
 
   const isGuestProgram = tier === 'Program' || tier === 'Guest Program'
 
   useEffect(() => {
+    if (!isActiveMember) {
+      setLoading(false)
+      return
+    }
     async function fetchPin() {
       try {
         const response = await fetch('/portal/api/verkada-pin')
@@ -45,9 +54,10 @@ export default function VerkadaPin({
     }
 
     fetchPin()
-  }, [])
+  }, [isActiveMember])
 
   useEffect(() => {
+    if (!isActiveMember) return
     async function fetchWeeklyCode() {
       try {
         const response = await fetch('/portal/api/weekly-door-code')
@@ -60,11 +70,11 @@ export default function VerkadaPin({
     }
 
     fetchWeeklyCode()
-  }, [])
+  }, [isActiveMember])
 
   // Fetch guest PIN for guest program members
   useEffect(() => {
-    if (!isGuestProgram) return
+    if (!isGuestProgram || !isActiveMember) return
 
     async function fetchGuestPin() {
       try {
@@ -80,7 +90,31 @@ export default function VerkadaPin({
     }
 
     fetchGuestPin()
-  }, [isGuestProgram])
+  }, [isGuestProgram, isActiveMember])
+
+  useEffect(() => {
+    if (unlockedAt === null) return
+    const timer = setTimeout(() => setUnlockedAt(null), 6000)
+    return () => clearTimeout(timer)
+  }, [unlockedAt])
+
+  const handleUnlock = async () => {
+    setUnlocking(true)
+    setUnlockError(null)
+    try {
+      const res = await fetch('/portal/api/unlock-door', { method: 'POST' })
+      const data = await res.json()
+      if (data.success) {
+        setUnlockedAt(Date.now())
+      } else {
+        setUnlockError(data.error || "couldn't unlock")
+      }
+    } catch {
+      setUnlockError("couldn't unlock")
+    } finally {
+      setUnlocking(false)
+    }
+  }
 
   const handleRegenerate = async () => {
     setShowConfirm(false)
@@ -117,6 +151,19 @@ export default function VerkadaPin({
     )
   }
 
+  if (!isActiveMember) {
+    return (
+      <>
+        <h3>door code</h3>
+        <p>
+          your membership isn&apos;t active right now, so door codes aren&apos;t
+          available. email{' '}
+          <a href="mailto:team@moxsf.com">team@moxsf.com</a> to sort it out.
+        </p>
+      </>
+    )
+  }
+
   if (error) {
     return (
       <>
@@ -126,10 +173,27 @@ export default function VerkadaPin({
     )
   }
 
+  const justUnlocked = unlockedAt !== null
   const weeklyCodeBlock = weeklyCode && (
     <div style={{ marginBottom: '20px' }}>
-      <p style={{ marginBottom: '5px' }}>this week's shared door code:</p>
-      <div className="pin-display">{weeklyCode}#</div>
+      <p style={{ marginBottom: '5px' }}>this week&apos;s shared door code:</p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+        <div className="pin-display">{weeklyCode}#</div>
+        <button
+          onClick={handleUnlock}
+          disabled={unlocking || justUnlocked || isViewingAs}
+          className={justUnlocked ? '' : 'primary'}
+        >
+          {unlocking
+            ? 'unlocking…'
+            : justUnlocked
+              ? '✓ unlocked'
+              : 'unlock door'}
+        </button>
+      </div>
+      {unlockError && (
+        <p className="error" style={{ marginTop: '8px' }}>{unlockError}</p>
+      )}
     </div>
   )
 
@@ -164,8 +228,9 @@ export default function VerkadaPin({
 
       {weeklyCodeBlock}
 
-      <p>
-        your personal PIN code. this is for guests or deliveries,{' '}
+      <p className="muted" style={{ fontSize: '0.9em' }}>
+        your personal PIN (for guests/deliveries): <code>{pin}#</code>
+        {' · '}
         <span
           onClick={() => setShowAppInfo(!showAppInfo)}
           style={{
@@ -176,7 +241,28 @@ export default function VerkadaPin({
         >
           or use the app
         </span>
-        .
+        {' · '}
+        {!showConfirm ? (
+          <span
+            onClick={() => !regenerating && !isViewingAs && setShowConfirm(true)}
+            style={{
+              textDecoration: 'underline',
+              textDecorationStyle: 'dotted',
+              cursor: regenerating || isViewingAs ? 'not-allowed' : 'pointer',
+              opacity: regenerating || isViewingAs ? 0.5 : 1,
+            }}
+          >
+            {regenerating ? 'regenerating…' : 'regenerate'}
+          </span>
+        ) : (
+          <>
+            confirm regenerate?{' '}
+            <button onClick={handleRegenerate} className="danger">
+              yes
+            </button>{' '}
+            <button onClick={() => setShowConfirm(false)}>cancel</button>
+          </>
+        )}
       </p>
 
       {showAppInfo && (
@@ -205,33 +291,9 @@ export default function VerkadaPin({
         </div>
       )}
 
-      <div className="pin-display">{pin}#</div>
-      <br />
-      {!showConfirm ? (
-        <button
-          onClick={() => setShowConfirm(true)}
-          disabled={regenerating || isViewingAs}
-        >
-          {regenerating ? 'generating...' : 'regenerate PIN'}
-        </button>
-      ) : (
-        <div className="alert warning">
-          <p>
-            <strong>confirm regenerate PIN?</strong> this is mainly for if you gave it to
-            someone you shouldn't have.
-          </p>
-          <div style={{ marginTop: '10px' }}>
-            <button onClick={handleRegenerate} className="danger">
-              yes, regenerate
-            </button>{' '}
-            <button onClick={() => setShowConfirm(false)}>cancel</button>
-          </div>
-        </div>
-      )}
-
       {isViewingAs && (
         <p className="muted" style={{ marginTop: '10px' }}>
-          to change this user's PIN, use the verkada admin portal
+          to change this user&apos;s PIN, use the verkada admin portal
         </p>
       )}
     </>

--- a/app/portal/api/create-day-pass-checkout/route.ts
+++ b/app/portal/api/create-day-pass-checkout/route.ts
@@ -1,6 +1,8 @@
 import { getSession } from '@/app/lib/session';
 import { stripe } from '@/app/lib/stripe';
 import { env } from '@/app/lib/env';
+import { getRecord, Tables } from '@/app/lib/airtable';
+import { canIssueGuestDayPass } from '@/app/lib/membership';
 
 export async function POST(request: Request) {
   try {
@@ -8,6 +10,23 @@ export async function POST(request: Request) {
 
     if (!session.isLoggedIn) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const effectiveUserId = session.viewingAsUserId || session.userId;
+    const record = await getRecord<{ Status?: string; Tier?: string }>(
+      Tables.People,
+      effectiveUserId
+    );
+    if (
+      !canIssueGuestDayPass({
+        status: record?.fields.Status ?? null,
+        tier: record?.fields.Tier ?? null,
+      })
+    ) {
+      return Response.json(
+        { error: 'Guest day passes are only available to active paying members.' },
+        { status: 403 }
+      );
     }
 
     const body = await request.json();

--- a/app/portal/api/unlock-door/route.ts
+++ b/app/portal/api/unlock-door/route.ts
@@ -1,0 +1,63 @@
+import { getSession } from '@/app/lib/session'
+import { getRecord, Tables } from '@/app/lib/airtable'
+import { isActiveMember } from '@/app/lib/membership'
+import { adminUnlockDoor } from '@/app/lib/verkada'
+
+const throttleMap = new Map<string, { count: number; resetAt: number }>()
+const THROTTLE_WINDOW_MS = 30_000
+const THROTTLE_MAX = 10
+
+function checkThrottle(userId: string): boolean {
+  const now = Date.now()
+  const entry = throttleMap.get(userId)
+  if (!entry || now > entry.resetAt) {
+    throttleMap.set(userId, { count: 1, resetAt: now + THROTTLE_WINDOW_MS })
+    return true
+  }
+  if (entry.count >= THROTTLE_MAX) return false
+  entry.count++
+  return true
+}
+
+export async function POST() {
+  try {
+    const session = await getSession()
+    if (!session.isLoggedIn) {
+      return Response.json({ success: false, error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const effectiveUserId = session.viewingAsUserId || session.userId
+
+    if (!checkThrottle(effectiveUserId)) {
+      return Response.json(
+        { success: false, error: 'Too many unlock attempts. Wait a moment.' },
+        { status: 429 }
+      )
+    }
+
+    const record = await getRecord<{ Status?: string; Tier?: string }>(
+      Tables.People,
+      effectiveUserId
+    )
+    if (
+      !isActiveMember({
+        status: record?.fields.Status ?? null,
+        tier: record?.fields.Tier ?? null,
+      })
+    ) {
+      return Response.json({ success: false, error: 'Forbidden' }, { status: 403 })
+    }
+
+    const result = await adminUnlockDoor()
+    console.log(
+      `[portal-unlock] user=${effectiveUserId} ok=${result.ok}`
+    )
+    if (result.ok) {
+      return Response.json({ success: true })
+    }
+    return Response.json({ success: false, error: result.error })
+  } catch (error) {
+    console.error('Error processing portal unlock:', error)
+    return Response.json({ success: false, error: 'Server error' }, { status: 500 })
+  }
+}

--- a/app/portal/api/weekly-door-code/route.ts
+++ b/app/portal/api/weekly-door-code/route.ts
@@ -1,5 +1,7 @@
 import { getSession } from '@/app/lib/session'
 import { env } from '@/app/lib/env'
+import { getRecord, Tables } from '@/app/lib/airtable'
+import { isActiveMember } from '@/app/lib/membership'
 
 let cachedToken: string | null = null
 let tokenExpiresAt: number = 0
@@ -48,6 +50,20 @@ export async function GET() {
     const session = await getSession()
     if (!session.isLoggedIn) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const effectiveUserId = session.viewingAsUserId || session.userId
+    const record = await getRecord<{ Status?: string; Tier?: string }>(
+      Tables.People,
+      effectiveUserId
+    )
+    if (
+      !isActiveMember({
+        status: record?.fields.Status ?? null,
+        tier: record?.fields.Tier ?? null,
+      })
+    ) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
 
     if (!env.VERKADA_WEEKLY_ACCESS_USER_ID) {

--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -1,35 +1,18 @@
 import { getSession, isCurrentlyStaff } from '@/app/lib/session'
-import { getRecord, Tables } from '@/app/lib/airtable'
+import { isActiveMember, canIssueGuestDayPass } from '@/app/lib/membership'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import LogoutButton from './LogoutButton'
-import ProfileEditForm from './profile/edit/ProfileEditForm'
 import HostedEvents from './HostedEvents'
 import VerkadaPin from './VerkadaPin'
 import AdminViewAsSelector from './AdminViewAsSelector'
 import MembershipStatus from './MembershipStatus'
 import DayPassPurchase from './DayPassPurchase'
 import SubscriptionInfo from './SubscriptionInfo'
+import { getUserProfile } from './profile'
 
 // Disable caching - session data (view-as) must be fresh on every request
 export const dynamic = 'force-dynamic'
-
-interface ProfileFields {
-  Name?: string
-  Email?: string
-  Website?: string
-  Photo?: Array<{ url: string }>
-  'Show in directory'?: boolean
-  'Stripe Customer ID'?: string
-  Status?: string
-  Tier?: string
-  Org?: string[]
-  'Discord Username'?: string
-  'Work thing'?: string
-  'Work thing URL'?: string
-  'Fun thing'?: string
-  'Fun thing URL'?: string
-}
 
 export default async function DashboardPage() {
   const session = await getSession()
@@ -46,6 +29,13 @@ export default async function DashboardPage() {
 
   const effectiveUserId = session.viewingAsUserId || session.userId
   const profile = await getUserProfile(effectiveUserId)
+
+  const activeMember = profile
+    ? isActiveMember({ status: profile.status, tier: profile.tier })
+    : false
+  const canDayPass = profile
+    ? canIssueGuestDayPass({ status: profile.status, tier: profile.tier })
+    : false
 
   if (!profile) {
     return (
@@ -120,31 +110,37 @@ export default async function DashboardPage() {
 
       {/* Door Access */}
       <section>
-        <VerkadaPin key={effectiveUserId} isViewingAs={!!session.viewingAsUserId} tier={profile.tier} />
+        <VerkadaPin key={effectiveUserId} isViewingAs={!!session.viewingAsUserId} tier={profile.tier} isActiveMember={activeMember} />
       </section>
 
-      <hr />
+      {/* Day Pass — paying members only */}
+      {canDayPass && (
+        <>
+          <hr />
+          <section>
+            <DayPassPurchase
+              stripeCustomerId={profile.stripeCustomerId}
+              userName={profile.name}
+              userEmail={profile.email}
+            />
+          </section>
+        </>
+      )}
 
-      {/* Day Pass */}
-      <section>
-        <DayPassPurchase
-          stripeCustomerId={profile.stripeCustomerId}
-          userName={profile.name}
-          userEmail={profile.email}
-        />
-      </section>
-
-      <hr />
-
-      {/* Room Booking */}
-      <section>
-        <h2>book a room</h2>
-        <p>
-          <Link href="/portal/book-room">
-            reserve a meeting room or call booth
-          </Link>
-        </p>
-      </section>
+      {/* Room Booking — active members only */}
+      {activeMember && (
+        <>
+          <hr />
+          <section>
+            <h2>book a room</h2>
+            <p>
+              <Link href="/portal/book-room">
+                reserve a meeting room or call booth
+              </Link>
+            </p>
+          </section>
+        </>
+      )}
 
       <hr />
 
@@ -158,7 +154,9 @@ export default async function DashboardPage() {
       {/* Profile */}
       <section>
         <h2>profile</h2>
-        <ProfileEditForm profile={profile} userId={effectiveUserId} />
+        <p>
+          <Link href="/portal/profile/edit">edit your profile</Link>
+        </p>
       </section>
 
       <hr />
@@ -166,48 +164,4 @@ export default async function DashboardPage() {
       <LogoutButton />
     </>
   )
-}
-
-async function getUserProfile(recordId: string): Promise<{
-  name: string
-  email: string
-  website: string
-  photo: string | null
-  directoryVisible: boolean
-  stripeCustomerId: string | null
-  status: string | null
-  tier: string | null
-  orgId: string | null
-  discordUsername: string | null
-  workThing: string | null
-  workThingUrl: string | null
-  funThing: string | null
-  funThingUrl: string | null
-  error?: string
-} | null> {
-  const record = await getRecord<ProfileFields>(Tables.People, recordId)
-
-  if (!record) {
-    return null
-  }
-
-  const fields = record.fields
-  const showInDirectory = fields['Show in directory']
-
-  return {
-    name: fields.Name || '',
-    email: fields.Email || '',
-    website: fields.Website || '',
-    photo: fields.Photo?.[0]?.url || null,
-    directoryVisible: showInDirectory === true,
-    stripeCustomerId: fields['Stripe Customer ID'] || null,
-    status: fields.Status || null,
-    tier: fields.Tier || null,
-    orgId: fields.Org?.[0] || null,
-    discordUsername: fields['Discord Username'] || null,
-    workThing: fields['Work thing'] || null,
-    workThingUrl: fields['Work thing URL'] || null,
-    funThing: fields['Fun thing'] || null,
-    funThingUrl: fields['Fun thing URL'] || null,
-  }
 }

--- a/app/portal/profile.ts
+++ b/app/portal/profile.ts
@@ -1,0 +1,60 @@
+import { getRecord, Tables } from '@/app/lib/airtable'
+
+interface ProfileFields {
+  Name?: string
+  Email?: string
+  Website?: string
+  Photo?: Array<{ url: string }>
+  'Show in directory'?: boolean
+  'Stripe Customer ID'?: string
+  Status?: string
+  Tier?: string
+  Org?: string[]
+  'Discord Username'?: string
+  'Work thing'?: string
+  'Work thing URL'?: string
+  'Fun thing'?: string
+  'Fun thing URL'?: string
+}
+
+export interface UserProfile {
+  name: string
+  email: string
+  website: string
+  photo: string | null
+  directoryVisible: boolean
+  stripeCustomerId: string | null
+  status: string | null
+  tier: string | null
+  orgId: string | null
+  discordUsername: string | null
+  workThing: string | null
+  workThingUrl: string | null
+  funThing: string | null
+  funThingUrl: string | null
+}
+
+export async function getUserProfile(
+  recordId: string
+): Promise<UserProfile | null> {
+  const record = await getRecord<ProfileFields>(Tables.People, recordId)
+  if (!record) return null
+
+  const fields = record.fields
+  return {
+    name: fields.Name || '',
+    email: fields.Email || '',
+    website: fields.Website || '',
+    photo: fields.Photo?.[0]?.url || null,
+    directoryVisible: fields['Show in directory'] === true,
+    stripeCustomerId: fields['Stripe Customer ID'] || null,
+    status: fields.Status || null,
+    tier: fields.Tier || null,
+    orgId: fields.Org?.[0] || null,
+    discordUsername: fields['Discord Username'] || null,
+    workThing: fields['Work thing'] || null,
+    workThingUrl: fields['Work thing URL'] || null,
+    funThing: fields['Fun thing'] || null,
+    funThingUrl: fields['Fun thing URL'] || null,
+  }
+}

--- a/app/portal/profile/edit/page.tsx
+++ b/app/portal/profile/edit/page.tsx
@@ -1,0 +1,50 @@
+import { getSession } from '@/app/lib/session'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import ProfileEditForm from './ProfileEditForm'
+import { getUserProfile } from '../../profile'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ProfileEditPage() {
+  const session = await getSession()
+
+  if (!session.isLoggedIn) {
+    redirect('/portal/login')
+  }
+
+  const effectiveUserId = session.viewingAsUserId || session.userId
+  const profile = await getUserProfile(effectiveUserId)
+
+  if (!profile) {
+    return (
+      <>
+        <Link href="/portal" className="back-link">
+          &larr; back to portal
+        </Link>
+        <h1>error</h1>
+        <p>unable to load your profile.</p>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Link href="/portal" className="back-link">
+        &larr; back to portal
+      </Link>
+
+      <h1>edit profile</h1>
+
+      {session.viewingAsUserId && session.viewingAsName && (
+        <div className="alert info">
+          <strong>admin mode:</strong> editing profile as{' '}
+          <strong>{session.viewingAsName}</strong>.{' '}
+          <Link href="/portal/api/view-as?clear=true">switch back</Link>
+        </div>
+      )}
+
+      <ProfileEditForm profile={profile} userId={effectiveUserId} />
+    </>
+  )
+}

--- a/scripts/scan-automations.ts
+++ b/scripts/scan-automations.ts
@@ -28,6 +28,7 @@ const PORTAL_AUTOMATION_ROUTES = [
   'portal/api/bulk-sync-discord-roles',
   'portal/api/pause-subscription',
   'portal/api/send-magic-link',
+  'portal/api/unlock-door',
 ]
 
 // Other known automation routes outside standard dirs


### PR DESCRIPTION
## Summary
- **Door codes & unlock button**: weekly code, personal PIN, and the new front-door unlock button on the portal homepage are gated to active members (Joined + Friend/Core/Resident/Private Office/Program/Guest Program, or Staff). Non-active members see a "your membership isn't active" line in place of the codes.
- **Guest day pass**: tighter — paying tiers + Staff only. The whole section is hidden for everyone else (including Program / Guest Program).
- **Room booking**: hidden entirely for non-active members.
- **New `/portal/api/unlock-door`**: backs the portal homepage Unlock button. Per-user 10/30s throttle. Reuses the shared `adminUnlockDoor()` helper from the recent /door PR.
- **Membership status copy**: a `STATUS_DISPLAY` map translates internal Airtable statuses (Rejected, Backburner, Cancelled, Declined, Visited) to a softer user-facing "inactive" or appropriate copy. Membership type is hidden when display status is "inactive".
- **Duplicate cancelled alert**: removed the Airtable-keyed alert in `MembershipStatus.tsx` in favor of the live-from-Stripe one in `SubscriptionInfo.tsx`.
- **Personal PIN**: demoted from a big `pin-display` block to a single muted line with inline "or use the app" / "regenerate" links.
- **Profile editor**: moved to its own `/portal/profile/edit` page (matches `/portal/submit-event`); portal home now links instead of inlining the whole form. `getUserProfile` extracted to `app/portal/profile.ts` so both pages share it.

## Test plan
- [x] Unit: 10 new tests in `app/lib/membership.test.ts` cover both predicates across Status × Tier permutations
- [x] `bun run test` — 107 passed
- [x] `bun run tsc --noEmit` clean
- [x] Local: portal as Staff → all sections visible, unlock works
- [x] Local: portal as Cancelled member → "membership status: inactive", door section shows "not active" message, day-pass and room-booking sections gone
- [x] Local: unauthenticated `POST /portal/api/unlock-door` → 401
- [ ] Post-deploy: confirm Stripe-cancelled member still gets the live "subscription cancelled / renew" alert (now only from SubscriptionInfo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)