### PR TITLE
Remove Friend tier references from join and renew pages

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -58,12 +58,6 @@ export function JoinContent(props: {
               better fit. This includes a dedicated desk where you can leave
               belongings, and external monitor.
               <br /> <br />
-              Finally, if you're not usually in SF, or expect to be coming
-              infrequently, we'd love to have you as a{' '}
-              <u className="underline-offset-2">Friend</u>. Beyond all of our
-              public and members events, you're welcome to drop by up to twice a
-              week!
-              <br /> <br />
               We want you to be confident that Mox is the right choice, so every
               membership comes with a 1-week free trial. You can also update or
               cancel your membership at any time.
@@ -138,8 +132,8 @@ export function JoinContent(props: {
             <p className="text-gray-700">
               We want Mox to be a place you're proud to show off to your friends
               and family. All memberships come with some free allowances for
-              guests: 1x/week for Friend, 1x/day for Core, and 2x/day for
-              Resident and Office members. Beyond that, we ask that you or your
+              guests: 1x/day for Core, and 2x/day for Resident and Office
+              members. Beyond that, we ask that you or your
               guest purchase a{' '}
               <a
                 href="/day-pass"
@@ -214,9 +208,8 @@ export function JoinContent(props: {
             {/* <div className="absolute -top-8 left-6 bg-amber-100 text-gray-800 font-bold text-xs px-2 py-1 rounded">
               Prices during beta
             </div> */}
-            <div className="grid grid-cols-3 gap-8">
+            <div className="grid grid-cols-2 gap-8">
               {[
-                { type: 'Friend', price: '$160' },
                 { type: 'Core', price: '$380' },
                 { type: 'Resident', price: '$780' },
               ].map((tier) => (

--- a/app/portal/renew/RenewContent.tsx
+++ b/app/portal/renew/RenewContent.tsx
@@ -58,12 +58,6 @@ export default function RenewContent({
               <u className="underline-offset-2">Resident</u> option may be a
               better fit. This includes a dedicated desk where you can leave
               belongings, and external monitor.
-              <br /> <br />
-              Finally, if you're not usually in SF, or expect to be coming
-              infrequently, we'd love to have you as a{' '}
-              <u className="underline-offset-2">Friend</u>. Beyond all of our
-              public and members events, you're welcome to drop by up to twice a
-              week!
             </p>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- The Friend membership tier is no longer offered for new signups (removed from the Stripe pricing table separately)
- Removes stale "Friend" copy from the join page: the tier description, guest policy allowance, and pricing grid card
- Removes the same stale "Friend" description from the portal renewal page
- All backend/access-control infrastructure for the Friend tier (`app/lib/membership.ts`, Stripe webhook handling, Discord role sync, Verkada door PINs) is intentionally left untouched, so existing Friend-tier members are unaffected

## Test plan
- [x] Unit tests: 107/107 passing (`bun run test:run`), including `membership.test.ts` confirming Friend-tier access logic is unaffected
- [x] TypeScript: clean (`tsc --noEmit`)
- [x] Verified locally in browser: join page (invited-user view w/ Stripe pricing table, and general "Memberships at Mox" static grid) shows only Core/Resident, no leftover Friend references or layout issues
- [x] Verified guest policy copy reads correctly without the Friend clause