### PR TITLE
Wire up GEF interest form to email

### DIFF
--- a/app/gef/GefLanding.tsx
+++ b/app/gef/GefLanding.tsx
@@ -17,6 +17,8 @@ const marqueeWords = [
 export default function GefLanding() {
   const marqueeTrackRef = useRef<HTMLDivElement>(null)
   const [formMessage, setFormMessage] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
 
   useEffect(() => {
     const track = marqueeTrackRef.current
@@ -40,9 +42,42 @@ export default function GefLanding() {
     }
   }, [])
 
-  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    setFormMessage('Form draft captured locally. We can wire this to the real destination next.')
+    if (submitting) return
+
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const payload = Object.fromEntries(formData.entries())
+
+    setSubmitting(true)
+    setFormMessage('Sending your interest...')
+
+    try {
+      const response = await fetch('/gef/api/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        setFormMessage(
+          data.error || 'Something went wrong. Please try again in a moment.'
+        )
+        return
+      }
+
+      form.reset()
+      setSubmitted(true)
+      setFormMessage(
+        'Thanks! Your interest is on its way. We’ll be in touch about next steps.'
+      )
+    } catch {
+      setFormMessage('Could not reach the server. Please try again in a moment.')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -327,7 +362,9 @@ export default function GefLanding() {
           </label>
           <div className={styles.formFooter}>
             <p>Five minutes is enough. If there is a fit, the next step is a short conversation.</p>
-            <button type="submit">Submit interest</button>
+            <button type="submit" disabled={submitting || submitted}>
+              {submitting ? 'Sending...' : submitted ? 'Interest sent' : 'Submit interest'}
+            </button>
           </div>
           <p className={styles.formNote} role="status" aria-live="polite">
             {formMessage}

--- a/app/gef/api/submit/route.ts
+++ b/app/gef/api/submit/route.ts
@@ -1,0 +1,106 @@
+import { isValidEmail } from '@/app/lib/airtable-helpers'
+import { sendEmail } from '@/app/lib/email'
+
+const RECIPIENT = 'carolina@moxsf.com'
+
+// Fields collected by the GEF interest form, in display order.
+const FIELDS: { key: string; label: string }[] = [
+  { key: 'name', label: 'Name' },
+  { key: 'email', label: 'Email' },
+  { key: 'country', label: 'Current country' },
+  { key: 'focus', label: 'Primary focus area' },
+  { key: 'background', label: 'Background' },
+  { key: 'proud', label: 'Work they are proud of' },
+  { key: 'intentions', label: 'What they would work on in SF' },
+]
+
+// Guard against oversized payloads.
+const MAX_FIELD_LENGTH = 5000
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: 'Invalid request.' }, { status: 400 })
+  }
+
+  // Collect + trim submitted values.
+  const values: Record<string, string> = {}
+  for (const { key } of FIELDS) {
+    const raw = body[key]
+    const value = typeof raw === 'string' ? raw.trim() : ''
+    if (value.length > MAX_FIELD_LENGTH) {
+      return Response.json(
+        { error: 'One of your answers is too long.' },
+        { status: 400 }
+      )
+    }
+    values[key] = value
+  }
+
+  // Every field on the form is required.
+  const missing = FIELDS.filter(({ key }) => !values[key])
+  if (missing.length > 0) {
+    return Response.json(
+      { error: `Please fill in: ${missing.map((f) => f.label).join(', ')}.` },
+      { status: 400 }
+    )
+  }
+
+  if (!isValidEmail(values.email)) {
+    return Response.json(
+      { error: 'Please enter a valid email address.' },
+      { status: 400 }
+    )
+  }
+
+  const text = FIELDS.map(({ key, label }) => `${label}:\n${values[key]}`).join(
+    '\n\n'
+  )
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 640px; margin: 0 auto;">
+      <h2 style="margin-bottom: 4px;">New Global Expert Fellowship interest</h2>
+      <p style="color: #666; margin-top: 0;">Submitted via moxsf.com/gef</p>
+      ${FIELDS.map(
+        ({ key, label }) => `
+        <div style="margin: 16px 0;">
+          <div style="font-weight: 600; color: #111;">${escapeHtml(label)}</div>
+          <div style="white-space: pre-wrap;">${escapeHtml(values[key])}</div>
+        </div>`
+      ).join('')}
+    </div>`
+
+  let sent = false
+  try {
+    sent = await sendEmail({
+      to: RECIPIENT,
+      from: 'Mox GEF <portal@account.moxsf.com>',
+      replyTo: values.email,
+      subject: `GEF interest: ${values.name}`,
+      text,
+      html,
+    })
+  } catch (error) {
+    console.error('[GEF] Error sending interest email:', error)
+  }
+
+  if (!sent) {
+    return Response.json(
+      { error: 'Something went wrong sending your form. Please try again.' },
+      { status: 502 }
+    )
+  }
+
+  return Response.json({ success: true })
+}

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -5,6 +5,8 @@ interface EmailOptions {
   subject: string
   text: string
   from?: string
+  html?: string
+  replyTo?: string
 }
 
 const DEFAULT_FROM = 'Member Portal <portal@account.moxsf.com>'
@@ -17,6 +19,8 @@ export async function sendEmail({
   subject,
   text,
   from = DEFAULT_FROM,
+  html,
+  replyTo,
 }: EmailOptions): Promise<boolean> {
   const resendApiKey = env.RESEND_API_KEY
 
@@ -37,6 +41,8 @@ export async function sendEmail({
         to: Array.isArray(to) ? to : [to],
         subject,
         text,
+        ...(html ? { html } : {}),
+        ...(replyTo ? { reply_to: replyTo } : {}),
       }),
     })
 


### PR DESCRIPTION
## Summary

The interest form on [moxsf.com/gef](https://moxsf.com/gef) previously captured input locally and sent it nowhere (it just showed a "draft captured locally" placeholder). This wires it up to actually deliver submissions by email.

## Changes

- **`app/gef/api/submit/route.ts`** (new) — API route that:
  - Validates that all form fields are present and the email is a valid address
  - Emails the submission to a different email via Resend (the same service the member portal already uses)
  - Sets **reply-to** to the applicant's email, so replying goes straight back to them
  - Sends a formatted HTML email (each field labeled) with a plain-text fallback; HTML-escapes user input
- **`app/gef/GefLanding.tsx`** — the form now POSTs the data and shows real states: `Sending…`, a success confirmation (with field reset), and clear inline errors on failure
- **`app/lib/email.ts`** — extended the shared `sendEmail` helper with optional `html` and `replyTo` params (additive; existing callers unaffected)

## Notes

- Email sends **from** `portal@account.moxsf.com`, the existing verified Resend sender domain used by the portal and EAG day-pass flows. Using a different from-address would require verifying that domain in Resend first.
- `RESEND_API_KEY` is already a required env var in production (used by magic-link auth and day-pass emails), so no new configuration is needed.
- Not an automation route, so no `automations-manifest.ts` regeneration required.

## Testing

Verified against a local dev server:
- Missing fields → `400` with a "Please fill in…" message
- Invalid email → `400` with validation error
- Valid submission → reaches the email send (returns `502` locally only because `RESEND_API_KEY` isn't set in the sandbox; sends and returns success in production)
- `/gef` page still renders (`200`)
- Typecheck clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN78s4TFjzis2cxgx27zmW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN78s4TFjzis2cxgx27zmW)_