### PR TITLE
Serve right-sized homepage card images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,13 @@ import { getPeople, getOrgs, getPrograms, getStaff, buildDirectoryData } from '.
 import DirectoryClient from './people/DirectoryClient'
 import './people/people.css'
 
+// The three hero cards render their photo at ~1/3 of the max-w-7xl grid on
+// desktop, a 192px thumbnail at md, and full-bleed on mobile. Without this,
+// next/image has no layout hint and falls back to the largest device size —
+// a 3840px-wide, 700KB+ variant preloaded as a priority image.
+const CARD_IMAGE_SIZES =
+  '(min-width: 1024px) 420px, (min-width: 768px) 192px, 100vw'
+
 async function HomepageDirectory() {
   let people: Awaited<ReturnType<typeof getPeople>> = []
   let orgsMap: Awaited<ReturnType<typeof getOrgs>> = new Map()
@@ -125,9 +132,10 @@ export default async function Component() {
               <Image
                 src="/images/014.jpg"
                 alt="Mox events"
-                width={2016}
-                height={1512}
+                width={4032}
+                height={3024}
                 priority
+                sizes={CARD_IMAGE_SIZES}
                 className="w-full md:w-48 lg:w-full h-48 md:h-auto lg:h-48 object-cover flex-shrink-0"
               />
               <div className="p-4 sm:p-6 flex flex-col flex-1">
@@ -153,9 +161,10 @@ export default async function Component() {
               <Image
                 src="/images/023.jpg"
                 alt="Mox community"
-                width={2016}
-                height={1512}
+                width={2000}
+                height={1333}
                 priority
+                sizes={CARD_IMAGE_SIZES}
                 className="w-full md:w-48 lg:w-full h-48 md:h-auto lg:h-48 object-cover flex-shrink-0"
               />
               <div className="p-4 sm:p-6 flex flex-col flex-1">
@@ -203,9 +212,10 @@ export default async function Component() {
               <Image
                 src="/images/003.jpg"
                 alt="Mox space"
-                width={2016}
-                height={1512}
+                width={1512}
+                height={1009}
                 priority
+                sizes={CARD_IMAGE_SIZES}
                 className="w-full md:w-48 lg:w-full h-48 md:h-auto lg:h-48 object-cover flex-shrink-0"
               />
               <div className="p-4 sm:p-6 flex flex-col flex-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,10 +9,7 @@ import { getPeople, getOrgs, getPrograms, getStaff, buildDirectoryData } from '.
 import DirectoryClient from './people/DirectoryClient'
 import './people/people.css'
 
-// The three hero cards render their photo at ~1/3 of the max-w-7xl grid on
-// desktop, a 192px thumbnail at md, and full-bleed on mobile. Without this,
-// next/image has no layout hint and falls back to the largest device size —
-// a 3840px-wide, 700KB+ variant preloaded as a priority image.
+// Without this hint next/image serves a 3840px variant at every viewport.
 const CARD_IMAGE_SIZES =
   '(min-width: 1024px) 420px, (min-width: 768px) 192px, 100vw'
 


### PR DESCRIPTION
## What

The three homepage hero cards passed no `sizes` to `next/image`. Without a layout hint the browser can't know the image only occupies a third of the grid, so it picks the largest entry in the srcset — `w=3840` — at every viewport. For `images/014.jpg` (a 4032×3024 source) that's a **712 KB WebP**, and `priority` preloads it as a render-blocking fetch.

This is the broken first card in the reported screenshot: the heaviest image on the page, fetched at max resolution on a phone, blocking first paint. When that fetch is slow or aborts you get the broken-image icon with alt text.

The asset itself was never the problem — `014.jpg` is a valid JPEG and both the local and production optimizers return it correctly.

## Changes

- Added a shared `CARD_IMAGE_SIZES` hint matching the actual responsive layout (`~1/3 grid ≥1024px`, `192px` thumb `≥768px`, `100vw` below).
- Corrected the declared intrinsic dimensions. All three were copy-pasted `2016×1512`, which matched none of the source files (actual: `4032×3024`, `2000×1333`, `1512×1009`).

## Result

Verified in the browser at both widths — all three images load and render.

| viewport | before | after |
|---|---|---|
| 375px mobile | `w=3840` — 712 + 117 + 118 KB = **948 KB** | `w=750` — 61 + 18 + 41 KB = **120 KB** |
| 1440px desktop | `w=3840` | `w=1080` |

## Notes for reviewers

- The `sizes` breakpoints mirror the existing `md:w-48 lg:w-full` classes on these images. If that layout changes, `CARD_IMAGE_SIZES` needs to change with it.
- `bunx tsc --noEmit` reports three pre-existing errors in `app/lib/claude.ts` (Anthropic SDK type drift on `"adaptive"` and `stop_details`). Unrelated to this change and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)