### PR TITLE
Add Global Expert Fellowship landing page

### DIFF
--- a/app/gef/GefLanding.tsx
+++ b/app/gef/GefLanding.tsx
@@ -1,0 +1,346 @@
+'use client'
+
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import styles from './gef.module.css'
+
+const marqueeWords = [
+  'Research',
+  'Founders',
+  'San Francisco',
+  'Global Experts',
+  'Mox',
+  'Impact',
+  'Mission',
+  'Community',
+]
+
+export default function GefLanding() {
+  const marqueeTrackRef = useRef<HTMLDivElement>(null)
+  const [formMessage, setFormMessage] = useState('')
+
+  useEffect(() => {
+    const track = marqueeTrackRef.current
+    if (!track || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    const updateMarquee = () => {
+      const halfWidth = track.scrollWidth / 2
+      if (!halfWidth) return
+
+      const offset = (window.scrollY * 0.32) % halfWidth
+      track.style.transform = `translateX(${-offset}px)`
+    }
+
+    updateMarquee()
+    window.addEventListener('scroll', updateMarquee, { passive: true })
+    window.addEventListener('resize', updateMarquee)
+
+    return () => {
+      window.removeEventListener('scroll', updateMarquee)
+      window.removeEventListener('resize', updateMarquee)
+    }
+  }, [])
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setFormMessage('Form draft captured locally. We can wire this to the real destination next.')
+  }
+
+  return (
+    <main className={styles.gefPage} id="top">
+      <div className={styles.grain} aria-hidden="true" />
+      <header className={styles.siteHeader} aria-label="Primary navigation">
+        <a className={styles.brand} href="#top" aria-label="Mox Global Expert Fellowship home">
+          <span className={styles.brandMark}>Mox</span>
+          <span>Global Expert Fellowship</span>
+        </a>
+        <nav aria-label="Page sections">
+          <a href="#room">The room</a>
+          <a href="#fit">Fit</a>
+          <a href="#path">Path</a>
+          <a href="#apply">Apply</a>
+        </nav>
+      </header>
+
+      <section className={styles.hero} aria-labelledby="hero-title">
+        <div className={styles.heroImage} aria-hidden="true">
+          <img src="/images/014.jpg" alt="" />
+        </div>
+        <div className={styles.heroMarquee} aria-hidden="true">
+          <div className={styles.marqueeTrack} ref={marqueeTrackRef}>
+            {[...marqueeWords, ...marqueeWords].map((word, index) => (
+              <span key={`${word}-${index}`}>{word}</span>
+            ))}
+          </div>
+        </div>
+        <div className={styles.heroContent}>
+          <p className={styles.kicker}>Global Expert Fellowship</p>
+          <h1 id="hero-title">Bring your research or startup to SF for a season.</h1>
+          <div className={styles.heroBottom}>
+            <p>
+              If you are outside the US and want your work closer to SF&apos;s people, pace,
+              and collaborators, the Global Expert Fellowship is for you.
+            </p>
+            <a className={styles.primaryAction} href="#apply">
+              <span>Start with the interest form</span>
+              <svg aria-hidden="true" viewBox="0 0 24 24">
+                <path
+                  d="M5 12h13m-5-5 5 5-5 5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.manifesto} id="room" aria-labelledby="room-title">
+        <div className={styles.manifestoLedger}>
+          <p className={styles.ledgerLabel}>Room notes</p>
+          <p>Peers who move quickly and take ideas seriously.</p>
+          <p>Potential collaborators across research, startups, policy, and community building.</p>
+          <p>Member dinners, reading groups, talks, coworking days, and time to work.</p>
+        </div>
+        <div className={styles.manifestoCopy}>
+          <p className={styles.kicker}>What this is</p>
+          <h2 id="room-title">Mox is a research-focused incubator and community space.</h2>
+          <p>
+            We gather AI safety researchers, policy experts, founders, writers, builders, and
+            community organizers in San Francisco. The Global Expert Fellowship helps people
+            from outside the US spend focused time at Mox, where ideas can move quickly from
+            conversation to collaborators, venues, demos, and next steps.
+          </p>
+        </div>
+      </section>
+
+      <section className={styles.focusStrip} aria-label="Program highlights">
+        <article>
+          <span>01</span>
+          <h3>Your own work</h3>
+          <p>Research, build a company, incubate a project, or collaborate with organizations around Mox.</p>
+        </article>
+        <article>
+          <span>02</span>
+          <h3>Time at Mox</h3>
+          <p>Fellows work from Mox at least three days in a typical week.</p>
+        </article>
+        <article>
+          <span>03</span>
+          <h3>Program support</h3>
+          <p>Mox supports and supervises your fellowship as your host organization and incubator.</p>
+        </article>
+      </section>
+
+      <section className={styles.photoRail} aria-label="Mox photos">
+        <figure>
+          <img src="/images/023.jpg" alt="People gathered around a whiteboard at Mox" />
+          <figcaption>Events and talks</figcaption>
+        </figure>
+        <figure>
+          <img src="/images/003.jpg" alt="A Mox coworking space" />
+          <figcaption>Workspace in SF</figcaption>
+        </figure>
+        <figure>
+          <img src="/images/021.jpg" alt="A room inside Mox" />
+          <figcaption>Places to settle in</figcaption>
+        </figure>
+      </section>
+
+      <section className={styles.fit} id="fit" aria-labelledby="fit-title">
+        <div className={styles.fitTitle}>
+          <p className={styles.kicker}>Good fit</p>
+          <h2 id="fit-title">Researchers and founders with a clear project for their time in SF.</h2>
+        </div>
+        <div className={styles.fitBoard}>
+          <article>
+            <h3>Relevant focus areas</h3>
+            <p>
+              Machine learning research, AI governance, biotech, biosecurity, entrepreneurship,
+              fieldbuilding, animal welfare, and nearby frontier areas.
+            </p>
+          </article>
+          <article>
+            <h3>Many kinds of proof count</h3>
+            <p>
+              Share your side projects, prototypes, communities, papers, products, grants,
+              public writing, or unusually useful things you have made.
+            </p>
+          </article>
+          <article>
+            <h3>A concrete plan</h3>
+            <p>
+              Bring a six-month or year-long research, startup, or incubation plan that makes
+              sense specifically at Mox.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className={styles.path} id="path" aria-labelledby="path-title">
+        <div className={styles.pathIntro}>
+          <p className={styles.kicker}>How to apply</p>
+          <h2 id="path-title">Start with a short interest form.</h2>
+        </div>
+        <ol className={styles.pathSteps}>
+          <li>
+            <span className={styles.time}>5 min</span>
+            <h3>Interest form</h3>
+            <p>Tell us about your background, proudest work, and what you want to build or research here.</p>
+          </li>
+          <li>
+            <span className={styles.time}>15 min</span>
+            <h3>Conversation</h3>
+            <p>A short conversation about your plans, your context, and what time at Mox would help with.</p>
+          </li>
+          <li>
+            <span className={styles.time}>1 hr</span>
+            <h3>Full application</h3>
+            <p>If the fit is promising, we ask for the complete program proposal.</p>
+          </li>
+          <li>
+            <span className={styles.time}>1.5 hr</span>
+            <h3>Visa setup</h3>
+            <p>After acceptance, we help you move through the required visa sponsor and documentation steps.</p>
+          </li>
+          <li>
+            <span className={styles.time}>~1 week</span>
+            <h3>Sponsor review</h3>
+            <p>The sponsor reviews your materials, then you schedule the consulate appointment for your visa.</p>
+          </li>
+          <li>
+            <span className={styles.time}>~1-2 weeks</span>
+            <h3>Arrive in SF</h3>
+            <p>Once everything is approved, you come to San Francisco and begin your fellowship at Mox.</p>
+          </li>
+        </ol>
+      </section>
+
+      <section className={styles.darkRoom} aria-labelledby="requirements-title">
+        <div className={styles.darkCopy}>
+          <p className={styles.kicker}>Practical basics</p>
+          <h2 id="requirements-title">A few things to know up front.</h2>
+          <p>
+            The fellowship works best for people with specialized knowledge, a clear program
+            of work, and enough flexibility to spend real time with the Mox community.
+          </p>
+        </div>
+        <div className={styles.requirementList}>
+          <p><strong>Expertise:</strong> specialized knowledge or skill relevant to Mox.</p>
+          <p><strong>Presence:</strong> collaborate in person at Mox three or more days most weeks.</p>
+          <p><strong>Progress:</strong> attend twice-monthly supervisor check-ins.</p>
+          <p><strong>Costs:</strong> plan for your US living costs, sponsor fees, and Mox resident-tier membership.</p>
+          <p><strong>Documents:</strong> prepare the financial, education, and activity-plan materials the process requires.</p>
+        </div>
+      </section>
+
+      <section className={styles.timeline} aria-labelledby="timeline-title">
+        <div className={styles.timelineTicket}>
+          <span>Rolling</span>
+          <strong>No deadline</strong>
+          <small>Qualified candidates can sometimes move quickly.</small>
+        </div>
+        <div className={styles.timelineCopy}>
+          <p className={styles.kicker}>Timing</p>
+          <h2 id="timeline-title">Applications are rolling.</h2>
+          <p>
+            We accept applications on a rolling basis. For qualified candidates with documents
+            ready, processing can sometimes take around one to two weeks, depending on country,
+            situation, and sponsor review.
+          </p>
+          <p>
+            Helpful things to gather early: bank documentation, translated diploma or transcripts,
+            and a clear weekly activity plan for your time at Mox.
+          </p>
+        </div>
+      </section>
+
+      <section className={styles.cabinet} aria-labelledby="cabinet-title">
+        <p className={styles.kicker}>Life at Mox</p>
+        <h2 id="cabinet-title">A regular week can include a lot.</h2>
+        <div className={styles.cabinetGrid}>
+          <article><span>Morning</span><p>Settle in at your desk, write, code, read, or prepare for a collaborator meeting.</p></article>
+          <article><span>Lunch</span><p>Meet researchers, founders, and organizers working across AI safety and frontier technology.</p></article>
+          <article><span>Afternoon</span><p>Use meeting rooms, call booths, office hours, and the ordinary helpfulness of people nearby.</p></article>
+          <article><span>Evening</span><p>Join member dinners, talks, reading groups, hackathons, demo days, or a quiet walk through SF.</p></article>
+        </div>
+      </section>
+
+      <section className={styles.apply} id="apply" aria-labelledby="apply-title">
+        <div className={styles.applyCopy}>
+          <p className={styles.kicker}>Pilot program</p>
+          <h2 id="apply-title">Tell us what you want to work on.</h2>
+          <p>
+            Start with a short note. If there is a good fit, we will invite you to a conversation
+            before asking for the full application.
+          </p>
+        </div>
+        <form className={styles.interestForm} aria-label="Global Expert Fellowship interest form" onSubmit={onSubmit}>
+          <div className={`${styles.formRow} ${styles.formRowTwo}`}>
+            <label>
+              <span>Name</span>
+              <input name="name" autoComplete="name" required />
+            </label>
+            <label>
+              <span>Email</span>
+              <input name="email" type="email" autoComplete="email" required />
+            </label>
+          </div>
+          <div className={`${styles.formRow} ${styles.formRowTwo}`}>
+            <label>
+              <span>Current country</span>
+              <input name="country" autoComplete="country-name" required />
+            </label>
+            <label>
+              <span>Primary focus area</span>
+              <input name="focus" placeholder="AI safety, biotech, fieldbuilding..." required />
+            </label>
+          </div>
+          <label>
+            <span>Background</span>
+            <textarea
+              name="background"
+              rows={4}
+              placeholder="Education, work, side projects, achievements, and anything else that helps us understand your fit."
+              required
+            />
+          </label>
+          <label>
+            <span>Work you are proud of</span>
+            <textarea
+              name="proud"
+              rows={3}
+              placeholder="A project, paper, prototype, company, community, or other thing you made."
+              required
+            />
+          </label>
+          <label>
+            <span>What would you work on in SF?</span>
+            <textarea
+              name="intentions"
+              rows={4}
+              placeholder="Tell us the research, startup, or project you would want to move forward during the fellowship."
+              required
+            />
+          </label>
+          <div className={styles.formFooter}>
+            <p>Five minutes is enough. If there is a fit, the next step is a short conversation.</p>
+            <button type="submit">Submit interest</button>
+          </div>
+          <p className={styles.formNote} role="status" aria-live="polite">
+            {formMessage}
+          </p>
+        </form>
+      </section>
+
+      <footer className={styles.footer}>
+        <span>Mox Global Expert Fellowship</span>
+        <a href="https://j1visa.state.gov/early-career-stem-research-initiative/">
+          State Department STEM initiative
+        </a>
+      </footer>
+    </main>
+  )
+}

--- a/app/gef/gef.module.css
+++ b/app/gef/gef.module.css
@@ -58,10 +58,10 @@
   display: flex;
   justify-content: space-between;
   left: 0;
-  padding: 18px clamp(18px, 4vw, 54px);
+  padding: 0 clamp(18px, 4vw, 54px);
   position: fixed;
   right: 0;
-  top: 0;
+  top: clamp(14px, 1.4vw, 18px);
   z-index: 12;
 }
 
@@ -146,12 +146,13 @@
 }
 
 .heroMarquee {
-  bottom: 18px;
+  bottom: 20px;
   display: flex;
   left: 0;
+  mask-image: linear-gradient(90deg, transparent, #000 5%, #000 95%, transparent);
   opacity: 0.52;
   overflow: hidden;
-  padding: 0 0 16px;
+  padding: 0 0 14px;
   position: absolute;
   right: 0;
   white-space: nowrap;
@@ -182,7 +183,7 @@
   flex-direction: column;
   justify-content: flex-end;
   min-height: 78svh;
-  padding: 120px clamp(22px, 5vw, 72px) 118px;
+  padding: 120px clamp(22px, 5vw, 72px) 136px;
   position: relative;
   z-index: 1;
 }
@@ -283,6 +284,7 @@
 
 .gefPage section:not(.hero) {
   padding: clamp(68px, 8.5vw, 128px) clamp(22px, 5vw, 72px);
+  scroll-margin-top: 112px;
 }
 
 .manifesto {
@@ -463,9 +465,9 @@
   align-items: start;
   border-top: 1px solid var(--line);
   display: grid;
-  gap: 20px;
-  grid-template-columns: 128px minmax(180px, 0.55fr) minmax(320px, 1fr);
-  padding: 32px 0;
+  gap: 20px clamp(28px, 4.5vw, 72px);
+  grid-template-columns: minmax(110px, 0.24fr) minmax(210px, 0.5fr) minmax(360px, 0.92fr);
+  padding: 34px 0;
 }
 
 .pathSteps li::before {
@@ -495,7 +497,7 @@
   grid-column: 3;
   grid-row: 1 / span 2;
   margin: 0;
-  max-width: 460px;
+  max-width: 560px;
 }
 
 .darkRoom {

--- a/app/gef/gef.module.css
+++ b/app/gef/gef.module.css
@@ -1,0 +1,898 @@
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,650&family=IBM+Plex+Mono:wght@500;600&family=Instrument+Sans:ital,wght@0,400..800;1,400..800&display=swap");
+
+.gefPage {
+  color-scheme: light;
+  --ink: #19171b;
+  --espresso: #55536e;
+  --paper: #fbf7ef;
+  --vellum: #fffaf2;
+  --bone: #ddd9e7;
+  --moss: #55536e;
+  --blue: #55536e;
+  --red: #d96049;
+  --gold: #f3da73;
+  --rose: #eab5aa;
+  --line: rgba(25, 23, 27, 0.15);
+  --pale-line: rgba(255, 250, 242, 0.22);
+  --shadow: 0 24px 60px rgba(25, 23, 27, 0.16);
+  --sans: "Instrument Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --display: "Fraunces", Georgia, "Times New Roman", serif;
+  --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--sans);
+}
+
+.gefPage * {
+  box-sizing: border-box;
+}
+
+.gefPage {
+  scroll-behavior: smooth;
+}
+
+.gefPage {
+  background: var(--paper);
+  color: var(--ink);
+  margin: 0;
+  overflow-x: hidden;
+}
+
+.grain {
+  background-image:
+    linear-gradient(rgba(25, 23, 27, 0.024) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(25, 23, 27, 0.02) 1px, transparent 1px);
+  background-size: 22px 22px, 22px 22px;
+  inset: 0;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  position: fixed;
+  z-index: 20;
+}
+
+.gefPage a {
+  color: inherit;
+}
+
+.siteHeader {
+  align-items: center;
+  color: var(--vellum);
+  display: flex;
+  justify-content: space-between;
+  left: 0;
+  padding: 18px clamp(18px, 4vw, 54px);
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 12;
+}
+
+.brand,
+.siteHeader nav {
+  align-items: center;
+  background: rgba(25, 23, 27, 0.68);
+  border: 1px solid rgba(255, 250, 242, 0.18);
+  border-radius: 999px;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.16);
+  display: flex;
+  gap: 14px;
+}
+
+.brand {
+  padding: 7px 16px 7px 7px;
+  text-decoration: none;
+}
+
+.brandMark {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--gold);
+  border-radius: 999px;
+  color: var(--ink);
+  display: inline-flex;
+  font-family: var(--display);
+  font-size: 14px;
+  font-weight: 800;
+  justify-content: center;
+  width: 42px;
+}
+
+.brand span:last-child,
+.siteHeader nav a {
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.siteHeader nav {
+  padding: 13px 18px;
+}
+
+.siteHeader nav a {
+  color: rgba(255, 250, 242, 0.76);
+  text-decoration: none;
+}
+
+.siteHeader nav a:hover,
+.siteHeader nav a:focus-visible {
+  color: var(--vellum);
+}
+
+.hero {
+  background: var(--ink);
+  color: var(--vellum);
+  min-height: 78svh;
+  overflow: hidden;
+  position: relative;
+}
+
+.heroImage {
+  inset: 0;
+  position: absolute;
+}
+
+.heroImage::after {
+  background:
+    linear-gradient(90deg, rgba(25, 23, 27, 0.88), rgba(25, 23, 27, 0.42) 50%, rgba(25, 23, 27, 0.14)),
+    linear-gradient(0deg, rgba(25, 23, 27, 0.78), rgba(25, 23, 27, 0.08) 50%);
+  content: "";
+  inset: 0;
+  position: absolute;
+}
+
+.heroImage img {
+  filter: saturate(0.92) contrast(1.04);
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.03);
+  width: 100%;
+}
+
+.heroMarquee {
+  bottom: 18px;
+  display: flex;
+  left: 0;
+  opacity: 0.52;
+  overflow: hidden;
+  padding: 0 0 16px;
+  position: absolute;
+  right: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.marqueeTrack {
+  display: flex;
+  gap: 14px;
+  width: max-content;
+  will-change: transform;
+}
+
+.heroMarquee span {
+  background: rgba(255, 250, 242, 0.05);
+  border: 1px solid rgba(255, 250, 242, 0.2);
+  border-radius: 999px;
+  color: var(--vellum);
+  flex: 0 0 auto;
+  font-family: var(--display);
+  font-size: clamp(24px, 3.4vw, 48px);
+  line-height: 1;
+  padding: 8px 22px 12px;
+}
+
+.heroContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 78svh;
+  padding: 120px clamp(22px, 5vw, 72px) 118px;
+  position: relative;
+  z-index: 1;
+}
+
+.kicker {
+  color: var(--red);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  margin: 0 0 18px;
+  text-transform: uppercase;
+}
+
+.hero .kicker,
+.darkRoom .kicker {
+  color: var(--gold);
+}
+
+.gefPage h1,
+.gefPage h2,
+.gefPage h3,
+.gefPage p {
+  margin-top: 0;
+}
+
+.gefPage h1 {
+  font-family: var(--display);
+  font-size: clamp(44px, 5.8vw, 88px);
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 0.96;
+  margin-bottom: clamp(24px, 4vw, 44px);
+  max-width: 1040px;
+  text-wrap: balance;
+}
+
+.gefPage h2 {
+  font-family: var(--display);
+  font-size: clamp(32px, 4.6vw, 64px);
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1;
+  margin-bottom: 28px;
+  text-wrap: balance;
+}
+
+.gefPage h3 {
+  font-size: clamp(20px, 1.9vw, 28px);
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1.02;
+  margin-bottom: 14px;
+}
+
+.gefPage p {
+  color: rgba(25, 23, 27, 0.72);
+  font-size: clamp(16px, 1.35vw, 20px);
+  line-height: 1.55;
+}
+
+.heroBottom {
+  align-items: end;
+  display: grid;
+  gap: 26px;
+  grid-template-columns: minmax(260px, 580px) auto;
+  max-width: 980px;
+}
+
+.heroBottom p {
+  color: rgba(255, 250, 242, 0.84);
+  font-size: clamp(18px, 1.65vw, 23px);
+  margin: 0;
+}
+
+.primaryAction {
+  text-decoration: none;
+}
+
+.primaryAction {
+  align-items: center;
+  background: var(--vellum);
+  border-radius: 999px;
+  color: var(--ink);
+  display: inline-flex;
+  font-weight: 900;
+  gap: 12px;
+  justify-content: center;
+  min-height: 58px;
+  padding: 0 24px;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.primaryAction svg {
+  height: 22px;
+  width: 22px;
+}
+
+.gefPage section:not(.hero) {
+  padding: clamp(68px, 8.5vw, 128px) clamp(22px, 5vw, 72px);
+}
+
+.manifesto {
+  background:
+    linear-gradient(180deg, rgba(221, 217, 231, 0.55), transparent 30%),
+    var(--paper);
+  display: grid;
+  gap: clamp(34px, 7vw, 98px);
+  grid-template-columns: minmax(250px, 0.72fr) minmax(0, 1.28fr);
+  padding-top: clamp(56px, 6vw, 96px) !important;
+}
+
+.manifestoLedger {
+  align-self: start;
+  background: var(--vellum);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  padding: clamp(22px, 3vw, 34px);
+  transform: rotate(-1.2deg);
+}
+
+.manifestoLedger p {
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(18px, 1.55vw, 24px);
+  line-height: 1.2;
+  margin: 0;
+  padding: 15px 0;
+}
+
+.manifestoLedger .ledgerLabel {
+  color: var(--red);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  padding-top: 0;
+  text-transform: uppercase;
+}
+
+.manifestoCopy {
+  max-width: 920px;
+}
+
+.manifestoCopy p:last-child {
+  font-size: clamp(18px, 1.45vw, 23px);
+}
+
+.focusStrip {
+  background: var(--vellum);
+  border-bottom: 1px solid var(--line);
+  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+}
+
+.photoRail {
+  background: var(--vellum);
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 1.15fr 0.85fr 0.7fr;
+  padding-bottom: clamp(36px, 5vw, 72px) !important;
+  padding-top: clamp(36px, 5vw, 72px) !important;
+}
+
+.photoRail figure {
+  margin: 0;
+  min-height: clamp(240px, 29vw, 420px);
+  overflow: hidden;
+  position: relative;
+}
+
+.photoRail figure:nth-child(2) {
+  margin-top: clamp(28px, 5vw, 70px);
+}
+
+.photoRail figure:nth-child(3) {
+  margin-top: clamp(8px, 3vw, 42px);
+}
+
+.photoRail img {
+  filter: saturate(0.9) contrast(1.02);
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.photoRail figcaption {
+  background: rgba(255, 250, 242, 0.86);
+  bottom: 12px;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  left: 12px;
+  letter-spacing: 0.06em;
+  padding: 8px 10px;
+  position: absolute;
+  text-transform: uppercase;
+}
+
+.focusStrip article {
+  border-right: 1px solid var(--line);
+  min-height: 340px;
+  padding: clamp(34px, 5vw, 70px) clamp(22px, 4vw, 52px);
+}
+
+.focusStrip article:last-child {
+  border-right: 0;
+}
+
+.focusStrip span,
+.path .time,
+.timelineTicket span,
+.cabinet span {
+  color: var(--red);
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  margin-bottom: 44px;
+  text-transform: uppercase;
+}
+
+.fit {
+  background: var(--bone);
+  display: grid;
+  gap: clamp(34px, 6vw, 84px);
+  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
+}
+
+.fitBoard {
+  display: grid;
+  gap: 16px;
+}
+
+.fitBoard article {
+  background: rgba(255, 250, 242, 0.68);
+  border: 1px solid var(--line);
+  padding: clamp(24px, 4vw, 42px);
+}
+
+.fitBoard article:nth-child(2) {
+  margin-left: clamp(0px, 8vw, 86px);
+}
+
+.fitBoard article:nth-child(3) {
+  background: var(--blue);
+  color: var(--vellum);
+}
+
+.fitBoard article:nth-child(3) p {
+  color: rgba(255, 250, 242, 0.8);
+}
+
+.path {
+  background: var(--paper);
+}
+
+.pathIntro {
+  max-width: 1120px;
+}
+
+.pathSteps {
+  counter-reset: step;
+  display: grid;
+  gap: 0;
+  list-style: none;
+  margin: clamp(34px, 6vw, 74px) 0 0;
+  padding: 0;
+}
+
+.pathSteps li {
+  align-items: start;
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 128px minmax(180px, 0.55fr) minmax(320px, 1fr);
+  padding: 32px 0;
+}
+
+.pathSteps li::before {
+  color: rgba(85, 83, 110, 0.22);
+  content: "0" counter(step);
+  counter-increment: step;
+  font-family: var(--display);
+  font-size: clamp(42px, 5.8vw, 78px);
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  line-height: 0.8;
+}
+
+.path .time {
+  grid-column: 2;
+  grid-row: 1;
+  margin-bottom: 0;
+}
+
+.pathSteps h3 {
+  grid-column: 2;
+  grid-row: 2;
+  margin-bottom: 0;
+}
+
+.pathSteps p {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+  margin: 0;
+  max-width: 460px;
+}
+
+.darkRoom {
+  background:
+    linear-gradient(180deg, rgba(217, 96, 73, 0.2), transparent 34%),
+    var(--espresso);
+  color: var(--vellum);
+  display: grid;
+  gap: clamp(34px, 7vw, 92px);
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.86fr);
+}
+
+.darkRoom p {
+  color: rgba(255, 250, 242, 0.72);
+}
+
+.requirementList {
+  border-top: 1px solid var(--pale-line);
+}
+
+.requirementList p {
+  border-bottom: 1px solid var(--pale-line);
+  font-size: clamp(17px, 1.45vw, 21px);
+  margin: 0;
+  padding: 22px 0;
+}
+
+.requirementList strong {
+  color: var(--vellum);
+}
+
+.timeline {
+  align-items: center;
+  background: var(--vellum);
+  display: grid;
+  gap: clamp(34px, 7vw, 100px);
+  grid-template-columns: minmax(260px, 0.62fr) minmax(0, 1.38fr);
+}
+
+.timelineTicket {
+  aspect-ratio: 0.78;
+  background: var(--moss);
+  color: var(--vellum);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  max-width: 420px;
+  padding: clamp(24px, 4vw, 44px);
+  position: relative;
+}
+
+.timelineTicket::before,
+.timelineTicket::after {
+  background: var(--vellum);
+  border-radius: 999px;
+  content: "";
+  height: 36px;
+  position: absolute;
+  right: -18px;
+  width: 36px;
+}
+
+.timelineTicket::before {
+  top: 20%;
+}
+
+.timelineTicket::after {
+  bottom: 20%;
+}
+
+.timelineTicket span {
+  color: rgba(255, 250, 242, 0.74);
+}
+
+.timelineTicket strong {
+  font-family: var(--display);
+  font-size: clamp(48px, 6vw, 82px);
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 0.88;
+}
+
+.timelineTicket small {
+  color: rgba(255, 250, 242, 0.74);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.timelineCopy {
+  max-width: 980px;
+}
+
+.cabinet {
+  background: var(--paper);
+}
+
+.cabinet h2 {
+  max-width: 980px;
+}
+
+.cabinetGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: clamp(34px, 6vw, 76px);
+}
+
+.cabinetGrid article {
+  border: 1px solid var(--line);
+  border-left: 0;
+  min-height: 280px;
+  padding: 28px;
+}
+
+.cabinetGrid article:first-child {
+  border-left: 1px solid var(--line);
+}
+
+.cabinetGrid article:nth-child(2n) {
+  transform: translateY(36px);
+}
+
+.cabinetGrid p {
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(20px, 1.8vw, 28px);
+  line-height: 1.2;
+}
+
+.apply {
+  align-items: stretch;
+  background: var(--blue);
+  color: var(--vellum);
+  display: grid;
+  gap: clamp(28px, 6vw, 80px);
+  grid-template-columns: minmax(280px, 0.72fr) minmax(420px, 1.28fr);
+}
+
+.apply p {
+  color: rgba(255, 250, 242, 0.76);
+}
+
+.interestForm {
+  background: rgba(255, 250, 242, 0.96);
+  border: 1px solid rgba(255, 250, 242, 0.3);
+  color: var(--ink);
+  display: grid;
+  gap: 16px;
+  padding: clamp(22px, 3vw, 38px);
+}
+
+.formRow {
+  display: grid;
+  gap: 14px;
+}
+
+.formRowTwo {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.interestForm label {
+  display: grid;
+  gap: 8px;
+}
+
+.interestForm label span {
+  color: rgba(25, 23, 27, 0.74);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.interestForm input,
+.interestForm textarea {
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(25, 23, 27, 0.18);
+  color: var(--ink);
+  font: 500 16px/1.45 var(--sans);
+  min-height: 48px;
+  outline: none;
+  padding: 12px 14px;
+  width: 100%;
+}
+
+.interestForm textarea {
+  resize: vertical;
+}
+
+.interestForm input:focus,
+.interestForm textarea:focus {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 3px rgba(243, 218, 115, 0.28);
+}
+
+.interestForm ::placeholder {
+  color: rgba(25, 23, 27, 0.38);
+}
+
+.formFooter {
+  align-items: center;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin-top: 6px;
+}
+
+.formFooter p,
+.formNote {
+  color: rgba(25, 23, 27, 0.62);
+  font-size: 14px;
+  margin: 0;
+}
+
+.formFooter button {
+  align-items: center;
+  background: var(--gold);
+  border: 1px solid rgba(25, 23, 27, 0.08);
+  border-radius: 999px;
+  color: var(--ink);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font: 900 15px/1 var(--sans);
+  gap: 12px;
+  justify-content: center;
+  min-height: 58px;
+  padding: 0 24px;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.formFooter button::after {
+  content: "→";
+  font-size: 22px;
+  line-height: 1;
+  margin-top: -1px;
+}
+
+.formFooter button:hover,
+.formFooter button:focus-visible {
+  background: #d7b766;
+  transform: translateY(-1px);
+}
+
+.footer {
+  align-items: center;
+  background: var(--ink);
+  color: rgba(255, 250, 242, 0.72);
+  display: flex;
+  font-size: 14px;
+  justify-content: space-between;
+  padding: 28px clamp(22px, 5vw, 72px);
+}
+
+.footer a {
+  text-decoration-color: rgba(255, 250, 242, 0.34);
+}
+
+@media (max-width: 980px) {
+  .heroBottom,
+  .manifesto,
+  .fit,
+  .darkRoom,
+  .timeline,
+  .apply {
+    grid-template-columns: 1fr;
+  }
+
+  .focusStrip,
+  .photoRail,
+  .cabinetGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .photoRail figure,
+  .photoRail figure:nth-child(2),
+  .photoRail figure:nth-child(3) {
+    margin-top: 0;
+    min-height: 300px;
+  }
+
+  .focusStrip article,
+  .cabinetGrid article,
+  .cabinetGrid article:first-child {
+    border-left: 0;
+    border-right: 0;
+    min-height: auto;
+  }
+
+  .cabinetGrid article:nth-child(2n),
+  .fitBoard article:nth-child(2) {
+    margin-left: 0;
+    transform: none;
+  }
+
+  .pathSteps li {
+    grid-template-columns: 78px 1fr;
+    gap: 10px 18px;
+    padding: 28px 0;
+  }
+
+  .pathSteps li::before {
+    grid-column: 1;
+    grid-row: 1 / span 3;
+  }
+
+  .path .time,
+  .pathSteps h3,
+  .pathSteps p {
+    grid-column: 2;
+    grid-row: auto;
+  }
+
+  .path .time {
+    margin-bottom: 4px;
+  }
+
+  .pathSteps p {
+    max-width: 560px;
+  }
+
+  .formRowTwo {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .siteHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .siteHeader nav {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  .hero,
+  .heroContent {
+    min-height: 82svh;
+  }
+
+  .heroMarquee {
+    bottom: 8px;
+    opacity: 0.34;
+  }
+
+  .heroMarquee span {
+    font-size: 26px;
+    padding: 7px 16px 10px;
+  }
+
+  .heroContent {
+    padding-bottom: 70px;
+    padding-top: 150px;
+  }
+
+  .heroBottom {
+    align-items: start;
+  }
+
+  .primaryAction {
+    width: 100%;
+  }
+
+  .manifestoLedger {
+    transform: none;
+  }
+
+  .pathSteps li {
+    grid-template-columns: 62px 1fr;
+  }
+
+  .pathSteps li::before {
+    grid-column: 1;
+    grid-row: 1 / span 3;
+  }
+
+  .path .time,
+  .pathSteps h3,
+  .pathSteps p {
+    grid-column: 2;
+  }
+
+  .timelineTicket {
+    min-height: 300px;
+  }
+
+  .formFooter {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+}

--- a/app/gef/gef.module.css
+++ b/app/gef/gef.module.css
@@ -457,17 +457,20 @@
   display: grid;
   gap: 0;
   list-style: none;
-  margin: clamp(34px, 6vw, 74px) 0 0;
+  margin: clamp(34px, 6vw, 74px) auto 0;
+  max-width: 1420px;
   padding: 0;
 }
 
 .pathSteps li {
-  align-items: start;
+  align-content: center;
+  align-items: center;
   border-top: 1px solid var(--line);
   display: grid;
-  gap: 20px clamp(28px, 4.5vw, 72px);
-  grid-template-columns: minmax(110px, 0.24fr) minmax(210px, 0.5fr) minmax(360px, 0.92fr);
-  padding: 34px 0;
+  gap: 8px clamp(30px, 4vw, 64px);
+  grid-template-columns: clamp(90px, 9vw, 142px) minmax(220px, 340px) minmax(360px, 640px);
+  min-height: clamp(124px, 12vw, 168px);
+  padding: 26px 0;
 }
 
 .pathSteps li::before {
@@ -475,10 +478,11 @@
   content: "0" counter(step);
   counter-increment: step;
   font-family: var(--display);
-  font-size: clamp(42px, 5.8vw, 78px);
+  font-size: clamp(56px, 6vw, 92px);
   grid-column: 1;
   grid-row: 1 / span 2;
   line-height: 0.8;
+  place-self: center start;
 }
 
 .path .time {
@@ -494,10 +498,11 @@
 }
 
 .pathSteps p {
+  align-self: center;
   grid-column: 3;
   grid-row: 1 / span 2;
   margin: 0;
-  max-width: 560px;
+  max-width: none;
 }
 
 .darkRoom {

--- a/app/gef/page.tsx
+++ b/app/gef/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next'
+import GefLanding from './GefLanding'
+
+export const metadata: Metadata = {
+  title: 'Global Expert Fellowship | Mox',
+  description:
+    'A Global Expert Fellowship for international researchers, founders, and domain specialists building frontier technology projects at Mox in San Francisco.',
+  openGraph: {
+    title: 'Global Expert Fellowship | Mox',
+    description:
+      'Bring your research or startup to SF for a season with the Mox community.',
+    url: 'https://moxsf.com/gef',
+    siteName: 'Mox SF',
+    images: [
+      {
+        url: '/images/014.jpg',
+        width: 1920,
+        height: 1440,
+        alt: 'Mox community event',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Global Expert Fellowship | Mox',
+    description:
+      'Bring your research or startup to SF for a season with the Mox community.',
+    images: ['/images/014.jpg'],
+  },
+}
+
+export default function Page() {
+  return <GefLanding />
+}


### PR DESCRIPTION
## Summary

Adds a standalone /gef landing page for the Mox Global Expert Fellowship.

The page preserves the designed standalone experience exactly in its own route:
- custom GEF layout and copy
- selected font trio: Instrument Sans, Fraunces, and IBM Plex Mono
- Mox photos from existing /public/images
- scroll-driven marquee and local interest form UI

## Notes

This intentionally does not adapt the page to the rest of the repository design system. The route is isolated under app/gef/ with CSS modules so it can be reviewed as its own landing page.

## Validation

- Started local Next dev server and checked GET /gef returns 200 OK.
- Verified rendered HTML includes the GEF hero, marquee terms, form fields, metadata for https://moxsf.com/gef, and no immigration copy.
- bun run lint is unavailable in this repo.
- bunx tsc --noEmit did not complete locally and was stopped after hanging without output.

Existing local env warnings appeared from portal/session health endpoints requiring env vars, not from the /gef route.
