### PR TITLE
Fix event time formatting to use Pacific time

### DIFF
--- a/app/lib/events.test.ts
+++ b/app/lib/events.test.ts
@@ -110,11 +110,12 @@ describe('parseAirtableEvent', () => {
 })
 
 describe('formatEventTime', () => {
+  // March 15 2024 is PDT (UTC-7). 6 PM PT = 01:00 UTC the next day.
   it('formats time only for event without end date', () => {
     const event: Event = {
       id: '1',
       name: 'Test',
-      startDate: new Date('2024-03-15T18:00:00'),
+      startDate: new Date('2024-03-16T01:00:00Z'),
     }
 
     expect(formatEventTime(event)).toBe('6 PM')
@@ -124,8 +125,8 @@ describe('formatEventTime', () => {
     const event: Event = {
       id: '1',
       name: 'Test',
-      startDate: new Date('2024-03-15T18:00:00'),
-      endDate: new Date('2024-03-15T21:00:00'),
+      startDate: new Date('2024-03-16T01:00:00Z'),
+      endDate: new Date('2024-03-16T04:00:00Z'),
     }
 
     expect(formatEventTime(event)).toBe('6 PM - 9 PM')
@@ -135,32 +136,32 @@ describe('formatEventTime', () => {
     const event: Event = {
       id: '1',
       name: 'Test',
-      startDate: new Date('2024-03-15T18:30:00'),
-      endDate: new Date('2024-03-15T21:45:00'),
+      startDate: new Date('2024-03-16T01:30:00Z'),
+      endDate: new Date('2024-03-16T04:45:00Z'),
     }
 
     expect(formatEventTime(event)).toBe('6:30 PM - 9:45 PM')
   })
 
-  it('includes date when showDate is true', () => {
+  it('includes date and PT suffix when showDate is true', () => {
     const event: Event = {
       id: '1',
       name: 'Test',
-      startDate: new Date('2024-03-15T18:00:00'),
+      startDate: new Date('2024-03-16T01:00:00Z'),
     }
 
-    expect(formatEventTime(event, true)).toBe('Friday, March 15, 6 PM')
+    expect(formatEventTime(event, true)).toBe('Friday, March 15, 6 PM PT')
   })
 
-  it('includes date and time range when showDate is true with end date', () => {
+  it('includes date, time range, and PT suffix when showDate is true with end date', () => {
     const event: Event = {
       id: '1',
       name: 'Test',
-      startDate: new Date('2024-03-15T18:00:00'),
-      endDate: new Date('2024-03-15T21:00:00'),
+      startDate: new Date('2024-03-16T01:00:00Z'),
+      endDate: new Date('2024-03-16T04:00:00Z'),
     }
 
-    expect(formatEventTime(event, true)).toBe('Friday, March 15, 6 PM - 9 PM')
+    expect(formatEventTime(event, true)).toBe('Friday, March 15, 6 PM - 9 PM PT')
   })
 })
 

--- a/app/lib/events.ts
+++ b/app/lib/events.ts
@@ -1,4 +1,7 @@
-import { format, parseISO, isSameDay, startOfDay } from 'date-fns'
+import { parseISO, isSameDay, startOfDay } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
+
+const PACIFIC_TZ = 'America/Los_Angeles'
 import {
   getRecords,
   findRecord,
@@ -150,17 +153,17 @@ export async function getEvents(): Promise<Event[]> {
 }
 
 export function formatEventTime(event: Event, showDate = false): string {
-  const startTime = format(event.startDate, 'h:mm a').replace(':00', '')
+  const startTime = formatInTimeZone(event.startDate, PACIFIC_TZ, 'h:mm a').replace(':00', '')
 
   if (!event.endDate) {
     return showDate
-      ? `${format(event.startDate, 'EEEE, MMMM d')}, ${startTime}`
+      ? `${formatInTimeZone(event.startDate, PACIFIC_TZ, 'EEEE, MMMM d')}, ${startTime} PT`
       : startTime
   }
 
-  const endTime = format(event.endDate, 'h:mm a').replace(':00', '')
+  const endTime = formatInTimeZone(event.endDate, PACIFIC_TZ, 'h:mm a').replace(':00', '')
   return showDate
-    ? `${format(event.startDate, 'EEEE, MMMM d')}, ${startTime} - ${endTime}`
+    ? `${formatInTimeZone(event.startDate, PACIFIC_TZ, 'EEEE, MMMM d')}, ${startTime} - ${endTime} PT`
     : `${startTime} - ${endTime}`
 }
 


### PR DESCRIPTION
formatEventTime was using date-fns format() which renders in the runtime's local TZ — UTC on Vercel — so the /door link and public events list both showed times shifted by 7-8 hours. Switch to formatInTimeZone with America/Los_Angeles, and append a "PT" suffix when showDate is true.