### PR TITLE
Unify portal door access as top section, polish membership display

### DIFF
--- a/app/portal/MembershipStatus.tsx
+++ b/app/portal/MembershipStatus.tsx
@@ -39,6 +39,16 @@ export default function MembershipStatus({
 
   // Translate Airtable internal statuses to softer user-facing copy.
   // Statuses not in the map are shown verbatim.
+  const STATUS_BADGE: Record<string, string> = {
+    active: 'confirmed',
+    invited: 'paused',
+    paused: 'paused',
+    'payment issue': 'cancelled',
+    inactive: 'cancelled',
+    'guest program': 'confirmed',
+    'event host': '',
+  }
+
   const STATUS_DISPLAY: Record<string, string> = {
     Joined: 'active',
     Invited: 'invited',
@@ -56,9 +66,8 @@ export default function MembershipStatus({
     Rejected: 'inactive',
     Declined: 'inactive',
   }
-  const displayStatus = status
-    ? STATUS_DISPLAY[status] || status
-    : 'unknown'
+  const isVisitor = !status
+  const displayStatus = status ? STATUS_DISPLAY[status] || status : 'visitor'
 
   // Format tier display name
   // Tiers: Staff, Volunteer, Private Office, Program, Resident, Core, Friend, Courtesy, Guest Program, Paused
@@ -71,23 +80,40 @@ export default function MembershipStatus({
 
   return (
     <>
-      <h2>access</h2>
+      <h2>membership</h2>
 
       <p>
-        membership status: <strong>{displayStatus}</strong>
         {tier && !isInvited && displayStatus !== 'inactive' && (
-          <>
-            {' '}
-            · membership type: <strong>{getTierDisplay()}</strong>
-          </>
+          <span style={{ display: 'inline-flex', gap: '6px', alignItems: 'center' }}>
+            <span className="badge">{getTierDisplay()}</span>
+            <span className={`badge ${STATUS_BADGE[displayStatus] ?? ''}`}>{displayStatus}</span>
+            {isPrivateOffice && orgId && (
+              <span className="muted">
+                ({loadingOrg ? 'loading...' : orgName || 'no office assigned'})
+              </span>
+            )}
+          </span>
         )}
-        {isPrivateOffice && orgId && (
+        {(!tier || isInvited || displayStatus === 'inactive') && (
           <>
-            {' '}
-            ({loadingOrg ? 'loading...' : orgName || 'no office assigned'})
+            membership status: <strong>{displayStatus}</strong>
+            {isPrivateOffice && orgId && (
+              <> ({loadingOrg ? 'loading...' : orgName || 'no office assigned'})</>
+            )}
           </>
         )}
       </p>
+
+      {(isVisitor || displayStatus === 'inactive') && !stripeCustomerId && (
+        <p style={{ marginTop: '15px' }}>
+          <Link
+            href={`/join?name=${encodeURIComponent(firstName)}`}
+            className="btn primary"
+          >
+            apply for membership
+          </Link>
+        </p>
+      )}
 
       {isInvited && (
         <>

--- a/app/portal/MyDayPasses.tsx
+++ b/app/portal/MyDayPasses.tsx
@@ -6,6 +6,7 @@ import { DayPass, computeExpiresAt, isExpired } from './dayPasses'
 interface MyDayPassesProps {
   passes: DayPass[]
   isActiveMember: boolean
+  hideHeading?: boolean
 }
 
 interface ActivatedState {
@@ -24,21 +25,15 @@ function formatDate(dateString: string | null): string {
 
 interface PassCardProps {
   pass: DayPass
-  alreadyActivated?: boolean
 }
 
-function PassCard({ pass, alreadyActivated }: PassCardProps) {
+function PassCard({ pass }: PassCardProps) {
   const [activated, setActivated] = useState<ActivatedState | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [unlocking, setUnlocking] = useState(false)
   const [unlocked, setUnlocked] = useState(false)
   const [unlockError, setUnlockError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (alreadyActivated) activate()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   const fetchDoorCode = async (): Promise<{ doorCode: string; expiresAt: string | null } | null> => {
     const res = await fetch('/portal/api/activate-day-pass', {
@@ -79,7 +74,14 @@ function PassCard({ pass, alreadyActivated }: PassCardProps) {
     }
   }
 
-  if (activated) {
+  useEffect(() => {
+    if (pass.status === 'Activated') activate()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const isAlreadyActivated = pass.status === 'Activated' && !activated
+
+  if (activated || isAlreadyActivated) {
     return (
       <div
         style={{
@@ -89,15 +91,28 @@ function PassCard({ pass, alreadyActivated }: PassCardProps) {
           marginBottom: '10px',
         }}
       >
+        <div style={{ marginBottom: '10px' }}>
+          <strong>{pass.passType}</strong>
+          <span className="muted" style={{ marginLeft: '8px', fontSize: '0.9em' }}>
+            {pass.dateActivated
+              ? `activated ${formatDate(pass.dateActivated)}`
+              : pass.datePurchased
+                ? `purchased ${formatDate(pass.datePurchased.split('T')[0])}`
+                : ''}
+          </span>
+        </div>
         <button onClick={unlock} disabled={unlocking || unlocked} className="primary">
           {unlocking ? 'unlocking...' : unlocked ? '✓ unlocked' : 'unlock door'}
         </button>
         {unlockError && <p className="error" style={{ marginTop: '8px' }}>{unlockError}</p>}
-        <p className="muted" style={{ marginTop: '10px', fontSize: '0.85em' }}>
-          Or enter <span style={{ fontFamily: 'monospace', fontWeight: 'bold', color: 'var(--text)', letterSpacing: '0.08em' }}>{activated.doorCode}#</span>
-          {' on the keypad.'}
-          {activated.expiresAt && <> Good until 11pm {formatDate(activated.expiresAt)}</>}.
-        </p>
+        {activated && (
+          <p className="muted" style={{ marginTop: '10px', fontSize: '0.85em' }}>
+            Or enter <span style={{ fontFamily: 'monospace', fontWeight: 'bold', color: 'var(--text)', letterSpacing: '0.08em' }}>{activated.doorCode}#</span>
+            {' on the keypad.'}
+            {activated.expiresAt && <> Good until 11pm {formatDate(activated.expiresAt)}</>}.
+          </p>
+        )}
+        {error && <p className="error" style={{ marginTop: '8px' }}>{error}</p>}
       </div>
     )
   }
@@ -127,7 +142,7 @@ function PassCard({ pass, alreadyActivated }: PassCardProps) {
   )
 }
 
-export default function MyDayPasses({ passes, isActiveMember }: MyDayPassesProps) {
+export default function MyDayPasses({ passes, isActiveMember, hideHeading }: MyDayPassesProps) {
   if (passes.length === 0) return null
 
   const unused = passes.filter((p) => p.status === 'Unused' && !isExpired(p))
@@ -140,12 +155,12 @@ export default function MyDayPasses({ passes, isActiveMember }: MyDayPassesProps
 
   return (
     <section>
-      <h2>my day passes</h2>
+      {!hideHeading && <h2>my day passes</h2>}
 
       {active.length > 0 && (
         <div style={{ marginBottom: '20px' }}>
           {active.map((pass) => (
-            <PassCard key={pass.id} pass={pass} alreadyActivated />
+            <PassCard key={pass.id} pass={pass} />
           ))}
         </div>
       )}

--- a/app/portal/VerkadaPin.tsx
+++ b/app/portal/VerkadaPin.tsx
@@ -28,6 +28,16 @@ export default function VerkadaPin({
 
   const isGuestProgram = tier === 'Program' || tier === 'Guest Program'
 
+  function accessDescription(tier?: string | null): string | null {
+    if (!tier) return null
+    if (tier === 'Friend') return 'you have drop-in access up to 2x/week.'
+    if (['Core', 'Resident', 'Private Office', 'Staff', 'Volunteer'].includes(tier))
+      return 'you have 24/7 access.'
+    return null
+  }
+
+  const accessDesc = accessDescription(tier)
+
   useEffect(() => {
     if (!isActiveMember) {
       setLoading(false)
@@ -143,57 +153,49 @@ export default function VerkadaPin({
   }
 
   if (loading) {
-    return (
-      <>
-        <h3>door code</h3>
-        <p className="loading">loading...</p>
-      </>
-    )
+    return <p className="loading">loading...</p>
   }
 
   if (!isActiveMember) {
     return (
-      <>
-        <h3>door code</h3>
-        <p>
-          your membership isn&apos;t active right now, so door codes aren&apos;t
-          available. email{' '}
-          <a href="mailto:team@moxsf.com">team@moxsf.com</a> to sort it out.
-        </p>
-      </>
+      <p>
+        your membership isn&apos;t active right now, so door codes aren&apos;t
+        available. email{' '}
+        <a href="mailto:team@moxsf.com">team@moxsf.com</a> to sort it out.
+      </p>
     )
   }
 
   if (error) {
-    return (
-      <>
-        <h3>door code</h3>
-        <p className="error">{error}</p>
-      </>
-    )
+    return <p className="error">{error}</p>
   }
 
   const justUnlocked = unlockedAt !== null
   const weeklyCodeBlock = weeklyCode && (
-    <div style={{ marginBottom: '20px' }}>
-      <p style={{ marginBottom: '5px' }}>this week&apos;s shared door code:</p>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
-        <div className="pin-display">{weeklyCode}#</div>
-        <button
-          onClick={handleUnlock}
-          disabled={unlocking || justUnlocked || isViewingAs}
-          className={justUnlocked ? '' : 'primary'}
-        >
-          {unlocking
-            ? 'unlocking…'
-            : justUnlocked
-              ? '✓ unlocked'
-              : 'unlock door'}
-        </button>
-      </div>
+    <div
+      style={{
+        border: '2px solid var(--border-dark)',
+        background: 'var(--bg-secondary)',
+        padding: '15px',
+        marginBottom: '20px',
+      }}
+    >
+      {accessDesc && (
+        <p className="muted" style={{ marginBottom: '10px', fontSize: '0.85em' }}>{accessDesc}</p>
+      )}
+      <button
+        onClick={handleUnlock}
+        disabled={unlocking || justUnlocked}
+        className={justUnlocked ? '' : 'primary'}
+      >
+        {unlocking ? 'unlocking…' : justUnlocked ? '✓ unlocked' : 'unlock door'}
+      </button>
       {unlockError && (
         <p className="error" style={{ marginTop: '8px' }}>{unlockError}</p>
       )}
+      <p className="muted" style={{ marginTop: '10px', fontSize: '0.85em' }}>
+        Or enter <span style={{ fontFamily: 'monospace', fontWeight: 'bold', color: 'var(--text)', letterSpacing: '0.08em' }}>{weeklyCode}#</span> on the keypad.
+      </p>
     </div>
   )
 
@@ -202,7 +204,6 @@ export default function VerkadaPin({
     if (isGuestProgram && guestPin) {
       return (
         <>
-          <h3>door code</h3>
           {weeklyCodeBlock}
           <p>as a guest program member, use this shared PIN code to enter:</p>
           <div className="pin-display">{guestPin}#</div>
@@ -212,7 +213,6 @@ export default function VerkadaPin({
 
     return (
       <>
-        <h3>front door access</h3>
         {weeklyCodeBlock}
         <p>
           door access is not available for your account. please contact a staff
@@ -224,7 +224,6 @@ export default function VerkadaPin({
 
   return (
     <>
-      <h3>door code</h3>
 
       {weeklyCodeBlock}
 

--- a/app/portal/buy-day-pass/page.tsx
+++ b/app/portal/buy-day-pass/page.tsx
@@ -1,0 +1,60 @@
+import { getSession } from '@/app/lib/session'
+import { canIssueGuestDayPass } from '@/app/lib/membership'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import DayPassPurchase from '../DayPassPurchase'
+import { getUserProfile } from '../profile'
+
+export const dynamic = 'force-dynamic'
+
+export default async function BuyDayPassPage() {
+  const session = await getSession()
+
+  if (!session.isLoggedIn) {
+    redirect('/portal/login')
+  }
+
+  const effectiveUserId = session.viewingAsUserId || session.userId
+  const profile = await getUserProfile(effectiveUserId)
+
+  if (!profile) {
+    return (
+      <>
+        <Link href="/portal" className="back-link">
+          &larr; back to portal
+        </Link>
+        <h1>error</h1>
+        <p>unable to load your profile.</p>
+      </>
+    )
+  }
+
+  const canDayPass = canIssueGuestDayPass({ status: profile.status, tier: profile.tier })
+  if (!canDayPass) {
+    redirect('/portal')
+  }
+
+  return (
+    <>
+      <Link href="/portal" className="back-link">
+        &larr; back to portal
+      </Link>
+
+      <h1>buy a guest day pass</h1>
+
+      {session.viewingAsUserId && session.viewingAsName && (
+        <div className="alert info">
+          <strong>admin mode:</strong> purchasing as{' '}
+          <strong>{session.viewingAsName}</strong>.{' '}
+          <Link href="/portal/api/view-as?clear=true">switch back</Link>
+        </div>
+      )}
+
+      <DayPassPurchase
+        stripeCustomerId={profile.stripeCustomerId}
+        userName={profile.name}
+        userEmail={profile.email}
+      />
+    </>
+  )
+}

--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -7,7 +7,6 @@ import HostedEvents from './HostedEvents'
 import VerkadaPin from './VerkadaPin'
 import AdminViewAsSelector from './AdminViewAsSelector'
 import MembershipStatus from './MembershipStatus'
-import DayPassPurchase from './DayPassPurchase'
 import MyDayPasses from './MyDayPasses'
 import SubscriptionInfo from './SubscriptionInfo'
 import { getUserProfile } from './profile'
@@ -103,6 +102,20 @@ export default async function DashboardPage() {
         </details>
       )}
 
+      {/* Door Access — always first for anyone who can get in */}
+      {(activeMember || dayPasses.length > 0) && (
+        <>
+          <section>
+            <h2>door access</h2>
+            {activeMember ? (
+              <VerkadaPin key={effectiveUserId} isViewingAs={!!session.viewingAsUserId} tier={profile.tier} isActiveMember={activeMember} />
+            ) : (
+              <MyDayPasses passes={dayPasses} isActiveMember={activeMember} hideHeading />
+            )}
+          </section>
+          <hr />
+        </>
+      )}
 
       {/* Membership Status */}
       <section>
@@ -122,15 +135,8 @@ export default async function DashboardPage() {
         </section>
       )}
 
-      <hr />
-
-      {/* Door Access */}
-      <section>
-        <VerkadaPin key={effectiveUserId} isViewingAs={!!session.viewingAsUserId} tier={profile.tier} isActiveMember={activeMember} />
-      </section>
-
-      {/* User's own day passes (if any) */}
-      {dayPasses.length > 0 && (
+      {/* Active members' day passes below membership info */}
+      {activeMember && dayPasses.length > 0 && (
         <>
           <hr />
           <MyDayPasses passes={dayPasses} isActiveMember={activeMember} />
@@ -142,11 +148,10 @@ export default async function DashboardPage() {
         <>
           <hr />
           <section>
-            <DayPassPurchase
-              stripeCustomerId={profile.stripeCustomerId}
-              userName={profile.name}
-              userEmail={profile.email}
-            />
+            <h2>guest day passes</h2>
+            <p>
+              <Link href="/portal/buy-day-pass">buy a day pass for a guest</Link>
+            </p>
           </section>
         </>
       )}


### PR DESCRIPTION
## Summary
- Door access section is now the first content block for any user who can enter — active members (VerkadaPin) and day-pass holders (MyDayPasses) both see it at the top
- Active members get a bordered unlock box with the weekly code shown below and an access description (24/7 or 2x/week) above the button, matching the day pass card style
- Activated day passes now auto-fetch and display the door code + unlock button on load (no extra tap)
- Unlock button now works in view-as mode (was incorrectly disabled client-side; API was already correct)
- Membership section renamed from "access"; tier + status shown as badge pills (green/yellow/red by status)
- Visitor and inactive members see an "apply for membership" button, suppressed if they have Stripe history (those users see "renew membership" in the subscription section instead)
- Guest day pass purchase moved to `/portal/buy-day-pass` — its own page with a back link, like edit profile

## Test plan
- [x] Active member: door access box appears first, unlock button works, keypad code visible, correct access description by tier
- [x] Friend tier: shows "drop-in access up to 2x/week"
- [x] Core/Resident/Staff: shows "24/7 access"
- [x] Day pass holder (no active membership): door access section shows passes, activated passes show unlock immediately
- [x] Unused day pass: shows "activate" button, not "get door code"
- [x] View-as active member: unlock button works
- [x] Inactive member with no Stripe history: "apply for membership" button shown
- [x] Inactive member with cancelled Stripe sub: no "apply" button, "renew membership" shown in subscription section
- [x] Guest day pass purchase: link from portal → /portal/buy-day-pass → form works → redirects to Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)